### PR TITLE
Fix curve layout, toggle style, and launch crash

### DIFF
--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -571,22 +571,44 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         slidersContainer.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -16).isActive = true
 
         // Frequency response curve (collapsible, below bands)
-        curveDisclosure = NSButton(title: "Frequency Response", target: self, action: #selector(toggleCurve(_:)))
-        curveDisclosure.bezelStyle = .disclosure
-        curveDisclosure.setButtonType(.pushOnPushOff)
-        curveDisclosure.state = .off
+        let curveWrapper = NSView()
+        curveWrapper.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.addArrangedSubview(curveWrapper)
+
+        // Toggle row: chevron + label
+        curveDisclosure = NSButton(title: "", target: self, action: #selector(toggleCurve(_:)))
+        curveDisclosure.bezelStyle = .inline
+        curveDisclosure.isBordered = false
+        curveDisclosure.setButtonType(.momentaryPushIn)
         curveDisclosure.font = .systemFont(ofSize: 10)
-        mainStack.addArrangedSubview(curveDisclosure)
-        curveDisclosure.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor).isActive = true
+        curveDisclosure.contentTintColor = .secondaryLabelColor
+        curveDisclosure.title = "\u{25B6} Response Curve"
+        curveDisclosure.translatesAutoresizingMaskIntoConstraints = false
+        curveWrapper.addSubview(curveDisclosure)
 
         curveView = FrequencyResponseView()
         curveView.translatesAutoresizingMaskIntoConstraints = false
         curveView.isHidden = true
-        mainStack.addArrangedSubview(curveView)
-        curveView.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: slidersContainer.trailingAnchor).isActive = true
+        curveWrapper.addSubview(curveView)
+
         curveHeightConstraint = curveView.heightAnchor.constraint(equalToConstant: 120)
         curveHeightConstraint.isActive = true
+
+        NSLayoutConstraint.activate([
+            // Pin wrapper to slidersContainer width
+            curveWrapper.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor),
+            curveWrapper.trailingAnchor.constraint(equalTo: slidersContainer.trailingAnchor),
+
+            // Toggle at top of wrapper
+            curveDisclosure.topAnchor.constraint(equalTo: curveWrapper.topAnchor),
+            curveDisclosure.leadingAnchor.constraint(equalTo: curveWrapper.leadingAnchor),
+
+            // Curve below toggle
+            curveView.topAnchor.constraint(equalTo: curveDisclosure.bottomAnchor, constant: 6),
+            curveView.leadingAnchor.constraint(equalTo: curveWrapper.leadingAnchor),
+            curveView.trailingAnchor.constraint(equalTo: curveWrapper.trailingAnchor),
+            curveView.bottomAnchor.constraint(equalTo: curveWrapper.bottomAnchor),
+        ])
 
         // Divider below bands
         let bottomDivider = NSBox()
@@ -974,12 +996,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     // MARK: - Actions
 
     @objc private func toggleCurve(_ sender: NSButton) {
-        let expanded = sender.state == .on
-        curveView.isHidden = !expanded
+        let wasHidden = curveView.isHidden
+        curveView.isHidden = !wasHidden
+        curveDisclosure.title = wasHidden ? "\u{25BC} Response Curve" : "\u{25B6} Response Curve"
 
         // Animate window height change
         if let window = self.window {
-            let delta: CGFloat = expanded ? 132 : -132  // 120 + spacing
+            let delta: CGFloat = wasHidden ? 132 : -132  // 120 + spacing
             var frame = window.frame
             frame.size.height += delta
             frame.origin.y -= delta

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -392,8 +392,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var deleteButton: NSButton!
     private var importExportButton: NSButton!
     private var curveView: FrequencyResponseView!
-    private var curveDisclosure: NSButton!
-    private var curveHeightConstraint: NSLayoutConstraint!
+    private var curveToggle: NSButton!
 
     /// Snapshot of the preset when it was loaded/saved, for reset.
     private var savedPresetSnapshot: EQPresetData?
@@ -566,49 +565,46 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             self?.reorderBand(from: from, to: to)
         }
 
-        mainStack.addArrangedSubview(slidersContainer)
-        slidersContainer.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
-        slidersContainer.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -16).isActive = true
+        // Wrap sliders + curve in a vertical container so they share width
+        let bandsAndCurve = NSStackView()
+        bandsAndCurve.orientation = .vertical
+        bandsAndCurve.alignment = .centerX
+        bandsAndCurve.spacing = 8
+        bandsAndCurve.translatesAutoresizingMaskIntoConstraints = false
 
