### PR TITLE
Add undo/redo for EQ modifications

### DIFF
--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -213,6 +213,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private let presetStore: PresetStore
 
     private var eqToggle: NSButton!
+    private var undoButton: NSButton!
+    private var redoButton: NSButton!
     private var presetPicker: NSPopUpButton!
     private var slidersContainer: BandDropTarget!
     private var sliders: [NSSlider] = []
@@ -344,6 +346,35 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         gearMenu.addItem(importItem)
         importExportButton.menu = gearMenu
 
+        // Undo/Redo buttons
+        undoButton = NSButton(frame: .zero)
+        undoButton.bezelStyle = .rounded
+        undoButton.isBordered = true
+        undoButton.title = ""
+        undoButton.toolTip = "Undo"
+        undoButton.isEnabled = false
+        if let undoImage = NSImage(systemSymbolName: "arrow.uturn.backward", accessibilityDescription: "Undo") {
+            let config = NSImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+            undoButton.image = undoImage.withSymbolConfiguration(config)
+        }
+        undoButton.target = self
+        undoButton.action = #selector(undoAction(_:))
+
+        redoButton = NSButton(frame: .zero)
+        redoButton.bezelStyle = .rounded
+        redoButton.isBordered = true
+        redoButton.title = ""
+        redoButton.toolTip = "Redo"
+        redoButton.isEnabled = false
+        if let redoImage = NSImage(systemSymbolName: "arrow.uturn.forward", accessibilityDescription: "Redo") {
+            let config = NSImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+            redoButton.image = redoImage.withSymbolConfiguration(config)
+        }
+        redoButton.target = self
+        redoButton.action = #selector(redoAction(_:))
+
+        presetRow.addArrangedSubview(undoButton)
+        presetRow.addArrangedSubview(redoButton)
         presetRow.addArrangedSubview(presetPicker)
         presetRow.addArrangedSubview(newButton)
         presetRow.addArrangedSubview(saveControl)
@@ -700,6 +731,55 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         resetButton.isEnabled = true
         populatePresetPicker()
         updateWindowTitle()
+        updateUndoRedoButtons()
+    }
+
+    private func updateUndoRedoButtons() {
+        let um = window?.undoManager
+        undoButton.isEnabled = um?.canUndo ?? false
+        redoButton.isEnabled = um?.canRedo ?? false
+    }
+
+    // MARK: - Undo/Redo
+
+    @objc private func undoAction(_ sender: NSButton) {
+        window?.undoManager?.undo()
+        updateUndoRedoButtons()
+    }
+
+    @objc private func redoAction(_ sender: NSButton) {
+        window?.undoManager?.redo()
+        updateUndoRedoButtons()
+    }
+
+    /// Snapshot taken at the start of a slider drag (coalesced into one undo)
+    private var sliderDragSnapshot: EQPresetData?
+
+    /// Register an undo action that restores the preset to `oldPreset`.
+    private func registerUndo(_ actionName: String, oldPreset: EQPresetData) {
+        guard let undoManager = window?.undoManager else { return }
+        let currentPreset = audioEngine.activePreset
+        undoManager.registerUndo(withTarget: self) { [weak self] target in
+            guard let self else { return }
+            let redoPreset = self.audioEngine.activePreset
+            self.audioEngine.activePreset = oldPreset
+            self.buildSliders()
+            if oldPreset == self.savedPresetSnapshot {
+                self.isModified = false
+                self.resetButton.isEnabled = false
+                self.populatePresetPicker()
+                self.updateWindowTitle()
+            } else {
+                self.markModified()
+            }
+            self.registerUndo(actionName, oldPreset: redoPreset)
+            // Defer button update until after undo manager finishes processing
+            DispatchQueue.main.async { [weak self] in
+                self?.updateUndoRedoButtons()
+            }
+        }
+        undoManager.setActionName(actionName)
+        updateUndoRedoButtons()
     }
 
     private func updateWindowTitle() {
@@ -767,6 +847,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         guard from != to,
               from < audioEngine.activePreset.bands.count,
               to <= audioEngine.activePreset.bands.count else { return }
+        let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
         var preset = audioEngine.activePreset
         let band = preset.bands.remove(at: from)
@@ -774,28 +855,33 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         audioEngine.activePreset = preset
         buildSliders()
         markModified()
+        registerUndo("Reorder Band", oldPreset: oldPreset)
     }
 
     @objc private func moveBandLeft(_ sender: NSMenuItem) {
         let index = sender.tag
         guard index > 0, index < audioEngine.activePreset.bands.count else { return }
+        let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
         var preset = audioEngine.activePreset
         preset.bands.swapAt(index, index - 1)
         audioEngine.activePreset = preset
         buildSliders()
         markModified()
+        registerUndo("Move Band Left", oldPreset: oldPreset)
     }
 
     @objc private func moveBandRight(_ sender: NSMenuItem) {
         let index = sender.tag
         guard index < audioEngine.activePreset.bands.count - 1 else { return }
+        let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
         var preset = audioEngine.activePreset
         preset.bands.swapAt(index, index + 1)
         audioEngine.activePreset = preset
         buildSliders()
         markModified()
+        registerUndo("Move Band Right", oldPreset: oldPreset)
     }
 
     @objc private func deleteBandFromMenu(_ sender: NSMenuItem) {
@@ -813,16 +899,19 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
+        let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
         var preset = audioEngine.activePreset
         preset.bands.remove(at: index)
         audioEngine.activePreset = preset
         buildSliders()
         markModified()
+        registerUndo("Delete Band", oldPreset: oldPreset)
     }
 
     @objc private func addBandLeft(_ sender: NSButton) {
         guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
         var preset = audioEngine.activePreset
         let leftmost = preset.bands.first ?? EQBand(frequency: 100, gain: 0)
@@ -830,10 +919,12 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         audioEngine.activePreset = preset
         buildSliders()
         markModified()
+        registerUndo("Add Band", oldPreset: oldPreset)
     }
 
     @objc private func addBandRight(_ sender: NSButton) {
         guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
         var preset = audioEngine.activePreset
         let rightmost = preset.bands.last ?? EQBand(frequency: 1000, gain: 0)
@@ -841,6 +932,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         audioEngine.activePreset = preset
         buildSliders()
         markModified()
+        registerUndo("Add Band", oldPreset: oldPreset)
     }
 
     // MARK: - NSTextFieldDelegate (editable dB / Hz / Q inputs)
