### PR TITLE
Add visual frequency response curve to EQ window

### DIFF
--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -26,6 +26,166 @@ final class ClickThroughView: NSView {
     }
 }
 
+// MARK: - Frequency response curve
+
+@available(macOS 14.2, *)
+@MainActor
+final class FrequencyResponseView: NSView {
+    private var bands: [EQBand] = []
+    private var maxGainDB: Float = 12
+
+    func updateBands(_ bands: [EQBand], maxGainDB: Float) {
+        self.bands = bands
+        self.maxGainDB = maxGainDB
+        needsDisplay = true
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: 120)
+    }
+
+    private func freqToX(_ freq: Float, width: CGFloat) -> CGFloat {
+        let norm = log10(Double(freq) / 20.0) / 3.0 // log10(20000/20) = 3
+        return CGFloat(norm) * width
+    }
+
+    private func gainToY(_ gain: Float, height: CGFloat) -> CGFloat {
+        let norm = Double(gain) / Double(maxGainDB)
+        return height / 2.0 + CGFloat(norm) * (height / 2.0)
+    }
+
+    private func compositeGain(at freq: Float) -> Float {
+        var total: Float = 0
+        for band in bands {
+            let octaves = log2(freq / band.frequency)
+            let sigma = band.bandwidth / 2.0
+            let exponent = -0.5 * (octaves / sigma) * (octaves / sigma)
+            total += band.gain * exp(exponent)
+        }
+        return total
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let b = bounds
+        let inset: CGFloat = 4
+        let plotRect = b.insetBy(dx: inset, dy: inset)
+
+        // Background
+        let bgPath = NSBezierPath(roundedRect: b, xRadius: 6, yRadius: 6)
+        NSColor.controlBackgroundColor.setFill()
+        bgPath.fill()
+        NSColor.separatorColor.setStroke()
+        bgPath.lineWidth = 0.5
+        bgPath.stroke()
+
+        ctx.saveGState()
+        ctx.clip(to: plotRect)
+
+        // Grid: 0 dB center line
+        let zeroY = plotRect.minY + plotRect.height / 2.0
+        ctx.setStrokeColor(NSColor.separatorColor.cgColor)
+        ctx.setLineWidth(0.5)
+        ctx.move(to: CGPoint(x: plotRect.minX, y: zeroY))
+        ctx.addLine(to: CGPoint(x: plotRect.maxX, y: zeroY))
+        ctx.strokePath()
+
+        // Dashed dB grid lines
+        let dashPattern: [CGFloat] = [4, 4]
+        ctx.setLineDash(phase: 0, lengths: dashPattern)
+        ctx.setStrokeColor(NSColor.separatorColor.withAlphaComponent(0.3).cgColor)
+        let dbStep: Float = maxGainDB <= 12 ? 6 : 12
+        var dbLine = dbStep
+        while dbLine < maxGainDB {
+            for sign: Float in [-1, 1] {
+                let y = gainToY(sign * dbLine, height: plotRect.height) + plotRect.minY
+                ctx.move(to: CGPoint(x: plotRect.minX, y: y))
+                ctx.addLine(to: CGPoint(x: plotRect.maxX, y: y))
+            }
+            dbLine += dbStep
+        }
+        ctx.strokePath()
+
+        // Vertical freq markers
+        let freqMarkers: [Float] = [100, 1000, 10000]
+        for freq in freqMarkers {
+            let x = freqToX(freq, width: plotRect.width) + plotRect.minX
+            ctx.move(to: CGPoint(x: x, y: plotRect.minY))
+            ctx.addLine(to: CGPoint(x: x, y: plotRect.maxY))
+        }
+        ctx.strokePath()
+        ctx.setLineDash(phase: 0, lengths: [])
+
+        // Freq labels
+        let labelAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 8),
+            .foregroundColor: NSColor.tertiaryLabelColor,
+        ]
+        for freq in freqMarkers {
+            let x = freqToX(freq, width: plotRect.width) + plotRect.minX
+            let label = freq >= 1000 ? "\(Int(freq / 1000))k" : "\(Int(freq))"
+            let str = NSAttributedString(string: label, attributes: labelAttrs)
+            str.draw(at: CGPoint(x: x + 2, y: plotRect.minY + 1))
+        }
+
+        // Composite curve
+        let sampleCount = 200
+        var curvePoints: [CGPoint] = []
+        for i in 0...sampleCount {
+            let t = Float(i) / Float(sampleCount)
+            let freq = 20.0 * pow(1000.0, t) // 20 to 20000
+            let gain = compositeGain(at: freq)
+            let clamped = min(max(gain, -maxGainDB), maxGainDB)
+            let x = CGFloat(t) * plotRect.width + plotRect.minX
+            let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+            curvePoints.append(CGPoint(x: x, y: y))
+        }
+
+        // Filled area from curve to 0dB line
+        if !curvePoints.isEmpty {
+            let fillPath = CGMutablePath()
+            fillPath.move(to: CGPoint(x: curvePoints[0].x, y: zeroY))
+            for pt in curvePoints { fillPath.addLine(to: pt) }
+            fillPath.addLine(to: CGPoint(x: curvePoints.last!.x, y: zeroY))
+            fillPath.closeSubpath()
+
+            ctx.saveGState()
+            ctx.addPath(fillPath)
+            ctx.clip()
+            let fillColor = NSColor.controlAccentColor.withAlphaComponent(0.15).cgColor
+            ctx.setFillColor(fillColor)
+            ctx.fill(plotRect)
+            ctx.restoreGState()
+
+            // Stroke curve
+            let curvePath = CGMutablePath()
+            curvePath.move(to: curvePoints[0])
+            for pt in curvePoints.dropFirst() { curvePath.addLine(to: pt) }
+            ctx.setStrokeColor(NSColor.controlAccentColor.withAlphaComponent(0.8).cgColor)
+            ctx.setLineWidth(1.5)
+            ctx.addPath(curvePath)
+            ctx.strokePath()
+        }
+
+        // Band markers
+        let markerRadius: CGFloat = 4
+        for band in bands {
+            let x = freqToX(band.frequency, width: plotRect.width) + plotRect.minX
+            let clamped = min(max(band.gain, -maxGainDB), maxGainDB)
+            let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+            let markerRect = CGRect(x: x - markerRadius, y: y - markerRadius,
+                                     width: markerRadius * 2, height: markerRadius * 2)
+            ctx.setFillColor(NSColor.controlAccentColor.cgColor)
+            ctx.fillEllipse(in: markerRect)
+            ctx.setStrokeColor(NSColor.controlBackgroundColor.cgColor)
+            ctx.setLineWidth(1)
+            ctx.strokeEllipse(in: markerRect)
+        }
+
+        ctx.restoreGState()
+    }
+}
+
 // MARK: - Drag handle view
 
 @available(macOS 14.2, *)
