### PR TITLE
Fix audio routing: sample rate mismatch, anti-clipping, volume loss

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,23 @@
+# Perth Backlog
+
+## Medium Priority
+
+### Per-app EQ profiles
+Sketch architecture for per-app routing before v1 ships to validate forward-compatibility.
+
+### Custom EQ sliders
+v0.2 — separate window with 10 vertical sliders, frequency labels, dB readout, "modified preset" indicator.
+
+### Accessibility
+Keyboard navigation, VoiceOver labels, contrast for icon states.
+
+### Low-latency mode
+Smaller ring buffer option for users who prefer lower latency over jitter tolerance.
+
+---
+
+## Resolved
+
+### Volume insertion loss with EQ active
+**Status:** Fixed
+**Fix:** AVAudioEngine was using the tap's sample rate (e.g., 48kHz) instead of the output device's native rate (e.g., 44.1kHz for Bluetooth). The resulting implicit resampling caused volume loss and crackling on devices with mismatched rates. Fixed by reading the output device's `kAudioDevicePropertyNominalSampleRate` and using it for AVAudioEngine's format. The aggregate device handles tap→device resampling natively.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Perth
+
+System-wide audio equalizer for macOS. A native Swift menu bar app that captures all system audio via Core Audio Taps, applies EQ processing, and plays it back through your output device.
+
+## Features
+
+- 10-band graphic EQ (32Hz–16kHz)
+- Presets: Flat, Bass Boost, Vocal Clarity
+- Anti-clipping preamp reduction (toggleable)
+- Automatic device switching
+- Sleep/wake handling
+- State persistence across launches
+
+## Requirements
+
+- macOS 14.2+ (Core Audio Taps API)
+- Screen & System Audio Recording permission
+
+## Building
+
+```bash
+swift build
+.build/arm64-apple-macosx/debug/Perth
+```
+
+## Architecture
+
+```
+System Audio → CATap (muted) → IOProc → Ring Buffer → AVAudioSourceNode → EQ → Output Device
+```
+
+Perth excludes its own process from the tap to prevent feedback loops. The app uses a private aggregate device combining the real output device with the tap stream.

--- a/Sources/Perth/AudioEngine.swift
+++ b/Sources/Perth/AudioEngine.swift
@@ -3,6 +3,9 @@ import AudioToolbox
 import AVFAudio
 import Foundation
 import Observation
+import os.log
+
+private let perthLog = OSLog(subsystem: "com.perth", category: "audio")
 
 // MARK: - Real-time Audio Callbacks (free functions, no actor isolation)
 // These run on Core Audio's IO thread. They MUST be free functions — not closures
@@ -75,6 +78,10 @@ final class AudioEngine {
     var onStateChange: (() -> Void)?
 
     var selectedPreset: EQPreset = .flat {
+        didSet { applyCurrentPreset() }
+    }
+
+    var preventClipping: Bool = true {
         didSet { applyCurrentPreset() }
     }
 
@@ -155,8 +162,27 @@ final class AudioEngine {
             AudioObjectGetPropertyData(tapID, &formatAddress, 0, nil, &formatSize, &tapFormat),
             "Failed to get tap format"
         )
-        let sampleRate = tapFormat.mSampleRate
+        let tapSampleRate = tapFormat.mSampleRate
         let channels = tapFormat.mChannelsPerFrame
+
+        // Read the output device's native sample rate for comparison
+        var nominalRateAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceSampleRate: Float64 = 0
+        var rateSize = UInt32(MemoryLayout<Float64>.size)
+        AudioObjectGetPropertyData(outputDeviceID, &nominalRateAddress, 0, nil, &rateSize, &deviceSampleRate)
+
+        // Use the output device's native sample rate for AVAudioEngine.
+        // The tap may capture at a different rate (e.g., 48kHz tap vs 44.1kHz Bluetooth).
+        // The aggregate device handles resampling between the tap and the IOProc.
+        let sampleRate = deviceSampleRate > 0 ? deviceSampleRate : tapSampleRate
+
+        os_log(.default, log: perthLog,
+               "tapRate: %{public}.0f  deviceRate: %{public}.0f  using: %{public}.0f  channels: %{public}u  device: %{public}@",
+               tapSampleRate, deviceSampleRate, sampleRate, channels, outputDeviceName as NSString)
 
         // 4. Create aggregate device with tap and output device in the creation dictionary.
         //    The tap list MUST be included at creation time — adding it later via
@@ -207,6 +233,18 @@ final class AudioEngine {
         rtChannelCount = channels
 
         let avEngine = AVAudioEngine()
+
+        // Explicitly set output to the real hardware device so Perth's playback
+        // goes directly to hardware, matching the gain staging of the original audio.
+        var outputID = outputDeviceID
+        let outputAU = avEngine.outputNode.audioUnit!
+        AudioUnitSetProperty(
+            outputAU,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global, 0,
+            &outputID, UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate,
                                    channels: AVAudioChannelCount(channels))!
 
@@ -221,13 +259,14 @@ final class AudioEngine {
             band.gain = selectedPreset.bands[i]
             band.bypass = false
         }
-        eqNode.globalGain = 0.0
+        eqNode.globalGain = preventClipping ? selectedPreset.preampGain : 0
+        eqNode.bypass = (selectedPreset == .flat)
         self.eq = eqNode
 
         avEngine.attach(sourceNode)
         avEngine.attach(eqNode)
         avEngine.connect(sourceNode, to: eqNode, format: format)
-        avEngine.connect(eqNode, to: avEngine.mainMixerNode, format: format)
+        avEngine.connect(eqNode, to: avEngine.outputNode, format: format)
 
         try avEngine.start()
         self.engine = avEngine
@@ -312,6 +351,8 @@ final class AudioEngine {
         for (i, gain) in gains.enumerated() {
             eq.bands[i].gain = gain
         }
+        eq.globalGain = preventClipping ? selectedPreset.preampGain : 0
+        eq.bypass = (selectedPreset == .flat)
     }
 
     // MARK: - Device Change Handling

--- a/Sources/Perth/EQPreset.swift
+++ b/Sources/Perth/EQPreset.swift
@@ -26,6 +26,15 @@ enum EQPreset: String, CaseIterable, Codable {
         }
     }
 
+    /// Automatic preamp reduction to prevent clipping.
+    /// Uses half the max boost as a compromise between clipping prevention and volume.
+    /// Full reduction (-maxBoost) is too quiet; no reduction clips on loud passages.
+    /// Half reduction keeps most content clean while staying closer to original volume.
+    var preampGain: Float {
+        let maxBoost = bands.max() ?? 0
+        return maxBoost > 0 ? -(maxBoost * 0.5) : 0
+    }
+
     static let frequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
     static let bandCount = 10
 }
