### PR TITLE
feat: add American Rap and German Rap presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.11.0] - 2026-03-30
+
+### Added
+- American Rap built-in preset (808-heavy sub-bass, mid scoop, vocal presence)
+- German Rap built-in preset (warm mid-bass, vocal clarity, balanced brightness)
+
 ## [0.10.0] - 2026-03-30
 
 ### Added

--- a/Sources/iQualize/EQModels.swift
+++ b/Sources/iQualize/EQModels.swift
@@ -181,9 +181,28 @@ extension EQPresetData {
         isBuiltIn: true
     )
 
+    static let americanRap = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-00000000000B")!,
+        name: "American Rap",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([10,  8,  4,  0, -2, -2,  2,  4,  6,  4]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
+    static let germanRap = EQPresetData(
+        id: UUID(uuidString: "00000000-0000-0000-0000-00000000000C")!,
+        name: "German Rap",
+        //                                        32  64 125 250 500  1k  2k  4k  8k 16k
+        bands: zip(defaultFrequencies, [Float]([ 6,  8,  6,  2, -2,  0,  4,  4,  2,  2]))
+            .map { EQBand(frequency: $0.0, gain: $0.1) },
+        isBuiltIn: true
+    )
+
     static let builtInPresets: [EQPresetData] = [
         .flat, .bassBoost, .vocalClarity, .loudness, .trebleBoost,
-        .podcast, .techno, .deepHouse, .hardTechno, .minimal
+        .podcast, .techno, .deepHouse, .hardTechno, .minimal,
+        .americanRap, .germanRap
     ]
 
     /// Suggest a frequency for a new band inserted into the current set.

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.10</string>
+	<string>0.11</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- **American Rap** preset: 808-heavy sub-bass (+10/+8 at 32-64Hz), mid scoop (-2 at 500-1kHz), vocal presence and hi-hat snap (+4/+6 at 4-8kHz)
- **German Rap** preset: warm mid-bass foundation (+6/+8/+6 at 32-125Hz), vocal clarity (+4 at 2-4kHz), balanced brightness
- Version bumped to v0.11.0

## Pre-Landing Review
No issues found. Data-only change (two static preset structs + version bump).

## Plan Completion
All 3 plan items DONE: preset definitions, array registration, version bump.

## Test plan
- [x] Build succeeds (`swift build`)
- [x] App launches successfully after install
- [x] Both presets appear in preset dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)