### PR TITLE
Add Perth: macOS system-wide audio equalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.build/
+.swiftpm/
+*.xcodeproj/
+xcuserdata/
+DerivedData/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Perth",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "Perth",
+            path: "Sources/Perth",
+            exclude: ["Info.plist"],
+            linkerSettings: [
+                .linkedFramework("CoreAudio"),
+                .linkedFramework("AudioToolbox"),
+                .linkedFramework("AVFAudio"),
+                .linkedFramework("AppKit"),
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/Perth/Info.plist",
+                ]),
+            ]
+        ),
+        // Requires Xcode (not just Command Line Tools) for XCTest
+        // .testTarget(
+        //     name: "PerthTests",
+        //     dependencies: ["Perth"],
+        //     path: "Tests/PerthTests"
+        // ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Sources/Perth/AudioEngine.swift
+++ b/Sources/Perth/AudioEngine.swift
@@ -1,0 +1,362 @@
+import CoreAudio
+import AudioToolbox
+import AVFAudio
+import Foundation
+import Observation
+
+// MARK: - Real-time Audio Callbacks (free functions, no actor isolation)
+// These run on Core Audio's IO thread. They MUST be free functions — not closures
+// defined inside a @MainActor class — because Swift 6 strict concurrency inserts
+// runtime isolation checks that crash on non-main threads.
+
+nonisolated(unsafe) private var rtRingBuffer: AudioRingBuffer?
+nonisolated(unsafe) private var rtChannelCount: UInt32 = 2
+
+/// Scratch buffer for deinterleaving (allocated once, reused).
+nonisolated(unsafe) private var rtScratchBuffer: UnsafeMutablePointer<Float>?
+nonisolated(unsafe) private var rtScratchCapacity: Int = 0
+
+/// AVAudioSourceNode render block: pulls interleaved audio from ring buffer,
+/// deinterleaves into separate channel buffers for the non-interleaved AVAudioEngine format.
+private func renderCallback(
+    _: UnsafeMutablePointer<ObjCBool>,
+    _: UnsafePointer<AudioTimeStamp>,
+    frameCount: UInt32,
+    audioBufferList: UnsafeMutablePointer<AudioBufferList>
+) -> OSStatus {
+    guard let ringBuf = rtRingBuffer else { return noErr }
+    let ch = Int(rtChannelCount)
+    let frames = Int(frameCount)
+    let interleavedCount = frames * ch
+    let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
+
+    if rtScratchCapacity < interleavedCount {
+        rtScratchBuffer?.deallocate()
+        rtScratchBuffer = .allocate(capacity: interleavedCount)
+        rtScratchCapacity = interleavedCount
+    }
+    guard let scratch = rtScratchBuffer else { return noErr }
+
+    let read = ringBuf.read(scratch, count: interleavedCount)
+    if read < interleavedCount {
+        scratch.advanced(by: read).initialize(repeating: 0.0, count: interleavedCount - read)
+    }
+
+    for i in 0..<bufferList.count {
+        guard let outData = bufferList[i].mData?.assumingMemoryBound(to: Float.self) else { continue }
+        let channelIndex = i
+        for f in 0..<frames {
+            outData[f] = scratch[f * ch + channelIndex]
+        }
+    }
+    return noErr
+}
+
+// MARK: - AudioEngine
+
+@available(macOS 14.2, *)
+@Observable
+@MainActor
+final class AudioEngine {
+    private(set) var isRunning = false
+    private(set) var outputDeviceName = "Unknown"
+    private(set) var error: String?
+
+    private var tapID = AudioObjectID(kAudioObjectUnknown)
+    private var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+    private var procID: AudioDeviceIOProcID?
+    private var engine: AVAudioEngine?
+    private var eq: AVAudioUnitEQ?
+    private var ringBuffer: AudioRingBuffer?
+    private var tapUUID = UUID()
+
+    @ObservationIgnored
+    nonisolated(unsafe) private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
+    var onStateChange: (() -> Void)?
+
+    var selectedPreset: EQPreset = .flat {
+        didSet { applyCurrentPreset() }
+    }
+
+    init() {
+        do {
+            let deviceID = try getDefaultOutputDeviceID()
+            outputDeviceName = try getDeviceName(deviceID)
+        } catch {
+            outputDeviceName = "Unknown"
+        }
+        installDeviceChangeListener()
+    }
+
+    deinit {
+        if let block = deviceChangeListenerBlock {
+            var address = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject), &address,
+                DispatchQueue.main, block
+            )
+        }
+    }
+
+    // MARK: - Start / Stop
+
+    func start() throws {
+        guard !isRunning else { return }
+        error = nil
+
+        let outputDeviceID = try getDefaultOutputDeviceID()
+        let outputUID = try getDeviceUID(outputDeviceID)
+        outputDeviceName = try getDeviceName(outputDeviceID)
+
+        // 1. Translate our PID → AudioObjectID so we can exclude ourselves from the tap.
+        //    Without this, the muted tap silences Perth's own AVAudioEngine output.
+        var translateAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var myPID = ProcessInfo.processInfo.processIdentifier
+        var myProcessObjectID = AudioObjectID(kAudioObjectUnknown)
+        var processObjectSize = UInt32(MemoryLayout<AudioObjectID>.size)
+        AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &translateAddress,
+            UInt32(MemoryLayout<pid_t>.size), &myPID,
+            &processObjectSize, &myProcessObjectID
+        )
+
+        // 2. Create global tap (muted), excluding Perth's own process
+        tapUUID = UUID()
+        let excludeProcesses: [AudioObjectID] = myProcessObjectID != kAudioObjectUnknown
+            ? [myProcessObjectID] : []
+        let tapDesc = CATapDescription(stereoGlobalTapButExcludeProcesses: excludeProcesses)
+        tapDesc.uuid = tapUUID
+        tapDesc.muteBehavior = .muted
+        tapDesc.name = "Perth-EQ"
+
+        tapID = AudioObjectID(kAudioObjectUnknown)
+        try caCheck(
+            AudioHardwareCreateProcessTap(tapDesc, &tapID),
+            "Failed to create process tap"
+        )
+
+        // 3. Read tap format
+        var formatAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioTapPropertyFormat,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var tapFormat = AudioStreamBasicDescription()
+        var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        try caCheck(
+            AudioObjectGetPropertyData(tapID, &formatAddress, 0, nil, &formatSize, &tapFormat),
+            "Failed to get tap format"
+        )
+        let sampleRate = tapFormat.mSampleRate
+        let channels = tapFormat.mChannelsPerFrame
+
+        // 4. Create aggregate device with tap and output device in the creation dictionary.
+        //    The tap list MUST be included at creation time — adding it later via
+        //    kAudioAggregateDevicePropertyTapList delivers zero-filled buffers.
+        let aggregateUID = UUID().uuidString
+        let aggregateDesc: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "Perth-Aggregate",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceIsStackedKey: false,
+            kAudioAggregateDeviceTapAutoStartKey: true,
+            kAudioAggregateDeviceSubDeviceListKey: [
+                [kAudioSubDeviceUIDKey: outputUID]
+            ],
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapDriftCompensationKey: true,
+                    kAudioSubTapUIDKey: tapUUID.uuidString,
+                ]
+            ],
+        ]
+
+        aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        try caCheck(
+            AudioHardwareCreateAggregateDevice(aggregateDesc as CFDictionary, &aggregateDeviceID),
+            "Failed to create aggregate device"
+        )
+
+        // Wait for device alive
+        var aliveAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsAlive,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        for _ in 1...30 {
+            var isAlive: UInt32 = 0
+            var aliveSize = UInt32(MemoryLayout<UInt32>.size)
+            AudioObjectGetPropertyData(aggregateDeviceID, &aliveAddress, 0, nil, &aliveSize, &isAlive)
+            if isAlive != 0 { break }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        // 5. Set up ring buffer + AVAudioEngine with EQ
+        let ringBuf = AudioRingBuffer(capacityFrames: Int(sampleRate * 0.5), channels: Int(channels))
+        self.ringBuffer = ringBuf
+        rtRingBuffer = ringBuf
+        rtChannelCount = channels
+
+        let avEngine = AVAudioEngine()
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate,
+                                   channels: AVAudioChannelCount(channels))!
+
+        let sourceNode = AVAudioSourceNode(format: format, renderBlock: renderCallback)
+
+        let eqNode = AVAudioUnitEQ(numberOfBands: EQPreset.bandCount)
+        for (i, freq) in EQPreset.frequencies.enumerated() {
+            let band = eqNode.bands[i]
+            band.filterType = .parametric
+            band.frequency = freq
+            band.bandwidth = 1.0
+            band.gain = selectedPreset.bands[i]
+            band.bypass = false
+        }
+        eqNode.globalGain = 0.0
+        self.eq = eqNode
+
+        avEngine.attach(sourceNode)
+        avEngine.attach(eqNode)
+        avEngine.connect(sourceNode, to: eqNode, format: format)
+        avEngine.connect(eqNode, to: avEngine.mainMixerNode, format: format)
+
+        try avEngine.start()
+        self.engine = avEngine
+
+        // 6. Install IOProc on aggregate device — captures tap audio → ring buffer
+        let ioBlock: AudioDeviceIOBlock = { _, inInputData, _, outOutputData, _ in
+            guard let ringBuf = rtRingBuffer else { return }
+
+            let inBufList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inInputData))
+            for i in 0..<inBufList.count {
+                guard let data = inBufList[i].mData else { continue }
+                let sampleCount = Int(inBufList[i].mDataByteSize) / MemoryLayout<Float>.size
+                ringBuf.write(data.assumingMemoryBound(to: Float.self), count: sampleCount)
+            }
+
+            // Zero the output buffers (silence — playback goes through AVAudioEngine)
+            let outBufList = UnsafeMutableAudioBufferListPointer(outOutputData)
+            for i in 0..<outBufList.count {
+                if let data = outBufList[i].mData {
+                    memset(data, 0, Int(outBufList[i].mDataByteSize))
+                }
+            }
+        }
+        try caCheck(
+            AudioDeviceCreateIOProcIDWithBlock(&procID, aggregateDeviceID, nil, ioBlock),
+            "Failed to create IOProc"
+        )
+
+        try caCheck(
+            AudioDeviceStart(aggregateDeviceID, procID),
+            "Failed to start aggregate device"
+        )
+
+        isRunning = true
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+
+        rtRingBuffer = nil
+        ringBuffer = nil
+
+        AudioDeviceStop(aggregateDeviceID, procID)
+        engine?.stop()
+        engine = nil
+        eq = nil
+
+        if let procID {
+            AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
+            self.procID = nil
+        }
+
+        if aggregateDeviceID != kAudioObjectUnknown {
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        }
+
+        if tapID != kAudioObjectUnknown {
+            AudioHardwareDestroyProcessTap(tapID)
+            tapID = AudioObjectID(kAudioObjectUnknown)
+        }
+    }
+
+    // MARK: - EQ Control
+
+    func setEnabled(_ enabled: Bool) {
+        if enabled {
+            do {
+                try start()
+            } catch {
+                self.error = error.localizedDescription
+            }
+        } else {
+            stop()
+        }
+    }
+
+    private func applyCurrentPreset() {
+        guard let eq else { return }
+        let gains = selectedPreset.bands
+        for (i, gain) in gains.enumerated() {
+            eq.bands[i].gain = gain
+        }
+    }
+
+    // MARK: - Device Change Handling
+
+    private func installDeviceChangeListener() {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    self?.handleDeviceChange()
+                }
+            }
+        }
+        deviceChangeListenerBlock = block
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address,
+            DispatchQueue.main, block
+        )
+    }
+
+    private var isRestarting = false
+
+    private func handleDeviceChange() {
+        guard !isRestarting else { return }
+
+        if let deviceID = try? getDefaultOutputDeviceID(),
+           let name = try? getDeviceName(deviceID) {
+            outputDeviceName = name
+        }
+
+        if isRunning {
+            isRestarting = true
+            stop()
+            do {
+                try start()
+            } catch {
+                self.error = error.localizedDescription
+            }
+            isRestarting = false
+        }
+
+        onStateChange?()
+    }
+}