@@ -862,12 +954,14 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                 let maxDB = audioEngine.maxGainDB
                 let clamped = min(max(value, -maxDB), maxDB)
                 if clamped != band.gain {
+                    let oldPreset = audioEngine.activePreset
                     forkIfBuiltIn()
                     var preset = audioEngine.activePreset
                     preset.bands[index].gain = clamped
                     audioEngine.activePreset = preset
                     sliders[index].doubleValue = Double(clamped)
                     markModified()
+                    registerUndo("Change Gain", oldPreset: oldPreset)
                 }
             }
             field.stringValue = audioEngine.activePreset.bands[index].gainLabel
@@ -876,11 +970,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             if let value = Float(text) {
                 let clamped = min(max(value, 20), 20000)
                 if clamped != band.frequency {
+                    let oldPreset = audioEngine.activePreset
                     forkIfBuiltIn()
                     var preset = audioEngine.activePreset
                     preset.bands[index].frequency = clamped
                     audioEngine.activePreset = preset
                     markModified()
+                    registerUndo("Change Frequency", oldPreset: oldPreset)
                 }
             }
             field.stringValue = audioEngine.activePreset.bands[index].frequencyLabel
@@ -889,11 +985,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             if let value = Float(text), value > 0 {
                 let clamped = min(max(value, 0.1), 10)
                 if clamped != band.bandwidth {
+                    let oldPreset = audioEngine.activePreset
                     forkIfBuiltIn()
                     var preset = audioEngine.activePreset
                     preset.bands[index].bandwidth = clamped
                     audioEngine.activePreset = preset
                     markModified()
+                    registerUndo("Change Bandwidth", oldPreset: oldPreset)
                 }
             }
             field.stringValue = audioEngine.activePreset.bands[index].bandwidthLabel
@@ -917,6 +1015,12 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     @objc private func sliderMoved(_ sender: NSSlider) {
         let index = sender.tag
         guard index < audioEngine.activePreset.bands.count else { return }
+
+        // Snapshot at drag start for coalesced undo
+        if sliderDragSnapshot == nil {
+            sliderDragSnapshot = audioEngine.activePreset
+        }
+
         forkIfBuiltIn()
         let gain = Float(sender.doubleValue)
 
@@ -926,6 +1030,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
         gainLabels[index].stringValue = preset.bands[index].gainLabel
         markModified()
+
+        // Register undo when drag ends (mouse up)
+        let event = NSApp.currentEvent
+        if event?.type == .leftMouseUp, let snapshot = sliderDragSnapshot {
+            registerUndo("Adjust Gain", oldPreset: snapshot)
+            sliderDragSnapshot = nil
+        }
     }
 
     @objc private func resetPreset(_ sender: NSButton) {
@@ -937,6 +1048,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         resetButton.isEnabled = false
         populatePresetPicker()
         updateWindowTitle()
+        window?.undoManager?.removeAllActions()
+        updateUndoRedoButtons()
     }
 
     @objc private func newPreset(_ sender: NSButton) {

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.4</string>
+	<string>0.5</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -17,6 +17,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             CGRequestScreenCaptureAccess()
         }
 
+        setupMainMenu()
+
         audioEngine = AudioEngine()
         presetStore = PresetStore()
         menuBarController = MenuBarController(audioEngine: audioEngine, presetStore: presetStore)
@@ -47,6 +49,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         audioEngine.stop()
+    }
+
+    private func setupMainMenu() {
+        let mainMenu = NSMenu()
+
+        // App menu
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu()
+        appMenu.addItem(withTitle: "About iQualize", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(.separator())
+        appMenu.addItem(withTitle: "Quit iQualize", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        // Edit menu (Undo/Redo)
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        let redoItem = editMenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+        redoItem.keyEquivalentModifierMask = [.command, .shift]
+        editMenu.addItem(.separator())
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
+        NSApp.mainMenu = mainMenu
     }
 
     private func handleSleep() {


### PR DESCRIPTION
## Summary
- Undo/redo buttons in EQ window (arrow icons) with proper enable/disable states
- macOS Edit menu with Undo (Cmd+Z) and Redo (Cmd+Shift+Z)
- All band modifications are undoable: slider drags (coalesced into one undo per drag), gain/frequency/Q text edits, add/delete/move/reorder bands
- Reset clears the undo/redo stack
- Bump version to 0.5.0

## Test plan
- [ ] Move a slider, verify undo button enables, click undo — slider reverts and undo disables
- [ ] Make multiple changes, undo all, verify redo enables for each
- [ ] Add a band, undo — band removed; redo — band re-added
- [ ] Delete a band, undo — band restored
- [ ] Edit frequency/Q text fields, undo reverts the value
- [ ] Click Reset, verify undo/redo buttons both disable
- [ ] Verify Cmd+Z and Cmd+Shift+Z work from Edit menu

Fixes no open issues — new feature for v0.5.0.