### PR TITLE
Add built-in presets, bypass toggle, and updated README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,23 @@ open /Applications/iQualize.app
 - Binary is codesigned with "Apple Development" cert to preserve TCC permissions across rebuilds
 - install.sh skips binary copy if unchanged (preserves cdhash)
 
+### Launch verification (REQUIRED)
+
+After every build+install, you MUST verify the app actually launches:
+
+```bash
+pkill -x iQualize; bash install.sh && open /Applications/iQualize.app
+sleep 2
+pgrep -x iQualize > /dev/null && echo "OK: app running" || echo "FAIL: app did not start"
+```
+
+If the app fails to launch ("can't be opened" error), debug and fix before proceeding. Common causes:
+- **TCC/cdhash mismatch**: the codesign identity changed or install.sh didn't re-sign properly
+- **Launchd spawn failure**: macOS sometimes needs a few seconds after killing the old process — add `sleep 1` before `open`
+- **Crash on startup**: run the binary directly to see the error: `/Applications/iQualize.app/Contents/MacOS/iQualize`
+
+**A task is not done until the app launches successfully.** Never skip this step.
+
 ## Architecture
 
 - `Sources/iQualize/iQualizeApp.swift` — app entry, NSApplicationDelegate

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # iQualize
 
-System-wide audio equalizer for macOS. A native Swift menu bar app that captures all system audio via Core Audio Taps, applies parametric EQ processing, and plays it back through your output device — no kernel extensions, no virtual audio drivers.
+System-wide parametric equalizer for macOS. Native Swift menu bar app that captures all system audio via Core Audio Taps, applies real-time EQ processing, and routes it to your output device — no kernel extensions, no virtual audio drivers, no background daemons.
 
 ```
 System Audio → CATap (muted) → IOProc → Ring Buffer → AVAudioSourceNode → EQ → Output Device
 ```
+
+Built for people who care about how their Mac sounds.
+
+## Why iQualize
+
+macOS has no system-wide EQ. If your headphones are bass-heavy, your speakers are muddy in a corner, or you just want more kick in your techno — you're stuck. iQualize fixes that with a parametric EQ that sits between every app on your system and your output device.
+
+No virtual audio device tricks. No kernel extension nightmares after macOS updates. Core Audio Taps (macOS 14.2+) is the proper API for this, and iQualize uses it.
 
 ## Requirements
 
@@ -20,52 +28,152 @@ open /Applications/iQualize.app
 
 ## Features
 
-### Equalizer
-- Up to 31 parametric EQ bands with editable frequency (20 Hz–20 kHz), gain, and Q/bandwidth
+### Parametric EQ
+
+- Up to 31 bands with editable frequency (20 Hz – 20 kHz), gain, and Q/bandwidth
 - Adjustable max gain range: ±6, ±12, ±18, or ±24 dB
-- Anti-clipping preamp that automatically reduces gain to prevent digital clipping
+- Anti-clipping preamp — automatically reduces gain to prevent digital clipping
 - Low Latency mode (50ms buffer) for real-time monitoring
 - Smooth, glitch-free parameter updates — only changed values are written to the audio unit
 
 ### Band Management
-- Add bands with + buttons on either side of the EQ
-- Smart frequency suggestions — new bands fill the largest spectral gap
+
+- Add bands with + buttons on either side of the EQ — new band copies the leftmost or rightmost band
 - Delete, reorder via drag-and-drop or right-click context menu (Move Left/Right)
 - Minimum 1 band, maximum 31
 
 ### Presets
-- Built-in presets: Flat, Bass Boost, Vocal Clarity
+
+- Built-in presets: Flat, Bass Boost, Vocal Clarity, Loudness, Treble Boost, Podcast, Techno, Deep House, Hard Techno, Minimal
 - Create, rename, overwrite, and delete custom presets
-- Built-in presets auto-fork when edited
+- Built-in presets auto-fork when edited (non-destructive)
 - Unsaved changes indicator (asterisk in title)
 - Import/export as `.iqpreset` JSON files with batch import and overwrite protection
 - Quick switching from the menu bar or EQ window picker
 
+#### Preset Format
+
+Presets are `.iqpreset` files — plain JSON:
+
+```json
+{
+  "bands": [
+    { "bandwidth": 1.0, "frequency": 80, "gain": 5 },
+    { "bandwidth": 1.2, "frequency": 200, "gain": -3 }
+  ],
+  "id": "CDE9BB8A-12A5-420C-9619-2790E20030D5",
+  "isBuiltIn": false,
+  "name": "My Preset"
+}
+```
+
+Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (Q factor — lower is wider, higher is narrower).
+
 ### Undo/Redo