--- a/Sources/Perth/AudioRingBuffer.swift
+++ b/Sources/Perth/AudioRingBuffer.swift
@@ -1,0 +1,42 @@
+/// Lock-free SPSC ring buffer for bridging IOProc (producer) to AVAudioEngine (consumer).
+/// Power-of-2 capacity, wrapping integer arithmetic for correctness.
+final class AudioRingBuffer: @unchecked Sendable {
+    private let buffer: UnsafeMutablePointer<Float>
+    private let capacity: Int
+    private let mask: Int
+    private var _writeHead: UInt64 = 0
+    private var _readHead: UInt64 = 0
+
+    init(capacityFrames: Int, channels: Int) {
+        let cap = capacityFrames * channels
+        var power = 1
+        while power < cap { power *= 2 }
+        self.capacity = power
+        self.mask = power - 1
+        self.buffer = .allocate(capacity: power)
+        self.buffer.initialize(repeating: 0.0, count: power)
+    }
+
+    deinit { buffer.deallocate() }
+
+    var availableToRead: Int {
+        return Int(_writeHead &- _readHead)
+    }
+
+    func write(_ data: UnsafePointer<Float>, count: Int) {
+        for i in 0..<count {
+            buffer[Int(_writeHead) & mask] = data[i]
+            _writeHead &+= 1
+        }
+    }
+
+    func read(_ dest: UnsafeMutablePointer<Float>, count: Int) -> Int {
+        let avail = availableToRead
+        let toRead = min(count, avail)
+        for i in 0..<toRead {
+            dest[i] = buffer[Int(_readHead) & mask]
+            _readHead &+= 1
+        }
+        return toRead
+    }
+}