-        // Frequency response curve (collapsible, below bands)
-        let curveWrapper = NSView()
-        curveWrapper.translatesAutoresizingMaskIntoConstraints = false
-        mainStack.addArrangedSubview(curveWrapper)
+        bandsAndCurve.addArrangedSubview(slidersContainer)
 
-        // Toggle row: chevron + label
-        curveDisclosure = NSButton(title: "", target: self, action: #selector(toggleCurve(_:)))
-        curveDisclosure.bezelStyle = .inline
-        curveDisclosure.isBordered = false
-        curveDisclosure.setButtonType(.momentaryPushIn)
-        curveDisclosure.font = .systemFont(ofSize: 10)
-        curveDisclosure.contentTintColor = .secondaryLabelColor
-        curveDisclosure.title = "\u{25B6} Response Curve"
-        curveDisclosure.translatesAutoresizingMaskIntoConstraints = false
-        curveWrapper.addSubview(curveDisclosure)
+        // Curve toggle — small disclosure triangle style
+        curveToggle = NSButton(title: "", target: self, action: #selector(toggleCurve(_:)))
+        curveToggle.bezelStyle = .disclosure
+        curveToggle.setButtonType(.pushOnPushOff)
+        curveToggle.title = ""
+        curveToggle.state = .off
+        curveToggle.translatesAutoresizingMaskIntoConstraints = false
+
+        let toggleLabel = NSTextField(labelWithString: "Response Curve")
+        toggleLabel.font = .systemFont(ofSize: 10)
+        toggleLabel.textColor = .secondaryLabelColor
+
+        let toggleRow = NSStackView(views: [curveToggle, toggleLabel])
+        toggleRow.orientation = .horizontal
+        toggleRow.spacing = 2
+        toggleRow.alignment = .centerY
+        bandsAndCurve.addArrangedSubview(toggleRow)
 
         curveView = FrequencyResponseView()
         curveView.translatesAutoresizingMaskIntoConstraints = false
         curveView.isHidden = true
-        curveWrapper.addSubview(curveView)
+        curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
+        bandsAndCurve.addArrangedSubview(curveView)
 
-        curveHeightConstraint = curveView.heightAnchor.constraint(equalToConstant: 120)
-        curveHeightConstraint.isActive = true
+        // Curve matches sliders width
+        curveView.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: slidersContainer.trailingAnchor).isActive = true
 
-        NSLayoutConstraint.activate([
-            // Pin wrapper to slidersContainer width
-            curveWrapper.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor),
-            curveWrapper.trailingAnchor.constraint(equalTo: slidersContainer.trailingAnchor),
-
-            // Toggle at top of wrapper
-            curveDisclosure.topAnchor.constraint(equalTo: curveWrapper.topAnchor),
-            curveDisclosure.leadingAnchor.constraint(equalTo: curveWrapper.leadingAnchor),
-
-            // Curve below toggle
-            curveView.topAnchor.constraint(equalTo: curveDisclosure.bottomAnchor, constant: 6),
-            curveView.leadingAnchor.constraint(equalTo: curveWrapper.leadingAnchor),
-            curveView.trailingAnchor.constraint(equalTo: curveWrapper.trailingAnchor),
-            curveView.bottomAnchor.constraint(equalTo: curveWrapper.bottomAnchor),
-        ])
+        mainStack.addArrangedSubview(bandsAndCurve)
+        bandsAndCurve.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
+        bandsAndCurve.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -16).isActive = true
 
         // Divider below bands
         let bottomDivider = NSBox()
