### PR TITLE
Fix EQ crackling and smooth preset switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
 # iQualize
 
-System-wide audio equalizer for macOS. A native Swift menu bar app that captures all system audio via Core Audio Taps, applies EQ processing, and plays it back through your output device.
+System-wide audio equalizer for macOS. A native Swift menu bar app that captures all system audio via Core Audio Taps, applies parametric EQ processing, and plays it back through your output device — no kernel extensions, no virtual audio drivers.
 
-## Features
-
-- Customizable EQ bands with editable dB, Hz, and Q values
-- Drag-and-drop band reordering
-- Add/remove bands inline with + buttons
-- Adjustable max dB cap (±6/12/18/24)
-- Low Latency mode (50ms ring buffer)
-- Preset management: save, save as, import/export JSON
-- Anti-clipping preamp reduction (toggleable)
-- Automatic device switching
-- Sleep/wake handling
-- State persistence across launches (including window state)
+```
+System Audio → CATap (muted) → IOProc → Ring Buffer → AVAudioSourceNode → EQ → Output Device
+```
 
 ## Requirements
 
@@ -27,10 +18,54 @@ bash install.sh          # builds, signs, installs to /Applications
 open /Applications/iQualize.app
 ```
 
-## Architecture
+## Features
 
-```
-System Audio → CATap (muted) → IOProc → Ring Buffer → AVAudioSourceNode → EQ → Output Device
-```
+### Equalizer
+- Up to 31 parametric EQ bands with editable frequency (20 Hz–20 kHz), gain, and Q/bandwidth
+- Adjustable max gain range: ±6, ±12, ±18, or ±24 dB
+- Anti-clipping preamp that automatically reduces gain to prevent digital clipping
+- Low Latency mode (50ms buffer) for real-time monitoring
+- Smooth, glitch-free parameter updates — only changed values are written to the audio unit
 
-iQualize excludes its own process from the tap to prevent feedback loops. The app uses a private aggregate device combining the real output device with the tap stream.
+### Band Management
+- Add bands with + buttons on either side of the EQ
+- Smart frequency suggestions — new bands fill the largest spectral gap
+- Delete, reorder via drag-and-drop or right-click context menu (Move Left/Right)
+- Minimum 1 band, maximum 31
+
+### Presets
+- Built-in presets: Flat, Bass Boost, Vocal Clarity
+- Create, rename, overwrite, and delete custom presets
+- Built-in presets auto-fork when edited
+- Unsaved changes indicator (asterisk in title)
+- Import/export as `.iqpreset` JSON files with batch import and overwrite protection
+- Quick switching from the menu bar or EQ window picker
+
+### Undo/Redo
+- Full undo/redo for all EQ modifications (gain, frequency, bandwidth, reorder, add, delete)
+- Slider drags coalesced into single undo actions
+- Cmd+Z / Cmd+Shift+Z
+
+### Menu Bar
+- Quick preset selection with checkmarks
+- Prevent Clipping and Low Latency toggles
+- Current output device display
+- Open EQ window (Cmd+,)
+
+### System Integration
+- Automatic output device switching and reconnection
+- Sleep/wake handling — pauses on sleep, resumes on wake
+- Window state and all settings persist across launches
+- Codesigned for stable TCC permissions across rebuilds
+- Built with Swift Package Manager — no Xcode project needed
+
+## Roadmap
+
+- [ ] Visual frequency response curve
+- [ ] Per-app audio routing (EQ only specific apps)
+- [ ] More built-in presets (Loudness, Treble Boost, Podcast, etc.)
+- [ ] Preset sharing / community presets
+- [ ] Audio spectrum analyzer / visualizer
+- [ ] Keyboard shortcuts for band adjustments
+- [ ] Sparkle auto-updates
+- [ ] Menu bar waveform or level meter

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -79,11 +79,7 @@ final class AudioEngine {
 
     var activePreset: EQPresetData = .flat {
         didSet {
-            if oldValue.bands.count != activePreset.bands.count {
-                if isRunning { rebuildEngine() }
-            } else {
-                applyBands()
-            }
+            applyBands(from: oldValue)
         }
     }
 
@@ -263,14 +259,18 @@ final class AudioEngine {
 
         let sourceNode = AVAudioSourceNode(format: format, renderBlock: renderCallback)
 
-        let eqNode = AVAudioUnitEQ(numberOfBands: activePreset.bands.count)
-        for (i, band) in activePreset.bands.enumerated() {
-            let eqBand = eqNode.bands[i]
-            eqBand.filterType = .parametric
-            eqBand.frequency = band.frequency
-            eqBand.bandwidth = band.bandwidth
-            eqBand.gain = band.gain
-            eqBand.bypass = false
+        let eqNode = AVAudioUnitEQ(numberOfBands: EQPresetData.maxBandCount)
+        for (i, eqBand) in eqNode.bands.enumerated() {
+            if i < activePreset.bands.count {
+                let band = activePreset.bands[i]
+                eqBand.filterType = .parametric
+                eqBand.frequency = band.frequency
+                eqBand.bandwidth = band.bandwidth
+                eqBand.gain = band.gain
+                eqBand.bypass = false
+            } else {
+                eqBand.bypass = true
+            }
         }
         eqNode.globalGain = preventClipping ? activePreset.preampGain : 0
         eqNode.bypass = activePreset.isFlat
@@ -358,13 +358,40 @@ final class AudioEngine {
         }
     }
 
-    private func applyBands() {
+    private func applyBands(from old: EQPresetData? = nil) {
         guard let eq else { return }
+        let newCount = activePreset.bands.count
+        let oldCount = old?.bands.count ?? 0
+
         for (i, band) in activePreset.bands.enumerated() {
-            eq.bands[i].frequency = band.frequency
-            eq.bands[i].gain = band.gain
-            eq.bands[i].bandwidth = band.bandwidth
+            let eqBand = eq.bands[i]
+            if i >= oldCount {
+                // New band — configure fully
+                eqBand.filterType = .parametric
+                eqBand.frequency = band.frequency
+                eqBand.bandwidth = band.bandwidth
+                eqBand.gain = band.gain
+                eqBand.bypass = false
+            } else if let oldBand = old?.bands[i] {
+                // Existing band — only update changed params
+                if band.frequency != oldBand.frequency { eqBand.frequency = band.frequency }
+                if band.gain != oldBand.gain { eqBand.gain = band.gain }
+                if band.bandwidth != oldBand.bandwidth { eqBand.bandwidth = band.bandwidth }
+            } else {
+                // No old data — write everything
+                eqBand.frequency = band.frequency
+                eqBand.gain = band.gain
+                eqBand.bandwidth = band.bandwidth
+            }
         }
+
+        // Bypass bands that are no longer active
+        if newCount < oldCount {
+            for i in newCount..<oldCount {
+                eq.bands[i].bypass = true
+            }
+        }
+
         eq.globalGain = preventClipping ? activePreset.preampGain : 0
         eq.bypass = activePreset.isFlat
     }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.5</string>
+	<string>0.5.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/iQualize.entitlements
+++ b/iQualize.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ else
     # Codesign with stable identity
     SIGN_ID="Apple Development"
     if [ -n "$SIGN_ID" ]; then
-        codesign --force --sign "$SIGN_ID" "$APP" 2>/dev/null && echo "Signed with: $SIGN_ID"
+        codesign --force --sign "$SIGN_ID" --entitlements iQualize.entitlements "$APP" 2>/dev/null && echo "Signed with: $SIGN_ID"
     fi
     echo "Binary updated"
 fi


### PR DESCRIPTION
## Summary
- **Diff-based `applyBands()`** — only writes EQ parameters that actually changed, eliminating IIR filter coefficient recalculation artifacts during slider drags (1 param write instead of 30)
- **Pre-allocated EQ bands** — creates AVAudioUnitEQ with max 31 bands upfront, bypassing unused ones. Preset switches with different band counts no longer rebuild the audio pipeline
- **Fixed codesigning** — `install.sh` now embeds entitlements so the app launches reliably after rebuild
- **README rewrite** — complete feature list and roadmap

## Test plan
- [ ] Play audio, drag EQ sliders rapidly — verify no crackling
- [ ] Switch between presets with different band counts — verify no audio gap
- [ ] Add/remove bands — verify seamless transition
- [ ] Test undo/redo after slider adjustments
- [ ] Test typing values in gain/frequency/bandwidth fields
- [ ] `bash install.sh && open /Applications/iQualize.app` works cleanly