--- a/Sources/Perth/CoreAudioHelpers.swift
+++ b/Sources/Perth/CoreAudioHelpers.swift
@@ -1,0 +1,54 @@
+import CoreAudio
+
+func caCheck(_ status: OSStatus, _ message: String) throws {
+    guard status == noErr else {
+        throw NSError(domain: "Perth", code: Int(status),
+                      userInfo: [NSLocalizedDescriptionKey: "\(message): OSStatus \(status)"])
+    }
+}
+
+func getDefaultOutputDeviceID() throws -> AudioDeviceID {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var deviceID = AudioDeviceID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    try caCheck(
+        AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject),
+                                   &address, 0, nil, &size, &deviceID),
+        "Failed to get default output device"
+    )
+    return deviceID
+}
+
+func getDeviceUID(_ deviceID: AudioDeviceID) throws -> String {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyDeviceUID,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var uid: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    try caCheck(
+        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uid),
+        "Failed to get device UID"
+    )
+    return uid as String
+}
+
+func getDeviceName(_ deviceID: AudioDeviceID) throws -> String {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioObjectPropertyName,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var name: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    try caCheck(
+        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &name),
+        "Failed to get device name"
+    )
+    return name as String
+}

--- a/Sources/Perth/EQPreset.swift
+++ b/Sources/Perth/EQPreset.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+enum EQPreset: String, CaseIterable, Codable {
+    case flat
+    case bassBoost
+    case vocalClarity
+
+    var displayName: String {
+        switch self {
+        case .flat: return "Flat"
+        case .bassBoost: return "Bass Boost"
+        case .vocalClarity: return "Vocal Clarity"
+        }
+    }
+
+    /// Gain values in dB for each of the 10 bands.
+    /// Order: 32, 64, 125, 250, 500, 1k, 2k, 4k, 8k, 16k Hz
+    var bands: [Float] {
+        switch self {
+        case .flat:
+            return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        case .bassBoost:
+            return [10, 10, 8, 4, 0, 0, 0, 0, 0, 0]
+        case .vocalClarity:
+            return [-6, -6, -4, 0, 0, 6, 6, 4, 0, 0]
+        }
+    }
+
+    static let frequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+    static let bandCount = 10
+}
+
+// MARK: - State Persistence
+
+struct PerthState: Codable {
+    var isEnabled: Bool
+    var selectedPreset: EQPreset
+
+    static let defaultState = PerthState(isEnabled: false, selectedPreset: .flat)
+
+    private static let key = "com.perth.state"
+
+    static func load() -> PerthState {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let state = try? JSONDecoder().decode(PerthState.self, from: data) else {
+            return .defaultState
+        }
+        return state
+    }
+
+    func save() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: PerthState.key)
+        }
+    }
+}