@@ -35,8 +44,9 @@ enum EQPreset: String, CaseIterable, Codable {
 struct PerthState: Codable {
     var isEnabled: Bool
     var selectedPreset: EQPreset
+    var preventClipping: Bool
 
-    static let defaultState = PerthState(isEnabled: false, selectedPreset: .flat)
+    static let defaultState = PerthState(isEnabled: false, selectedPreset: .flat, preventClipping: true)
 
     private static let key = "com.perth.state"
 

--- a/Sources/Perth/MenuBarController.swift
+++ b/Sources/Perth/MenuBarController.swift
@@ -25,6 +25,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
 
         // Restore saved state
         audioEngine.selectedPreset = state.selectedPreset
+        audioEngine.preventClipping = state.preventClipping
         if state.isEnabled {
             audioEngine.setEnabled(true)
             updateIcon()
@@ -59,6 +60,15 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
             item.state = audioEngine.selectedPreset == preset ? .on : .off
             menu.addItem(item)
         }
+
+        menu.addItem(.separator())
+
+        // Prevent Clipping toggle
+        let clippingItem = NSMenuItem(title: "Prevent Clipping",
+                                       action: #selector(toggleClipping(_:)), keyEquivalent: "")
+        clippingItem.target = self
+        clippingItem.state = audioEngine.preventClipping ? .on : .off
+        menu.addItem(clippingItem)
 
         menu.addItem(.separator())
 
@@ -104,6 +114,12 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
               let preset = EQPreset(rawValue: rawValue) else { return }
         audioEngine.selectedPreset = preset
         state.selectedPreset = preset
+        state.save()
+    }
+
+    @objc private func toggleClipping(_ sender: NSMenuItem) {
+        audioEngine.preventClipping.toggle()
+        state.preventClipping = audioEngine.preventClipping
         state.save()
     }
 


### PR DESCRIPTION
## Summary
- **Fix Bluetooth crackling**: Use output device's native sample rate instead of the tap's rate. The tap captures at 48kHz but Bluetooth devices run at 44.1kHz — the mismatch caused crackling/distortion.
- **Fix volume insertion loss**: Route AVAudioEngine output directly to hardware device (bypassing mainMixerNode) and use the correct device sample rate, eliminating the ~1-2dB volume drop when EQ was active.
- **Add anti-clipping preamp**: Automatic gain reduction (half the max boost) when boosting frequencies. Toggleable via "Prevent Clipping" menu item, persisted across launches.
- **EQ bypass for Flat preset**: Skip EQ processing entirely when Flat is selected.
- **Add README.md and BACKLOG.md**: Project documentation and backlog tracking.

## Test plan
- [ ] Toggle EQ on with Flat preset — volume should match EQ off
- [ ] Switch between built-in speakers and Bluetooth device with EQ active — no crackling
- [ ] Select Bass Boost with Prevent Clipping on — should sound clean without distortion
- [ ] Select Bass Boost with Prevent Clipping off — louder but may clip on loud passages
- [ ] Toggle EQ off and back on — audio should resume cleanly
- [ ] Kill and relaunch app — state (preset, clipping toggle, enabled) should restore