@@ -996,13 +992,11 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     // MARK: - Actions
 
     @objc private func toggleCurve(_ sender: NSButton) {
-        let wasHidden = curveView.isHidden
-        curveView.isHidden = !wasHidden
-        curveDisclosure.title = wasHidden ? "\u{25BC} Response Curve" : "\u{25B6} Response Curve"
+        let expanding = curveView.isHidden
+        curveView.isHidden = !expanding
 
-        // Animate window height change
         if let window = self.window {
-            let delta: CGFloat = wasHidden ? 132 : -132  // 120 + spacing
+            let delta: CGFloat = expanding ? 128 : -128
             var frame = window.frame
             frame.size.height += delta
             frame.origin.y -= delta

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -598,9 +598,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
         bandsAndCurve.addArrangedSubview(curveView)
 
-        // Curve matches sliders width
-        curveView.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: slidersContainer.trailingAnchor).isActive = true
+        // Curve matches full bands row width (including + buttons)
+        curveView.leadingAnchor.constraint(equalTo: bandsAndCurve.leadingAnchor).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: bandsAndCurve.trailingAnchor).isActive = true
 
         mainStack.addArrangedSubview(bandsAndCurve)
         bandsAndCurve.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -393,7 +393,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var importExportButton: NSButton!
     private var curveView: FrequencyResponseView!
     private var curveToggle: NSButton!
-    private var curveWidthConstraints: [NSLayoutConstraint] = []
 
     /// Snapshot of the preset when it was loaded/saved, for reset.
     private var savedPresetSnapshot: EQPresetData?
@@ -598,6 +597,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.isHidden = true
         curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
         bandsAndCurve.addArrangedSubview(curveView)
+
+        // Curve matches full window width like the dividers
+        curveView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
 
         mainStack.addArrangedSubview(bandsAndCurve)
         bandsAndCurve.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
@@ -832,17 +835,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             let newWidth = max(bandsWidth, window.minSize.width)
             frame.size.width = newWidth
             window.setFrame(frame, display: true, animate: true)
-        }
-
-        // Constrain curve width to band columns (excluding + buttons)
-        NSLayoutConstraint.deactivate(curveWidthConstraints)
-        curveWidthConstraints = []
-        let bandColumns = slidersContainer.arrangedSubviews.filter { $0 is DraggableBandColumn }
-        if let first = bandColumns.first, let last = bandColumns.last {
-            let leading = curveView.leadingAnchor.constraint(equalTo: first.leadingAnchor)
-            let trailing = curveView.trailingAnchor.constraint(equalTo: last.trailingAnchor)
-            curveWidthConstraints = [leading, trailing]
-            NSLayoutConstraint.activate(curveWidthConstraints)
         }
 
         updateCurveView()

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -392,6 +392,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var deleteButton: NSButton!
     private var importExportButton: NSButton!
     private var curveView: FrequencyResponseView!
+    private var curveDisclosure: NSButton!
+    private var curveHeightConstraint: NSLayoutConstraint!
 
     /// Snapshot of the preset when it was loaded/saved, for reset.
     private var savedPresetSnapshot: EQPresetData?
@@ -404,7 +406,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         self.presetStore = presetStore
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 550),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 420),
             styleMask: [.titled, .closable, .miniaturizable],
             backing: .buffered,
             defer: false
@@ -412,7 +414,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         window.title = "iQualize"
         window.center()
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 480, height: 550)
+        window.minSize = NSSize(width: 480, height: 420)
 
         super.init(window: window)
 
@@ -552,14 +554,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         topDivider.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
         topDivider.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
 
-        // Frequency response curve
-        curveView = FrequencyResponseView()
-        curveView.translatesAutoresizingMaskIntoConstraints = false
-        mainStack.addArrangedSubview(curveView)
-        curveView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
-        curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
-
         // Row 2: Sliders area
         slidersContainer = BandDropTarget()
         slidersContainer.orientation = .horizontal
@@ -575,6 +569,24 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         mainStack.addArrangedSubview(slidersContainer)
         slidersContainer.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
         slidersContainer.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -16).isActive = true