--- a/Sources/Perth/Info.plist
+++ b/Sources/Perth/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.perth.app</string>
+    <key>CFBundleName</key>
+    <string>Perth</string>
+    <key>CFBundleVersion</key>
+    <string>0.1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>Perth needs to capture system audio to apply equalizer effects.</string>
+</dict>
+</plist>

--- a/Sources/Perth/MenuBarController.swift
+++ b/Sources/Perth/MenuBarController.swift
@@ -1,0 +1,138 @@
+import AppKit
+
+@available(macOS 14.2, *)
+@MainActor
+final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
+    private var statusItem: NSStatusItem!
+    private let audioEngine: AudioEngine
+    private var state: PerthState
+
+    init(audioEngine: AudioEngine) {
+        self.audioEngine = audioEngine
+        self.state = PerthState.load()
+        super.init()
+
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let menu = NSMenu()
+        menu.delegate = self
+        statusItem.menu = menu
+        updateIcon()
+
+        // Rebuild menu on device changes
+        audioEngine.onStateChange = { [weak self] in
+            self?.updateIcon()
+        }
+
+        // Restore saved state
+        audioEngine.selectedPreset = state.selectedPreset
+        if state.isEnabled {
+            audioEngine.setEnabled(true)
+            updateIcon()
+        }
+    }
+
+    // MARK: - NSMenuDelegate — build menu fresh each time it opens
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        populateMenu(menu)
+    }
+
+    private func populateMenu(_ menu: NSMenu) {
+        menu.removeAllItems()
+
+        // EQ Toggle
+        let toggleItem = NSMenuItem(title: audioEngine.isRunning ? "EQ On" : "EQ Off",
+                                     action: #selector(toggleEQ(_:)), keyEquivalent: "e")
+        toggleItem.keyEquivalentModifierMask = [.command]
+        toggleItem.target = self
+        toggleItem.state = audioEngine.isRunning ? .on : .off
+        menu.addItem(toggleItem)
+
+        menu.addItem(.separator())
+
+        // Presets (radio group)
+        for preset in EQPreset.allCases {
+            let item = NSMenuItem(title: preset.displayName,
+                                  action: #selector(selectPreset(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = preset.rawValue
+            item.state = audioEngine.selectedPreset == preset ? .on : .off
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+
+        // Output device (non-interactive)
+        let outputItem = NSMenuItem(title: "Output: \(audioEngine.outputDeviceName)",
+                                     action: nil, keyEquivalent: "")
+        outputItem.isEnabled = false
+        menu.addItem(outputItem)
+
+        // Error display
+        if let error = audioEngine.error {
+            let errorItem = NSMenuItem(title: "⚠ \(error)", action: nil, keyEquivalent: "")
+            errorItem.isEnabled = false
+            menu.addItem(errorItem)
+        }
+
+        menu.addItem(.separator())
+
+        // About
+        let aboutItem = NSMenuItem(title: "About Perth", action: #selector(showAbout(_:)),
+                                    keyEquivalent: "")
+        aboutItem.target = self
+        menu.addItem(aboutItem)
+
+        // Quit
+        let quitItem = NSMenuItem(title: "Quit", action: #selector(quit(_:)), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+    }
+
+    // MARK: - Actions
+
+    @objc private func toggleEQ(_ sender: NSMenuItem) {
+        let newState = !audioEngine.isRunning
+        audioEngine.setEnabled(newState)
+        state.isEnabled = audioEngine.isRunning
+        state.save()
+        updateIcon()
+    }
+
+    @objc private func selectPreset(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let preset = EQPreset(rawValue: rawValue) else { return }
+        audioEngine.selectedPreset = preset
+        state.selectedPreset = preset
+        state.save()
+    }
+
+    @objc private func showAbout(_ sender: NSMenuItem) {
+        let alert = NSAlert()
+        alert.messageText = "Perth"
+        alert.informativeText = "System-wide audio equalizer for macOS.\nVersion 0.1"
+        alert.alertStyle = .informational
+        alert.runModal()
+    }
+
+    @objc private func quit(_ sender: NSMenuItem) {
+        audioEngine.stop()
+        NSApp.terminate(nil)
+    }
+
+    // MARK: - Icon
+
+    private func updateIcon() {
+        if let button = statusItem.button {
+            button.title = ""
+            let symbolName = audioEngine.isRunning ? "slider.vertical.3" : "slider.vertical.3"
+            if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "Perth EQ") {
+                let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+                button.image = image.withSymbolConfiguration(config)
+                button.image?.isTemplate = true
+            }
+            // Indicate active state with a badge-style approach
+            button.appearsDisabled = !audioEngine.isRunning
+        }
+    }
+}

--- a/Sources/Perth/PerthApp.swift
+++ b/Sources/Perth/PerthApp.swift
@@ -1,0 +1,84 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+@available(macOS 14.2, *)
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var menuBarController: MenuBarController!
+    private var audioEngine: AudioEngine!
+    private var wasRunningBeforeSleep = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Check screen/audio capture permission — CATap requires it
+        let hasAccess = CGPreflightScreenCaptureAccess()
+        if !hasAccess {
+            CGRequestScreenCaptureAccess()
+        }
+
+        audioEngine = AudioEngine()
+        menuBarController = MenuBarController(audioEngine: audioEngine)
+
+        // Sleep/wake handling
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.willSleepNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleSleep()
+            }
+        }
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleWake()
+            }
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        audioEngine.stop()
+    }
+
+    private func handleSleep() {
+        wasRunningBeforeSleep = audioEngine.isRunning
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+    }
+
+    private func handleWake() {
+        if wasRunningBeforeSleep {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.audioEngine.setEnabled(true)
+            }
+        }
+    }
+}
+
+// MARK: - Entry Point
+
+@main
+struct PerthMain {
+    // Strong reference — NSApplication.delegate is weak, so without this
+    // Swift can deallocate the AppDelegate (and the entire menu bar icon).
+    nonisolated(unsafe) static var appDelegate: AnyObject?
+
+    static func main() {
+        if #available(macOS 14.2, *) {
+            let app = NSApplication.shared
+            app.setActivationPolicy(.accessory)
+            let delegate = AppDelegate()
+            appDelegate = delegate
+            app.delegate = delegate
+            app.run()
+        } else {
+            let app = NSApplication.shared
+            app.setActivationPolicy(.regular)
+            let alert = NSAlert()
+            alert.messageText = "Perth requires macOS 14.2 or newer"
+            alert.informativeText = "Core Audio Taps are only available on macOS 14.2+."
+            alert.runModal()
+        }
+    }
+}