@@ -231,6 +391,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var resetButton: NSButton!
     private var deleteButton: NSButton!
     private var importExportButton: NSButton!
+    private var curveView: FrequencyResponseView!
 
     /// Snapshot of the preset when it was loaded/saved, for reset.
     private var savedPresetSnapshot: EQPresetData?
@@ -243,7 +404,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         self.presetStore = presetStore
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 420),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 550),
             styleMask: [.titled, .closable, .miniaturizable],
             backing: .buffered,
             defer: false
@@ -251,7 +412,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         window.title = "iQualize"
         window.center()
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 480, height: 420)
+        window.minSize = NSSize(width: 480, height: 550)
 
         super.init(window: window)
 
@@ -390,6 +551,14 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         mainStack.addArrangedSubview(topDivider)
         topDivider.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
         topDivider.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
+
+        // Frequency response curve
+        curveView = FrequencyResponseView()
+        curveView.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.addArrangedSubview(curveView)
+        curveView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
+        curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
 
         // Row 2: Sliders area
         slidersContainer = BandDropTarget()
@@ -638,6 +807,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             window.setFrame(frame, display: true, animate: true)
         }
 
+        updateCurveView()
     }
 
     // MARK: - Sync UI ↔ Engine
@@ -654,6 +824,11 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         clippingCheckbox.state = audioEngine.preventClipping ? .on : .off
         lowLatencyCheckbox.state = audioEngine.lowLatency ? .on : .off
         updateWindowTitle()
+        updateCurveView()
+    }
+
+    private func updateCurveView() {
+        curveView.updateBands(audioEngine.activePreset.bands, maxGainDB: audioEngine.maxGainDB)
     }
 
     private func populatePresetPicker() {
@@ -991,6 +1166,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             }
             field.stringValue = audioEngine.activePreset.bands[index].bandwidthLabel
         }
+        updateCurveView()
     }
 
     @objc private func presetChanged(_ sender: NSPopUpButton) {
@@ -1024,6 +1200,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         audioEngine.activePreset = preset
 
         gainLabels[index].stringValue = preset.bands[index].gainLabel
+        updateCurveView()
         markModified()
 
         // Register undo when drag ends (mouse up)

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>0.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.6</string>
+	<string>0.7</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Adds a `FrequencyResponseView` (120pt NSView with Core Graphics drawing) above the EQ sliders
- Log-scale frequency axis (20Hz–20kHz) with grid lines at 100Hz, 1kHz, 10kHz
- dB gain Y axis with dashed grid lines matching max gain range
- Composite EQ curve rendered as gradient-filled area + stroke, using Gaussian bell approximation per band
- Band node markers (accent-colored circles) at each band's frequency/gain position
- Real-time updates on slider drag, text field edits, preset changes, band add/delete/reorder, and max gain changes
- Window height increased to accommodate the curve (420 → 550)
- Version bump: 0.6.0 → 0.7.0

Fixes #23

## Test plan
- [ ] Open EQ window — curve appears above sliders with correct axes
- [ ] Drag sliders — curve updates in real-time
- [ ] Edit gain/frequency/bandwidth text fields — curve updates on commit
- [ ] Switch presets — curve reflects new band configuration
- [ ] Add/remove bands — curve and markers update
- [ ] Change max gain dB — curve Y axis rescales
- [ ] Undo/redo — curve follows state changes