+
+        // Frequency response curve (collapsible, below bands)
+        curveDisclosure = NSButton(title: "Frequency Response", target: self, action: #selector(toggleCurve(_:)))
+        curveDisclosure.bezelStyle = .disclosure
+        curveDisclosure.setButtonType(.pushOnPushOff)
+        curveDisclosure.state = .off
+        curveDisclosure.font = .systemFont(ofSize: 10)
+        mainStack.addArrangedSubview(curveDisclosure)
+        curveDisclosure.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor).isActive = true
+
+        curveView = FrequencyResponseView()
+        curveView.translatesAutoresizingMaskIntoConstraints = false
+        curveView.isHidden = true
+        mainStack.addArrangedSubview(curveView)
+        curveView.leadingAnchor.constraint(equalTo: slidersContainer.leadingAnchor).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: slidersContainer.trailingAnchor).isActive = true
+        curveHeightConstraint = curveView.heightAnchor.constraint(equalToConstant: 120)
+        curveHeightConstraint.isActive = true
 
         // Divider below bands
         let bottomDivider = NSBox()
@@ -960,6 +972,20 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
 
     // MARK: - Actions
+
+    @objc private func toggleCurve(_ sender: NSButton) {
+        let expanded = sender.state == .on
+        curveView.isHidden = !expanded
+
+        // Animate window height change
+        if let window = self.window {
+            let delta: CGFloat = expanded ? 132 : -132  // 120 + spacing
+            var frame = window.frame
+            frame.size.height += delta
+            frame.origin.y -= delta
+            window.setFrame(frame, display: true, animate: true)
+        }
+    }
 
     @objc private func toggleBypass(_ sender: NSButton) {
         audioEngine.bypassed = sender.state == .on

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -393,6 +393,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var importExportButton: NSButton!
     private var curveView: FrequencyResponseView!
     private var curveToggle: NSButton!
+    private var curveWidthConstraints: [NSLayoutConstraint] = []
 
     /// Snapshot of the preset when it was loaded/saved, for reset.
     private var savedPresetSnapshot: EQPresetData?
@@ -597,10 +598,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.isHidden = true
         curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
         bandsAndCurve.addArrangedSubview(curveView)
-
-        // Curve matches full bands row width (including + buttons)
-        curveView.leadingAnchor.constraint(equalTo: bandsAndCurve.leadingAnchor).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: bandsAndCurve.trailingAnchor).isActive = true
 
         mainStack.addArrangedSubview(bandsAndCurve)
         bandsAndCurve.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
@@ -835,6 +832,17 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             let newWidth = max(bandsWidth, window.minSize.width)
             frame.size.width = newWidth
             window.setFrame(frame, display: true, animate: true)
+        }
+
+        // Constrain curve width to band columns (excluding + buttons)
+        NSLayoutConstraint.deactivate(curveWidthConstraints)
+        curveWidthConstraints = []
+        let bandColumns = slidersContainer.arrangedSubviews.filter { $0 is DraggableBandColumn }
+        if let first = bandColumns.first, let last = bandColumns.last {
+            let leading = curveView.leadingAnchor.constraint(equalTo: first.leadingAnchor)
+            let trailing = curveView.trailingAnchor.constraint(equalTo: last.trailingAnchor)
+            curveWidthConstraints = [leading, trailing]
+            NSLayoutConstraint.activate(curveWidthConstraints)
         }
 
         updateCurveView()

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -598,13 +598,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.heightAnchor.constraint(equalToConstant: 120).isActive = true
         bandsAndCurve.addArrangedSubview(curveView)
 
-        // Curve matches full window width like the dividers
-        curveView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
-
         mainStack.addArrangedSubview(bandsAndCurve)
         bandsAndCurve.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
         bandsAndCurve.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -16).isActive = true
+
+        // Curve matches full window width like the dividers
+        curveView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 16).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -16).isActive = true
 
         // Divider below bands
         let bottomDivider = NSBox()

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -42,7 +42,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !flag {
-            menuBarController.openEQWindow()
+            menuBarController?.openEQWindow()
         }
         return true
     }


### PR DESCRIPTION
## Summary
- Move frequency response curve below bands, make it collapsible with native disclosure triangle
- Match curve width to window dividers (full width minus padding)
- Fix crash on launch: constraint was activated before views shared a common ancestor
- Fix pre-existing nil crash in `applicationShouldHandleReopen`

## Test plan
- [ ] App launches without crash
- [ ] Curve toggle expands/collapses correctly, window resizes to match
- [ ] Curve width matches the divider lines above and below
- [ ] Clicking dock icon when no windows visible doesn't crash