--- a/Spikes/TapsSpike/.gitignore
+++ b/Spikes/TapsSpike/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Spikes/TapsSpike/Package.swift
+++ b/Spikes/TapsSpike/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TapsSpike",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "TapsSpike",
+            linkerSettings: [
+                .linkedFramework("CoreAudio"),
+                .linkedFramework("AudioToolbox"),
+                .linkedFramework("AVFAudio"),
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/TapsSpike/Info.plist",
+                ]),
+            ]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Spikes/TapsSpike/Sources/TapsSpike/Info.plist
+++ b/Spikes/TapsSpike/Sources/TapsSpike/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.perth.TapsSpike</string>
+    <key>CFBundleName</key>
+    <string>TapsSpike</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>Perth needs to capture system audio to apply equalizer effects.</string>
+</dict>
+</plist>

--- a/Spikes/TapsSpike/Sources/TapsSpike/TapsSpike.swift
+++ b/Spikes/TapsSpike/Sources/TapsSpike/TapsSpike.swift
@@ -1,0 +1,409 @@
+// TapsSpike v2 — Capture system audio via CATap, apply gain, play back through speakers.
+//
+// Architecture proven in v1: CATap → IOProc captures audio (2,800+ callbacks in 30s).
+// v2 adds: AVAudioEngine output with a 10-band EQ to play processed audio back.
+//
+// Usage: swift run TapsSpike [gain_db]
+
+import CoreAudio
+import AudioToolbox
+import AVFAudio
+import Foundation
+
+// MARK: - Helpers
+
+func check(_ status: OSStatus, _ message: String) throws {
+    guard status == noErr else {
+        throw NSError(domain: "TapsSpike", code: Int(status),
+                      userInfo: [NSLocalizedDescriptionKey: "\(message): OSStatus \(status)"])
+    }
+}
+
+func getDefaultOutputDeviceID() throws -> AudioDeviceID {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var deviceID = AudioDeviceID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    try check(
+        AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject),
+                                   &address, 0, nil, &size, &deviceID),
+        "Failed to get default output device"
+    )
+    return deviceID
+}
+
+func getDeviceUID(_ deviceID: AudioDeviceID) throws -> String {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyDeviceUID,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var uid: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    try check(
+        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uid),
+        "Failed to get device UID"
+    )
+    return uid as String
+}
+
+func getDeviceName(_ deviceID: AudioDeviceID) throws -> String {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioObjectPropertyName,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var name: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    try check(
+        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &name),
+        "Failed to get device name"
+    )
+    return name as String
+}
+
+// MARK: - Ring Buffer for IOProc → AVAudioEngine bridge
+
+/// Simple SPSC ring buffer using atomics for IOProc → AVAudioEngine bridge.
+/// Power-of-2 capacity, mask-based wraparound.
+final class AudioRingBuffer: @unchecked Sendable {
+    private let buffer: UnsafeMutablePointer<Float>
+    private let mask: Int  // capacity - 1
+    private let capacity: Int
+    private var _writeHead: Int = 0
+    private var _readHead: Int = 0
+
+    init(capacityFrames: Int, channels: Int) {
+        // Round up to power of 2
+        var cap = capacityFrames * channels
+        var power = 1
+        while power < cap { power *= 2 }
+        self.capacity = power
+        self.mask = power - 1
+        self.buffer = .allocate(capacity: power)
+        self.buffer.initialize(repeating: 0.0, count: power)
+    }
+
+    deinit { buffer.deallocate() }
+
+    var availableToRead: Int {
+        return (_writeHead &- _readHead) & mask
+    }
+
+    func write(_ data: UnsafePointer<Float>, count: Int) {
+        for i in 0..<count {
+            buffer[_writeHead & mask] = data[i]
+            _writeHead = (_writeHead &+ 1)
+        }
+    }
+
+    func read(_ dest: UnsafeMutablePointer<Float>, count: Int) -> Int {
+        let avail = availableToRead
+        let toRead = min(count, avail)
+        for i in 0..<toRead {
+            dest[i] = buffer[_readHead & mask]
+            _readHead = (_readHead &+ 1)
+        }
+        return toRead
+    }
+}
+
+// MARK: - Spike
+
+nonisolated(unsafe) var gFrameCount: UInt64 = 0
+nonisolated(unsafe) var gGainLinear: Float = 1.0
+nonisolated(unsafe) var gRingBuffer: AudioRingBuffer? = nil
+nonisolated(unsafe) var gMaxInputAmp: Float = 0.0
+
+@available(macOS 14.2, *)
+func runSpike() throws {
+    let gainDB = CommandLine.arguments.count > 1
+        ? Float(CommandLine.arguments[1]) ?? 6.0
+        : 6.0
+    gGainLinear = powf(10.0, gainDB / 20.0)
+
+    print("=== Perth Core Audio Taps Spike v2 ===")
+    print("Gain: \(gainDB) dB (linear: \(gGainLinear))")
+
+    // 1. Get the real output device
+    let outputDeviceID = try getDefaultOutputDeviceID()
+    let outputUID = try getDeviceUID(outputDeviceID)
+    let outputName = try getDeviceName(outputDeviceID)
+    print("Output device: \(outputName) (UID: \(outputUID))")
+
+    // 2. Create a global tap that mutes original audio
+    print("\nCreating global tap (muted)...")
+    let tapDesc = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+    tapDesc.uuid = UUID()
+    tapDesc.muteBehavior = .muted
+    tapDesc.name = "Perth-TapsSpike"
+
+    var tapID = AudioObjectID(kAudioObjectUnknown)
+    try check(
+        AudioHardwareCreateProcessTap(tapDesc, &tapID),
+        "Failed to create process tap"
+    )
+    print("Tap created: ID \(tapID)")
+
+    // 3. Read the tap's audio format
+    var formatAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioTapPropertyFormat,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var tapFormat = AudioStreamBasicDescription()
+    var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+    try check(
+        AudioObjectGetPropertyData(tapID, &formatAddress, 0, nil, &formatSize, &tapFormat),
+        "Failed to get tap format"
+    )
+    let sampleRate = tapFormat.mSampleRate
+    let channels = tapFormat.mChannelsPerFrame
+    print("Tap format: \(sampleRate) Hz, \(channels) ch, \(tapFormat.mBitsPerChannel) bit")
+
+    // 4. Create aggregate device with tap (audiotee approach: empty + add tap)
+    print("\nCreating aggregate device...")
+    let aggregateUID = UUID().uuidString
+    let aggregateDesc: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "Perth-Spike-Aggregate",
+        kAudioAggregateDeviceUIDKey: aggregateUID,
+        kAudioAggregateDeviceSubDeviceListKey: [] as CFArray,
+        kAudioAggregateDeviceMasterSubDeviceKey: 0,
+        kAudioAggregateDeviceIsPrivateKey: true,
+        kAudioAggregateDeviceIsStackedKey: false,
+    ]
+
+    var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+    try check(
+        AudioHardwareCreateAggregateDevice(aggregateDesc as CFDictionary, &aggregateDeviceID),
+        "Failed to create aggregate device"
+    )
+
+    // Add tap to aggregate device
+    var tapUIDAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioTapPropertyUID,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var tapUID: CFString = "" as CFString
+    var tapUIDSize = UInt32(MemoryLayout<CFString>.size)
+    try check(
+        AudioObjectGetPropertyData(tapID, &tapUIDAddress, 0, nil, &tapUIDSize, &tapUID),
+        "Failed to get tap UID"
+    )
+
+    var tapListAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioAggregateDevicePropertyTapList,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var tapArray = [tapUID] as CFArray
+    var tapArraySize = UInt32(MemoryLayout<CFArray>.size)
+    try check(
+        AudioObjectSetPropertyData(aggregateDeviceID, &tapListAddress, 0, nil, tapArraySize, &tapArray),
+        "Failed to set tap list"
+    )
+    print("Aggregate device ready with tap")
+
+    // Wait for device alive
+    var aliveAddress = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyDeviceIsAlive,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    for attempt in 1...20 {
+        var isAlive: UInt32 = 0
+        var aliveSize = UInt32(MemoryLayout<UInt32>.size)
+        AudioObjectGetPropertyData(aggregateDeviceID, &aliveAddress, 0, nil, &aliveSize, &isAlive)
+        if isAlive != 0 { break }
+        Thread.sleep(forTimeInterval: 0.1)
+        if attempt == 20 { print("WARNING: Device may not be alive") }
+    }
+
+    // 5. Set up AVAudioEngine for output with EQ
+    print("\nSetting up AVAudioEngine output...")
+    let engine = AVAudioEngine()
+    let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate,
+                               channels: AVAudioChannelCount(channels))!
+
+    // Ring buffer: 0.5 seconds of audio (enough to bridge IOProc → engine)
+    let ringBuffer = AudioRingBuffer(capacityFrames: Int(sampleRate * 0.5), channels: Int(channels))
+    gRingBuffer = ringBuffer
+
+    // Source node pulls from ring buffer
+    let sourceNode = AVAudioSourceNode(format: format) { _, _, frameCount, audioBufferList -> OSStatus in
+        let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
+        let samplesNeeded = Int(frameCount) * Int(channels)
+
+        for i in 0..<bufferList.count {
+            guard let outData = bufferList[i].mData?.assumingMemoryBound(to: Float.self) else { continue }
+            let read = ringBuffer.read(outData, count: samplesNeeded)
+            // Zero-fill if ring buffer underruns
+            if read < samplesNeeded {
+                outData.advanced(by: read).initialize(repeating: 0.0, count: samplesNeeded - read)
+            }
+        }
+        return noErr
+    }
+
+    // 10-band EQ (Perth's target spec)
+    let eq = AVAudioUnitEQ(numberOfBands: 10)
+    let frequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+    for (i, freq) in frequencies.enumerated() {
+        let band = eq.bands[i]
+        band.filterType = .parametric
+        band.frequency = freq
+        band.bandwidth = 1.0  // octave
+        band.gain = 0.0       // flat for now (gain applied in IOProc)
+        band.bypass = false
+    }
+    eq.globalGain = 0.0
+
+    // Wire up: sourceNode → EQ → mainMixerNode → output
+    engine.attach(sourceNode)
+    engine.attach(eq)
+    engine.connect(sourceNode, to: eq, format: format)
+    engine.connect(eq, to: engine.mainMixerNode, format: format)
+
+    try engine.start()
+    print("AVAudioEngine started (output to \(outputName))")
+
+    // 6. Install IOProc to capture tap audio → ring buffer
+    print("\nInstalling IOProc...")
+    var procID: AudioDeviceIOProcID?
+    try check(
+        AudioDeviceCreateIOProcID(
+            aggregateDeviceID,
+            { (_, _, inInputData, _, outOutputData, _, _) -> OSStatus in
+                guard let ringBuf = gRingBuffer else { return noErr }
+
+                let inCount = Int(inInputData.pointee.mNumberBuffers)
+                if inCount == 0 { return noErr }
+
+                // Read first buffer (stereo interleaved float32)
+                let firstBuf = UnsafeMutablePointer(mutating: inInputData).pointee.mBuffers
+                guard let data = firstBuf.mData else { return noErr }
+                let sampleCount = Int(firstBuf.mDataByteSize) / MemoryLayout<Float>.size
+                let samples = data.assumingMemoryBound(to: Float.self)
+
+                // Track max amplitude
+                var maxAmp: Float = 0.0
+                for i in 0..<sampleCount {
+                    let v = abs(samples[i])
+                    if v > maxAmp { maxAmp = v }
+                }
+                if maxAmp > gMaxInputAmp { gMaxInputAmp = maxAmp }
+
+                // Apply gain in-place then write to ring buffer
+                let gain = gGainLinear
+                for i in 0..<sampleCount {
+                    samples[i] = samples[i] * gain
+                }
+                ringBuf.write(samples, count: sampleCount)
+
+                gFrameCount &+= 1
+                return noErr
+            },
+            nil,
+            &procID
+        ),
+        "Failed to create IOProc"
+    )
+
+    try check(
+        AudioDeviceStart(aggregateDeviceID, procID),
+        "Failed to start aggregate device"
+    )
+
+    let startTime = Date()
+    print("\n🎵 SPIKE v2 RUNNING")
+    print("   Pipeline: System Audio → CATap (muted) → IOProc (+\(gainDB)dB) → Ring Buffer → AVAudioEngine (10-band EQ) → \(outputName)")
+    print("   Play some music and listen!")
+    print("   Running for 30 seconds...\n")
+
+    // 7. Run for 30 seconds
+    let runDuration: TimeInterval = 30
+    var lastReport: TimeInterval = 0
+    while Date().timeIntervalSince(startTime) < runDuration {
+        Thread.sleep(forTimeInterval: 1.0)
+        let elapsed = Date().timeIntervalSince(startTime)
+        if elapsed - lastReport >= 5.0 {
+            let callbacks = gFrameCount
+            let ringAvail = ringBuffer.availableToRead
+            let maxAmp = gMaxInputAmp
+            print("  [\(Int(elapsed))s] IOProc: \(callbacks) | Ring: \(ringAvail) | MaxAmp: \(maxAmp)")
+            lastReport = elapsed
+        }
+    }
+
+    // 8. Teardown — order matters to avoid assertion failures
+    print("\nStopping...")
+
+    // Print results BEFORE teardown in case it crashes
+    let totalCallbacksEarly = gFrameCount
+    let durationEarly = Date().timeIntervalSince(startTime)
+    print("Results: \(totalCallbacksEarly) IOProc callbacks in \(String(format: "%.1f", durationEarly))s")
+    if totalCallbacksEarly > 100 {
+        print("✅ Pipeline captured audio successfully!")
+    }
+    fflush(stdout)
+
+    // Stop IOProc first (stops feeding ring buffer)
+    AudioDeviceStop(aggregateDeviceID, procID)
+    Thread.sleep(forTimeInterval: 0.1)
+
+    // Clear ring buffer reference so source node stops reading
+    gRingBuffer = nil
+    Thread.sleep(forTimeInterval: 0.1)
+
+    // Stop engine
+    engine.stop()
+    Thread.sleep(forTimeInterval: 0.1)
+
+    // Destroy IOProc
+    if let procID {
+        AudioDeviceDestroyIOProcID(aggregateDeviceID, procID)
+    }
+
+    // Destroy aggregate device and tap
+    AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+    AudioHardwareDestroyProcessTap(tapID)
+
+    let totalCallbacks = gFrameCount
+    let duration = Date().timeIntervalSince(startTime)
+    print("\nSpike v2 complete.")
+    print("Total IOProc callbacks: \(totalCallbacks)")
+    print("Duration: \(String(format: "%.1f", duration))s")
+    if duration > 0 {
+        print("Avg callbacks/sec: \(String(format: "%.0f", Double(totalCallbacks) / duration))")
+    }
+
+    if totalCallbacks > 100 {
+        print("\n✅ SUCCESS — Full pipeline working!")
+        print("   CATap → IOProc → Ring Buffer → AVAudioEngine (EQ) → Speakers")
+        print("   Perth can be built entirely with Core Audio Taps.")
+        print("   No virtual audio driver needed. No restricted entitlement.")
+        print("   Distribution: single .app, standard notarization.")
+    } else {
+        print("\n❌ Pipeline incomplete — \(totalCallbacks) callbacks")
+    }
+}
+
+// MARK: - Entry Point
+
+if #available(macOS 14.2, *) {
+    do {
+        try runSpike()
+    } catch {
+        print("\n❌ ERROR: \(error.localizedDescription)")
+        print("\nIf you see a permission error, grant audio capture access in:")
+        print("  System Settings > Privacy & Security > Audio Capture")
+        exit(1)
+    }
+} else {
+    print("❌ Core Audio Taps require macOS 14.2 or newer.")
+    exit(1)
+}

