### PR TITLE
Bump version to 0.3.0 and enforce version bumping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Version lives in `Sources/iQualize/Info.plist` (`CFBundleShortVersionString` and
 - Multiple bug fixes in one PR = one patch bump
 - Multiple features in one PR = one minor bump
 - Always update both `CFBundleShortVersionString` (e.g. `0.4.0`) and `CFBundleVersion` (e.g. `0.4`)
+- You MUST check and bump the version on every PR — do not wait for the user to remind you
 
 ## Task Tracking
 


### PR DESCRIPTION
## Summary
- Bump version to 0.3.0 in Info.plist
- Add mandatory version bump rule to CLAUDE.md

## Test plan
- [x] Version shows 0.3.0 in About dialog