### PR TITLE
Add low-latency mode (50ms ring buffer)

### DIFF
--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -91,6 +91,10 @@ final class AudioEngine {
         didSet { applyBands() }
     }
 
+    var lowLatency: Bool = false {
+        didSet { if isRunning { rebuildEngine() } }
+    }
+
     init() {
         do {
             let deviceID = try getDefaultOutputDeviceID()
@@ -233,7 +237,8 @@ final class AudioEngine {
         }
 
         // 5. Set up ring buffer + AVAudioEngine with EQ
-        let ringBuf = AudioRingBuffer(capacityFrames: Int(sampleRate * 0.5), channels: Int(channels))
+        let bufferSeconds = lowLatency ? 0.05 : 0.5
+        let ringBuf = AudioRingBuffer(capacityFrames: Int(sampleRate * bufferSeconds), channels: Int(channels))
         self.ringBuffer = ringBuf
         rtRingBuffer = ringBuf
         rtChannelCount = channels

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -6,11 +6,13 @@ struct iQualizeState: Codable {
     var isEnabled: Bool
     var selectedPresetID: UUID
     var preventClipping: Bool
+    var lowLatency: Bool
 
     static let defaultState = iQualizeState(
         isEnabled: false,
         selectedPresetID: EQPresetData.flat.id,
-        preventClipping: true
+        preventClipping: true,
+        lowLatency: false
     )
 
     private static let key = "com.iqualize.state"
@@ -26,18 +28,21 @@ struct iQualizeState: Codable {
         case isEnabled
         case selectedPresetID
         case preventClipping
+        case lowLatency
     }
 
-    init(isEnabled: Bool, selectedPresetID: UUID, preventClipping: Bool) {
+    init(isEnabled: Bool, selectedPresetID: UUID, preventClipping: Bool, lowLatency: Bool = false) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.preventClipping = preventClipping
+        self.lowLatency = lowLatency
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         isEnabled = (try? container.decode(Bool.self, forKey: .isEnabled)) ?? false
         preventClipping = (try? container.decode(Bool.self, forKey: .preventClipping)) ?? true
+        lowLatency = (try? container.decode(Bool.self, forKey: .lowLatency)) ?? false
 
         if let id = try? container.decode(UUID.self, forKey: .selectedPresetID) {
             selectedPresetID = id

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -16,6 +16,7 @@ final class EQWindowController: NSWindowController {
     private var gainLabels: [NSTextField] = []
     private var freqLabels: [NSTextField] = []
     private var clippingCheckbox: NSButton!
+    private var lowLatencyCheckbox: NSButton!
     private var outputLabel: NSTextField!
     private var deleteButton: NSButton!
     private var saveButton: NSButton!
@@ -150,6 +151,10 @@ final class EQWindowController: NSWindowController {
                                      target: self, action: #selector(toggleClipping(_:)))
         clippingCheckbox.state = audioEngine.preventClipping ? .on : .off
 
+        lowLatencyCheckbox = NSButton(checkboxWithTitle: "Low Latency",
+                                       target: self, action: #selector(toggleLowLatency(_:)))
+        lowLatencyCheckbox.state = audioEngine.lowLatency ? .on : .off
+
         let bottomRow = NSStackView()
         bottomRow.orientation = .horizontal
         bottomRow.distribution = .fill
@@ -162,6 +167,7 @@ final class EQWindowController: NSWindowController {
 
         bottomRow.addArrangedSubview(eqToggle)
         bottomRow.addArrangedSubview(spacer)
+        bottomRow.addArrangedSubview(lowLatencyCheckbox)
         bottomRow.addArrangedSubview(clippingCheckbox)
 
         mainStack.addArrangedSubview(bottomRow)
@@ -245,6 +251,7 @@ final class EQWindowController: NSWindowController {
         updateOutputLabel()
         updateEQToggle()
         clippingCheckbox.state = audioEngine.preventClipping ? .on : .off
+        lowLatencyCheckbox.state = audioEngine.lowLatency ? .on : .off
         savedPresetSnapshot = audioEngine.activePreset
         isModified = false
         resetButton.isEnabled = false
@@ -345,6 +352,13 @@ final class EQWindowController: NSWindowController {
         audioEngine.preventClipping = sender.state == .on
         var state = iQualizeState.load()
         state.preventClipping = audioEngine.preventClipping
+        state.save()
+    }
+
+    @objc private func toggleLowLatency(_ sender: NSButton) {
+        audioEngine.lowLatency = sender.state == .on
+        var state = iQualizeState.load()
+        state.lowLatency = audioEngine.lowLatency
         state.save()
     }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
+	<string>iQualize</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.iqualize.app</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.1</string>
+	<string>0.2</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -31,6 +31,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
             audioEngine.activePreset = preset
         }
         audioEngine.preventClipping = state.preventClipping
+        audioEngine.lowLatency = state.lowLatency
         audioEngine.setEnabled(true)
         updateIcon()
     }
@@ -75,6 +76,13 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         clippingItem.target = self
         clippingItem.state = audioEngine.preventClipping ? .on : .off
         menu.addItem(clippingItem)
+
+        // Low Latency toggle
+        let latencyItem = NSMenuItem(title: "Low Latency",
+                                      action: #selector(toggleLowLatency(_:)), keyEquivalent: "")
+        latencyItem.target = self
+        latencyItem.state = audioEngine.lowLatency ? .on : .off
+        menu.addItem(latencyItem)
 
         menu.addItem(.separator())
 
@@ -144,6 +152,12 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     @objc private func toggleClipping(_ sender: NSMenuItem) {
         audioEngine.preventClipping.toggle()
         state.preventClipping = audioEngine.preventClipping
+        state.save()
+    }
+
+    @objc private func toggleLowLatency(_ sender: NSMenuItem) {
+        audioEngine.lowLatency.toggle()
+        state.lowLatency = audioEngine.lowLatency
         state.save()
     }
 

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 # Build iQualize and install to ~/Applications for Spotlight/Dock access
-
 set -e
 
+cd "$(dirname "$0")"
+
 echo "Building iQualize..."
-xcodebuild -project iQualize.xcodeproj -scheme iQualize -configuration Release build 2>&1 | tail -5
+swift build -c release 2>&1 | tail -5
 
-APP_PATH=$(xcodebuild -project iQualize.xcodeproj -scheme iQualize -configuration Release -showBuildSettings 2>/dev/null | grep " BUILT_PRODUCTS_DIR" | awk '{print $3}')
+APP=/Applications/iQualize.app
+mkdir -p "$APP/Contents/MacOS"
 
-mkdir -p ~/Applications
+# Copy binary — always overwrites, keeping the same app identity for macOS permissions
+cp -f .build/release/iQualize "$APP/Contents/MacOS/iQualize"
 
-echo "Installing to ~/Applications/iQualize.app..."
-rm -rf ~/Applications/iQualize.app
-cp -R "$APP_PATH/iQualize.app" ~/Applications/iQualize.app
+# Always update Info.plist so version stays current
+cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"
 
-echo "Done! iQualize is now available in Spotlight and can be dragged to the Dock."
+echo "Installed to /Applications/iQualize.app"
+echo "You can drag it to the Dock or find it in Spotlight."


### PR DESCRIPTION
## Summary
- Adds a Low Latency toggle (50ms vs 500ms ring buffer) to reduce audio processing delay for real-time use cases
- Toggle available in both the menu bar and EQ settings window, persisted across launches
- Fixes `install.sh` to use SPM (`swift build`) instead of the removed Xcode project
- Bumps version to 0.2, fixes Info.plist Xcode variable references

## Test plan
- [x] Toggle Low Latency on/off — engine restarts with brief audio gap
- [x] Setting persists across quit and relaunch
- [x] Both menu bar and EQ window reflect toggle state
- [x] `install.sh` builds and installs to /Applications