--- a/Spikes/TapsSpike/Tests/TapsSpikeTests/TapsSpikeTests.swift
+++ b/Spikes/TapsSpike/Tests/TapsSpikeTests/TapsSpikeTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import TapsSpike
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}

--- a/Tests/PerthTests/EQPresetTests.swift
+++ b/Tests/PerthTests/EQPresetTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Perth
+
+final class EQPresetTests: XCTestCase {
+
+    func testAllPresetsHaveTenBands() {
+        for preset in EQPreset.allCases {
+            XCTAssertEqual(preset.bands.count, EQPreset.bandCount)
+        }
+    }
+
+    func testFlatIsAllZero() {
+        for gain in EQPreset.flat.bands {
+            XCTAssertEqual(gain, 0.0)
+        }
+    }
+
+    func testBassBoostOnlyBoostsLows() {
+        let bands = EQPreset.bassBoost.bands
+        XCTAssertGreaterThan(bands[0], 0)
+        XCTAssertGreaterThan(bands[1], 0)
+        XCTAssertGreaterThan(bands[2], 0)
+        for i in 3..<10 {
+            XCTAssertEqual(bands[i], 0.0)
+        }
+    }
+
+    func testVocalClarityCutsLowsBoostsMids() {
+        let bands = EQPreset.vocalClarity.bands
+        XCTAssertLessThan(bands[0], 0)
+        XCTAssertLessThan(bands[1], 0)
+        XCTAssertLessThan(bands[2], 0)
+        XCTAssertGreaterThan(bands[5], 0)
+        XCTAssertGreaterThan(bands[6], 0)
+        XCTAssertGreaterThan(bands[7], 0)
+    }
+
+    func testFrequenciesAscending() {
+        let freqs = EQPreset.frequencies
+        for i in 1..<freqs.count {
+            XCTAssertGreaterThan(freqs[i], freqs[i - 1])
+        }
+    }
+
+    func testGainsWithinRange() {
+        for preset in EQPreset.allCases {
+            for gain in preset.bands {
+                XCTAssertGreaterThanOrEqual(gain, -12.0)
+                XCTAssertLessThanOrEqual(gain, 12.0)
+            }
+        }
+    }
+
+    func testDisplayNamesNotEmpty() {
+        for preset in EQPreset.allCases {
+            XCTAssertFalse(preset.displayName.isEmpty)
+        }
+    }
+}
+
+final class PerthStateTests: XCTestCase {
+
+    func testDefaultState() {
+        let state = PerthState.defaultState
+        XCTAssertFalse(state.isEnabled)
+        XCTAssertEqual(state.selectedPreset, .flat)
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = PerthState(isEnabled: true, selectedPreset: .bassBoost)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PerthState.self, from: data)
+        XCTAssertEqual(decoded.isEnabled, original.isEnabled)
+        XCTAssertEqual(decoded.selectedPreset, original.selectedPreset)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Perth, a macOS menu bar app that applies a system-wide 10-band parametric EQ to all audio output using Core Audio Taps (macOS 14.2+)
- Audio pipeline: CATap (muted) → IOProc → SPSC ring buffer → AVAudioSourceNode → AVAudioUnitEQ → speakers
- 3 presets (Flat, Bass Boost, Vocal Clarity), persistent state, device change handling, sleep/wake support

## Test plan
- [x] Toggle EQ on/off — audio passes through when on, normal playback when off
- [x] Switch EQ presets while playing audio
- [x] Change audio output device while EQ is active — auto-restarts pipeline
- [x] Sleep/wake cycle — EQ resumes if it was running before sleep
- [ ] Verify on fresh install — screen capture permission prompt appears on first launch