+
 - Full undo/redo for all EQ modifications (gain, frequency, bandwidth, reorder, add, delete)
 - Slider drags coalesced into single undo actions
 - Cmd+Z / Cmd+Shift+Z
 
 ### Menu Bar
+
 - Quick preset selection with checkmarks
+- Bypass EQ toggle (Cmd+B) — pass audio through unprocessed
 - Prevent Clipping and Low Latency toggles
 - Current output device display
 - Open EQ window (Cmd+,)
 
 ### System Integration
+
 - Automatic output device switching and reconnection
 - Sleep/wake handling — pauses on sleep, resumes on wake
 - Window state and all settings persist across launches
 - Codesigned for stable TCC permissions across rebuilds
 - Built with Swift Package Manager — no Xcode project needed
 
+## Architecture
+
+iQualize uses Core Audio Taps (CATap), introduced in macOS 14.2, to intercept system audio without a virtual audio device. Virtual devices (like BlackHole or eqMac's driver approach) create a secondary audio path — you lose system volume control, break some DRM-protected audio, and add latency. CATap captures the audio stream directly from the HAL, processes it in-process, and sends it to the output device.
+
+```
+┌─────────────────────────────────────────────────┐
+│  macOS Audio Server                             │
+│                                                 │
+│  App Audio ──┬── Output Device (muted by tap)   │
+│              │                                  │
+│              └── CATap ──► iQualize IOProc      │
+│                            │                    │
+│                            ▼                    │
+│                       Ring Buffer               │
+│                            │                    │
+│                            ▼                    │
+│                   AVAudioSourceNode             │
+│                            │                    │
+│                            ▼                    │
+│                    AVAudioUnitEQ                 │
+│                    (parametric EQ)               │
+│                            │                    │
+│                            ▼                    │
+│                    Output Device                 │
+└─────────────────────────────────────────────────┘
+```
+
+The ring buffer decouples the real-time IOProc callback from AVAudioEngine's pull model. Parameter changes are written atomically — no locks in the audio thread, no glitches on slider drags.
+
+## Output Handling
+
+iQualize detects the output device's sample rate and converts internally so the audio plays back correctly regardless of what device you're on. Bluetooth sends stereo (2ch) only — SBC, AAC, and aptX all max out at 2 channels. If your speaker system supports 5.1 (e.g. Teufel Concept E via USB), the hardware handles channel routing and upmixing (Dolby Pro Logic II etc) on its end.
+
 ## Roadmap
 
-- [ ] Visual frequency response curve
-- [ ] Per-app audio routing (EQ only specific apps)
-- [ ] More built-in presets (Loudness, Treble Boost, Podcast, etc.)
-- [ ] Preset sharing / community presets
-- [ ] Audio spectrum analyzer / visualizer
-- [ ] Keyboard shortcuts for band adjustments
-- [ ] Sparkle auto-updates
-- [ ] Menu bar waveform or level meter
+Prioritized by impact vs effort. Score = impact (1-5) x ease (1-5). Higher = do first.
+
+### Low-hanging fruit (score 15+)
+
+| Feature | Impact | Ease | Score | Notes |
+|---|---|---|---|---|
+| Smart frequency suggestions | 3 | 5 | 15 | New bands fill the largest spectral gap instead of copying the edge band |
+| Keyboard shortcuts for bands | 3 | 5 | 15 | Arrow keys to adjust selected band gain/freq |
+| Visual frequency response curve | 5 | 3 | 15 | Draw the composite EQ curve in the window — biggest UX upgrade |
+
+### High impact, moderate effort (score 10-14)
+
+| Feature | Impact | Ease | Score | Notes |
+|---|---|---|---|---|
+| Filter types per band | 5 | 3 | 15 | Bell, low/high shelf, low/high pass, notch, bandpass — AVAudioUnitEQ already supports these filter types natively |
+| Per-band bypass | 4 | 3 | 12 | Set individual band gain to 0 without losing saved value, toggle in UI |
+| Drag-on-curve editing | 5 | 2 | 10 | Drag band nodes directly on the response curve — needs hit testing, coordinate mapping |
+| Real-time spectrum analyzer | 5 | 2 | 10 | FFT of audio buffer, render behind EQ curve. Pre/post EQ modes. Huge visual feature |
+| Peak hold markers | 3 | 4 | 12 | Piggybacks on the analyzer — small addition once FFT exists |
+| Filter slope selection | 3 | 4 | 12 | 6/12/24/48 dB/oct for pass filters — expose existing Core Audio param |
+| Per-band solo | 3 | 3 | 9 | Mute all other bands, play only the selected band's affected range |
+| Menu bar level meter | 3 | 3 | 9 | RMS/peak meter from the output buffer, render in menu bar icon |
+| Sparkle auto-updates | 3 | 3 | 9 | Standard for Mac apps, one-time setup |
+
+### Differentiators (score 5-9, higher effort but competitive moat)
+
+| Feature | Impact | Ease | Score | Notes |
+|---|---|---|---|---|
+| Per-app volume mixer | 5 | 2 | 10 | Independent volume per app. Requires per-process audio taps — significant Core Audio work |
+| Per-app EQ routing | 5 | 1 | 5 | Different EQ per app. Same tap challenge as above but with per-stream EQ instances |
+| AutoEQ headphone profiles | 5 | 2 | 10 | Import from the open-source AutoEQ database. Match headphone model, apply corrective curve |
+| Preset sharing / community | 4 | 2 | 8 | Web directory or GitHub repo of .iqpreset files, in-app browse and import |
+| Mid/Side processing | 4 | 2 | 8 | Encode L/R to Mid/Side, EQ independently, decode back. Matrix math in the audio buffer |
+| L/R independent EQ | 3 | 3 | 9 | Separate curves per channel — simpler than Mid/Side, just duplicate the EQ chain |
+| Shortcuts integration | 3 | 3 | 9 | macOS Shortcuts actions for preset switching, bypass toggle — good for automation |
+
+### Moonshots (high effort, high reward)
+
+| Feature | Impact | Ease | Score | Notes |
+|---|---|---|---|---|
+| Audiogram hearing compensation | 5 | 1 | 5 | Built-in hearing test (play tones, user marks threshold), generate corrective L/R curve. Nobody does this well on macOS — huge accessibility angle, press-worthy |
+| Room correction via mic | 5 | 1 | 5 | Play test tones through speakers, record with Mac mic, compute room response, generate inverse EQ. Pro studio feature at consumer level |
+| AU plugin hosting | 5 | 1 | 5 | Load third-party Audio Unit effects into the signal chain. Opens the entire AU plugin ecosystem |
+| Dynamic EQ | 4 | 1 | 4 | Bands activate based on signal threshold — compressor married to EQ. Requires sidechain analysis per band |
+| Linear phase mode | 3 | 1 | 3 | FIR filter implementation, preserves phase coherence. High latency, mastering use case |
+| Auto-gain compensation | 3 | 2 | 6 | Maintain perceived loudness while EQ changes. Integrate over frequency-weighted gain |
+| Multichannel-aware EQ | 4 | 1 | 4 | Per-channel or per-group curves for 5.1/7.1 setups. Needs channel routing UI |
+
+## License
+
+[TODO]

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -91,6 +91,10 @@ final class AudioEngine {
         didSet { if isRunning { rebuildEngine() } }
     }
 
+    var bypassed: Bool = false {
+        didSet { applyBands() }
+    }
+
     var maxGainDB: Float = 12
 
     init() {
@@ -273,7 +277,7 @@ final class AudioEngine {
             }
         }
         eqNode.globalGain = preventClipping ? activePreset.preampGain : 0
-        eqNode.bypass = activePreset.isFlat
+        eqNode.bypass = bypassed || activePreset.isFlat
         self.eq = eqNode
 
         avEngine.attach(sourceNode)
@@ -393,7 +397,7 @@ final class AudioEngine {
         }
 
         eq.globalGain = preventClipping ? activePreset.preampGain : 0
-        eq.bypass = activePreset.isFlat
+        eq.bypass = bypassed || activePreset.isFlat
     }
 
     private func rebuildEngine() {

--- a/Sources/iQualize/EQModels.swift
+++ b/Sources/iQualize/EQModels.swift
@@ -71,7 +71,73 @@ extension EQPresetData {
         isBuiltIn: true
     )
 
-    static let builtInPresets: [EQPresetData] = [.flat, .bassBoost, .vocalClarity]
+    static let loudness = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!,
+        name: "Loudness",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([ 8,  6,  0, -2, -4, -2,  0,  2,  4,  6]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let trebleBoost = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!,
+        name: "Treble Boost",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([ 0,  0,  0,  0,  0,  2,  4,  6,  8, 10]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let podcast = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000006")!,
+        name: "Podcast",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([-8, -4, -2,  0,  2,  4,  6,  4,  2,  0]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let techno = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000007")!,
+        name: "Techno",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([ 8,  8,  4, -2, -4, -2,  0,  4,  6,  8]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let deepHouse = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000008")!,
+        name: "Deep House",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([ 6, 10,  8,  2, -2, -4, -2,  0,  2,  4]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let hardTechno = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000009")!,
+        name: "Hard Techno",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([10, 10,  6,  0, -4, -2,  2,  6,  8, 10]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let minimal = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!,
+        name: "Minimal",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([ 4,  6,  4,  0, -2, -2,  0,  2,  4,  2]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let builtInPresets: [EQPresetData] = [
+        .flat, .bassBoost, .vocalClarity, .loudness, .trebleBoost,
+        .podcast, .techno, .deepHouse, .hardTechno, .minimal
+    ]
 
     /// Suggest a frequency for a new band inserted into the current set.
     /// Finds the largest gap (in octaves) between existing bands and returns

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -9,6 +9,7 @@ struct iQualizeState: Codable {
     var lowLatency: Bool
     var windowOpen: Bool
     var maxGainDB: Float
+    var bypassed: Bool
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -16,7 +17,8 @@ struct iQualizeState: Codable {
         preventClipping: true,
         lowLatency: false,
         windowOpen: false,
-        maxGainDB: 12
+        maxGainDB: 12,
+        bypassed: false
     )
 
     private static let key = "com.iqualize.state"
@@ -35,15 +37,17 @@ struct iQualizeState: Codable {
         case lowLatency
         case windowOpen
         case maxGainDB
+        case bypassed
     }
 
-    init(isEnabled: Bool, selectedPresetID: UUID, preventClipping: Bool, lowLatency: Bool = false, windowOpen: Bool = false, maxGainDB: Float = 12) {
+    init(isEnabled: Bool, selectedPresetID: UUID, preventClipping: Bool, lowLatency: Bool = false, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.preventClipping = preventClipping
         self.lowLatency = lowLatency
         self.windowOpen = windowOpen
         self.maxGainDB = maxGainDB
+        self.bypassed = bypassed
     }
 
     init(from decoder: Decoder) throws {
@@ -53,6 +57,7 @@ struct iQualizeState: Codable {
         lowLatency = (try? container.decode(Bool.self, forKey: .lowLatency)) ?? false
         windowOpen = (try? container.decode(Bool.self, forKey: .windowOpen)) ?? false
         maxGainDB = (try? container.decode(Float.self, forKey: .maxGainDB)) ?? 12
+        bypassed = (try? container.decode(Bool.self, forKey: .bypassed)) ?? false
 
         if let id = try? container.decode(UUID.self, forKey: .selectedPresetID) {
             selectedPresetID = id

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -212,7 +212,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private let audioEngine: AudioEngine
     private let presetStore: PresetStore
 
-    private var eqToggle: NSButton!
     private var undoButton: NSButton!
     private var redoButton: NSButton!
     private var presetPicker: NSPopUpButton!
@@ -221,6 +220,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var gainLabels: [UnitTextField] = []
     private var freqLabels: [UnitTextField] = []
     private var qLabels: [UnitTextField] = []
+    private var bypassCheckbox: NSButton!
     private var clippingCheckbox: NSButton!
     private var lowLatencyCheckbox: NSButton!
     private var maxGainPicker: NSPopUpButton!
@@ -267,7 +267,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         audioEngine.onStateChange = { [weak self] in
             previousCallback?()
             self?.updateOutputLabel()
-            self?.updateEQToggle()
         }
     }
 
@@ -416,8 +415,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         bottomDivider.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
 
         // Row 3: Bottom bar — EQ Enabled (left) + Prevent Clipping (right)
-        eqToggle = NSButton(checkboxWithTitle: "EQ Enabled", target: self, action: #selector(toggleEQ(_:)))
-        eqToggle.state = audioEngine.isRunning ? .on : .off
+        bypassCheckbox = NSButton(checkboxWithTitle: "Bypass",
+                                    target: self, action: #selector(toggleBypass(_:)))
+        bypassCheckbox.state = audioEngine.bypassed ? .on : .off
 
         clippingCheckbox = NSButton(checkboxWithTitle: "Prevent Clipping",
                                      target: self, action: #selector(toggleClipping(_:)))
@@ -449,7 +449,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         maxGainPicker.target = self
         maxGainPicker.action = #selector(maxGainChanged(_:))
 
-        bottomRow.addArrangedSubview(eqToggle)
+        bottomRow.addArrangedSubview(bypassCheckbox)
         bottomRow.addArrangedSubview(spacer)
         bottomRow.addArrangedSubview(maxGainLabel)
         bottomRow.addArrangedSubview(maxGainPicker)
@@ -650,7 +650,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         buildSliders()
         updateDeleteButton()
         updateOutputLabel()
-        updateEQToggle()
+        bypassCheckbox.state = audioEngine.bypassed ? .on : .off
         clippingCheckbox.state = audioEngine.preventClipping ? .on : .off
         lowLatencyCheckbox.state = audioEngine.lowLatency ? .on : .off
         updateWindowTitle()
@@ -697,9 +697,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         outputLabel.stringValue = "Output: \(audioEngine.outputDeviceName)"
     }
 
-    private func updateEQToggle() {
-        eqToggle.state = audioEngine.isRunning ? .on : .off
-    }
 
 
     /// If the active preset is built-in, fork it into a custom copy before editing.
@@ -789,13 +786,11 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     // MARK: - Actions
 
-    @objc private func toggleEQ(_ sender: NSButton) {
-        let enable = sender.state == .on
-        audioEngine.setEnabled(enable)
+    @objc private func toggleBypass(_ sender: NSButton) {
+        audioEngine.bypassed = sender.state == .on
         var state = iQualizeState.load()
-        state.isEnabled = audioEngine.isRunning
+        state.bypassed = audioEngine.bypassed
         state.save()
-        updateEQToggle()
     }
 
     @objc private func toggleClipping(_ sender: NSButton) {

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.1</string>
+	<string>0.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.5.1</string>
+	<string>0.6</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -33,6 +33,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         audioEngine.preventClipping = state.preventClipping
         audioEngine.lowLatency = state.lowLatency
         audioEngine.maxGainDB = state.maxGainDB
+        audioEngine.bypassed = state.bypassed
         audioEngine.setEnabled(true)
         updateIcon()
 
@@ -83,6 +84,14 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         }
 
         menu.addItem(.separator())
+
+        // Bypass EQ toggle
+        let bypassItem = NSMenuItem(title: "Bypass EQ",
+                                      action: #selector(toggleBypass(_:)), keyEquivalent: "b")
+        bypassItem.keyEquivalentModifierMask = [.command]
+        bypassItem.target = self
+        bypassItem.state = audioEngine.bypassed ? .on : .off
+        menu.addItem(bypassItem)
 
         // Prevent Clipping toggle
         let clippingItem = NSMenuItem(title: "Prevent Clipping",
@@ -138,14 +147,6 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
 
     // MARK: - Actions
 
-    @objc private func toggleEQ(_ sender: NSMenuItem) {
-        let newState = !audioEngine.isRunning
-        audioEngine.setEnabled(newState)
-        state.isEnabled = audioEngine.isRunning
-        state.save()
-        updateIcon()
-    }
-
     @objc private func selectPreset(_ sender: NSMenuItem) {
         guard let uuidString = sender.representedObject as? String,
               let id = UUID(uuidString: uuidString),
@@ -179,6 +180,13 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         state.save()
     }
 
+    @objc private func toggleBypass(_ sender: NSMenuItem) {
+        audioEngine.bypassed.toggle()
+        state.bypassed = audioEngine.bypassed
+        state.save()
+        updateIcon()
+    }
+
     @objc private func toggleClipping(_ sender: NSMenuItem) {
         audioEngine.preventClipping.toggle()
         state.preventClipping = audioEngine.preventClipping
@@ -210,13 +218,13 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     private func updateIcon() {
         if let button = statusItem.button {
             button.title = ""
-            let symbolName = "slider.vertical.3"
+            let symbolName = audioEngine.bypassed ? "slider.vertical.3" : "slider.vertical.3"
             if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "iQualize") {
                 let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
                 button.image = image.withSymbolConfiguration(config)
                 button.image?.isTemplate = true
             }
-            button.appearsDisabled = !audioEngine.isRunning
+            button.appearsDisabled = !audioEngine.isRunning || audioEngine.bypassed
         }
     }
 }


### PR DESCRIPTION
## Summary
- 7 new built-in presets: Loudness, Treble Boost, Podcast, Techno, Deep House, Hard Techno, Minimal
- Global bypass toggle (Cmd+B) in menu bar and EQ window — smooth, no audio gap — replaces old EQ Enabled checkbox
- README rewritten with architecture docs, preset format spec, and prioritized roadmap
- CLAUDE.md updated with mandatory launch verification step
- Version bump: 0.5.1 → 0.6.0

Fixes #19
Fixes #20

## Test plan
- [ ] Verify all 10 built-in presets appear in menu bar and EQ window picker
- [ ] Toggle bypass from menu bar (Cmd+B) — audio should pass through without EQ, no gap
- [ ] Toggle bypass from EQ window checkbox — same behavior
- [ ] Menu bar icon dims when bypassed
- [ ] Bypass state persists after quit and relaunch
- [ ] Switching presets while bypassed works correctly
- [ ] App launches successfully after install