### PR TITLE
Fix reset not clearing unsaved changes marker

### DIFF
--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -905,6 +905,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         buildSliders()
         isModified = false
         resetButton.isEnabled = false
+        populatePresetPicker()
         updateWindowTitle()
     }
 


### PR DESCRIPTION
## Summary
- Reset button now clears the `*` from preset picker by repopulating it after restoring the snapshot

## Test plan
- [x] Modify a preset, hit Reset — `*` disappears from picker and title