### PR TITLE
feat: biquad frequency response visualization (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ All notable changes to iQualize will be documented in this file.
 ## [0.11.0] - 2026-03-30
 
 ### Added
+- Accurate biquad frequency response curve using Audio EQ Cookbook formulas, showing the true filter response behind the EQ sliders
+- Per-band ghost fills showing individual filter contribution shapes
+- Anchor dots with drop lines at each band's frequency on the composite curve
+- Split composite fill (boost regions brighter than cut regions)
+- Detailed frequency/dB grid (20Hz–20kHz vertical, 6dB horizontal)
 - American Rap built-in preset (808-heavy sub-bass, mid scoop, vocal presence)
 - German Rap built-in preset (warm mid-bass, vocal clarity, balanced brightness)
+
+### Changed
+- Spline curve (connecting slider knobs) now rendered as a dashed gray line to distinguish from the biquad response
+- install.sh now re-signs the app when only Info.plist changes (fixes launch failures after version bump)
 
 ## [0.10.0] - 2026-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to iQualize will be documented in this file.
 ### Added
 - Accurate biquad frequency response curve using Audio EQ Cookbook formulas, showing the true filter response behind the EQ sliders
 - Per-band ghost fills showing individual filter contribution shapes
-- Anchor dots with drop lines at each band's frequency on the composite curve
+- Anchor dots with drop lines and dB labels at each band's frequency on the composite curve
 - Split composite fill (boost regions brighter than cut regions)
 - Detailed frequency/dB grid (20Hz–20kHz vertical, 6dB horizontal)
+- Axis labels (+12, 0, -12 dB) in the left margin outside the graph area
 - American Rap built-in preset (808-heavy sub-bass, mid scoop, vocal presence)
 - German Rap built-in preset (warm mid-bass, vocal clarity, balanced brightness)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ open /Applications/iQualize.app
 
 - Up to 31 bands with editable frequency (20 Hz – 20 kHz), gain, and Q/bandwidth
 - 7 filter types per band: Bell (parametric), Low Shelf, High Shelf, Low Pass, High Pass, Band Pass, and Notch
-- Frequency response curve rendered as a translucent backdrop behind the EQ sliders, with per-filter-type curve shapes and Catmull-Rom spline interpolation
+- Accurate biquad frequency response curve using Audio EQ Cookbook formulas, rendered as a translucent backdrop behind EQ sliders
+- Per-band ghost fills, anchor dots with dB labels, and split boost/cut composite fill
+- Axis labels and detailed frequency/dB grid overlay
+- Catmull-Rom spline interpolation connecting slider knob positions (dashed gray line)
 - Adjustable max gain range: ±6, ±12, ±18, or ±24 dB
 - Anti-clipping preamp — automatically reduces gain to prevent digital clipping
 - Low Latency mode (50ms buffer) for real-time monitoring
@@ -46,7 +49,7 @@ open /Applications/iQualize.app
 
 ### Presets
 
-- Built-in presets: Flat, Bass Boost, Vocal Clarity, Loudness, Treble Boost, Podcast, Techno, Deep House, Hard Techno, Minimal
+- Built-in presets: Flat, Bass Boost, Vocal Clarity, Loudness, Treble Boost, Podcast, Techno, Deep House, Hard Techno, Minimal, American Rap, German Rap
 - Create, rename, overwrite, and delete custom presets
 - Built-in presets auto-fork when edited (non-destructive)
 - Unsaved changes indicator (asterisk in title)
@@ -136,13 +139,13 @@ Prioritized by impact vs effort. Score = impact (1-5) x ease (1-5). Higher = do 
 |---|---|---|---|---|
 | Smart frequency suggestions | 3 | 5 | 15 | New bands fill the largest spectral gap instead of copying the edge band |
 | Keyboard shortcuts for bands | 3 | 5 | 15 | Arrow keys to adjust selected band gain/freq |
-| Visual frequency response curve | 5 | 3 | 15 | Draw the composite EQ curve in the window — biggest UX upgrade |
+| ~~Visual frequency response curve~~ | ~~5~~ | ~~3~~ | ~~15~~ | ✅ Done in v0.11.0 — biquad response curve with ghost fills, anchor dots, axis labels |
 
 ### High impact, moderate effort (score 10-14)
 
 | Feature | Impact | Ease | Score | Notes |
 |---|---|---|---|---|
-| Filter types per band | 5 | 3 | 15 | Bell, low/high shelf, low/high pass, notch, bandpass — AVAudioUnitEQ already supports these filter types natively |
+| ~~Filter types per band~~ | ~~5~~ | ~~3~~ | ~~15~~ | ✅ Done in v0.10.0 — Bell, low/high shelf, low/high pass, notch, bandpass |
 | Per-band bypass | 4 | 3 | 12 | Set individual band gain to 0 without losing saved value, toggle in UI |
 | Drag-on-curve editing | 5 | 2 | 10 | Drag band nodes directly on the response curve — needs hit testing, coordinate mapping |
 | Real-time spectrum analyzer | 5 | 2 | 10 | FFT of audio buffer, render behind EQ curve. Pre/post EQ modes. Huge visual feature |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ open /Applications/iQualize.app
 ### Parametric EQ
 
 - Up to 31 bands with editable frequency (20 Hz – 20 kHz), gain, and Q/bandwidth
+- 7 filter types per band: Bell (parametric), Low Shelf, High Shelf, Low Pass, High Pass, Band Pass, and Notch
+- Frequency response curve rendered as a translucent backdrop behind the EQ sliders, with per-filter-type curve shapes and Catmull-Rom spline interpolation
 - Adjustable max gain range: ±6, ±12, ±18, or ±24 dB
 - Anti-clipping preamp — automatically reduces gain to prevent digital clipping
 - Low Latency mode (50ms buffer) for real-time monitoring
@@ -58,8 +60,8 @@ Presets are `.iqpreset` files — plain JSON:
 ```json
 {
   "bands": [
-    { "bandwidth": 1.0, "frequency": 80, "gain": 5 },
-    { "bandwidth": 1.2, "frequency": 200, "gain": -3 }
+    { "bandwidth": 1.0, "filterType": "parametric", "frequency": 80, "gain": 5 },
+    { "bandwidth": 1.2, "filterType": "lowShelf", "frequency": 200, "gain": -3 }
   ],
   "id": "CDE9BB8A-12A5-420C-9619-2790E20030D5",
   "isBuiltIn": false,
@@ -67,7 +69,7 @@ Presets are `.iqpreset` files — plain JSON:
 }
 ```
 
-Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (Q factor — lower is wider, higher is narrower).
+Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (Q factor — lower is wider, higher is narrower), `filterType` (one of `parametric`, `lowShelf`, `highShelf`, `lowPass`, `highPass`, `bandPass`, `notch` — defaults to `parametric` if omitted).
 
 ### Undo/Redo
 

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -96,6 +96,7 @@ final class AudioEngine {
     }
 
     var maxGainDB: Float = 12
+    private(set) var outputSampleRate: Double = 48000
 
     init() {
         do {
@@ -191,6 +192,7 @@ final class AudioEngine {
         // The tap may capture at a different rate (e.g., 48kHz tap vs 44.1kHz Bluetooth).
         // The aggregate device handles resampling between the tap and the IOProc.
         let sampleRate = deviceSampleRate > 0 ? deviceSampleRate : tapSampleRate
+        self.outputSampleRate = sampleRate
 
         os_log(.default, log: appLog,
                "tapRate: %{public}.0f  deviceRate: %{public}.0f  using: %{public}.0f  channels: %{public}u  device: %{public}@",

--- a/Sources/iQualize/BiquadResponse.swift
+++ b/Sources/iQualize/BiquadResponse.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+// MARK: - Biquad Coefficients
+
+struct BiquadCoefficients: Sendable {
+    let b0: Double, b1: Double, b2: Double
+    let a0: Double, a1: Double, a2: Double
+
+    /// Evaluate the filter's gain in dB at a given frequency.
+    func gainDB(at frequency: Double, sampleRate: Double) -> Double {
+        let w = 2.0 * .pi * frequency / sampleRate
+        let cosW = cos(w), sinW = sin(w)
+        let cos2W = cos(2.0 * w), sin2W = sin(2.0 * w)
+
+        // Normalize by a0
+        let nb0 = b0 / a0, nb1 = b1 / a0, nb2 = b2 / a0
+        let na1 = a1 / a0, na2 = a2 / a0
+
+        let numReal = nb0 + nb1 * cosW + nb2 * cos2W
+        let numImag = -(nb1 * sinW + nb2 * sin2W)
+        let denReal = 1.0 + na1 * cosW + na2 * cos2W
+        let denImag = -(na1 * sinW + na2 * sin2W)
+
+        let numMagSq = numReal * numReal + numImag * numImag
+        let denMagSq = denReal * denReal + denImag * denImag
+
+        guard denMagSq > 1e-30 else { return -120.0 }
+        return 10.0 * log10(numMagSq / denMagSq)
+    }
+}
+
+// MARK: - Biquad Response Computation
+
+enum BiquadResponse {
+
+    /// Generate log-spaced frequencies from 20 Hz to 20 kHz.
+    static func logFrequencies(count: Int = 512) -> [Double] {
+        (0..<count).map { i in
+            let t = Double(i) / Double(count - 1)
+            return 20.0 * pow(1000.0, t)
+        }
+    }
+
+    /// Compute biquad coefficients for a band using Audio EQ Cookbook formulas.
+    static func coefficients(for band: EQBand, sampleRate: Double) -> BiquadCoefficients {
+        let f0 = Double(band.frequency)
+        let gain = Double(band.gain)
+        let bw = Double(max(band.bandwidth, 0.05))
+
+        let w0 = 2.0 * .pi * f0 / sampleRate
+        let cosW0 = cos(w0)
+        let sinW0 = sin(w0)
+
+        // Bandwidth (octaves) → Q conversion
+        let sinW0Safe = abs(sinW0) > 1e-10 ? sinW0 : 1e-10
+        let Q = 1.0 / (2.0 * sinh(log(2.0) / 2.0 * bw * w0 / sinW0Safe))
+
+        let alpha = sinW0 / (2.0 * Q)
+
+        switch band.filterType {
+        case .parametric:
+            let A = pow(10.0, gain / 40.0)
+            return BiquadCoefficients(
+                b0: 1.0 + alpha * A,
+                b1: -2.0 * cosW0,
+                b2: 1.0 - alpha * A,
+                a0: 1.0 + alpha / A,
+                a1: -2.0 * cosW0,
+                a2: 1.0 - alpha / A
+            )
+
+        case .lowShelf:
+            let A = pow(10.0, gain / 40.0)
+            let twoSqrtAAlpha = 2.0 * sqrt(A) * alpha
+            return BiquadCoefficients(
+                b0: A * ((A + 1) - (A - 1) * cosW0 + twoSqrtAAlpha),
+                b1: 2.0 * A * ((A - 1) - (A + 1) * cosW0),
+                b2: A * ((A + 1) - (A - 1) * cosW0 - twoSqrtAAlpha),
+                a0: (A + 1) + (A - 1) * cosW0 + twoSqrtAAlpha,
+                a1: -2.0 * ((A - 1) + (A + 1) * cosW0),
+                a2: (A + 1) + (A - 1) * cosW0 - twoSqrtAAlpha
+            )
+
+        case .highShelf:
+            let A = pow(10.0, gain / 40.0)
+            let twoSqrtAAlpha = 2.0 * sqrt(A) * alpha
+            return BiquadCoefficients(
+                b0: A * ((A + 1) + (A - 1) * cosW0 + twoSqrtAAlpha),
+                b1: -2.0 * A * ((A - 1) + (A + 1) * cosW0),
+                b2: A * ((A + 1) + (A - 1) * cosW0 - twoSqrtAAlpha),
+                a0: (A + 1) - (A - 1) * cosW0 + twoSqrtAAlpha,
+                a1: 2.0 * ((A - 1) - (A + 1) * cosW0),
+                a2: (A + 1) - (A - 1) * cosW0 - twoSqrtAAlpha
+            )
+
+        case .lowPass:
+            return BiquadCoefficients(
+                b0: (1.0 - cosW0) / 2.0,
+                b1: 1.0 - cosW0,
+                b2: (1.0 - cosW0) / 2.0,
+                a0: 1.0 + alpha,
+                a1: -2.0 * cosW0,
+                a2: 1.0 - alpha
+            )
+
+        case .highPass:
+            return BiquadCoefficients(
+                b0: (1.0 + cosW0) / 2.0,
+                b1: -(1.0 + cosW0),
+                b2: (1.0 + cosW0) / 2.0,
+                a0: 1.0 + alpha,
+                a1: -2.0 * cosW0,
+                a2: 1.0 - alpha
+            )
+
+        case .bandPass:
+            return BiquadCoefficients(
+                b0: alpha,
+                b1: 0.0,
+                b2: -alpha,
+                a0: 1.0 + alpha,
+                a1: -2.0 * cosW0,
+                a2: 1.0 - alpha
+            )
+
+        case .notch:
+            return BiquadCoefficients(
+                b0: 1.0,
+                b1: -2.0 * cosW0,
+                b2: 1.0,
+                a0: 1.0 + alpha,
+                a1: -2.0 * cosW0,
+                a2: 1.0 - alpha
+            )
+        }
+    }
+
+    /// Composite frequency response: sum of all bands' dB contributions.
+    static func compositeResponse(
+        bands: [EQBand], sampleRate: Double, frequencies: [Double]
+    ) -> [Double] {
+        guard !bands.isEmpty else {
+            return [Double](repeating: 0.0, count: frequencies.count)
+        }
+
+        let allCoeffs = bands.map { coefficients(for: $0, sampleRate: sampleRate) }
+        return frequencies.map { freq in
+            var total = 0.0
+            for coeffs in allCoeffs {
+                total += coeffs.gainDB(at: freq, sampleRate: sampleRate)
+            }
+            return total
+        }
+    }
+}

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -230,84 +230,166 @@ final class FrequencyResponseView: NSView {
         ctx.saveGState()
         ctx.clip(to: plotRect)
 
-        // Grid: 0 dB center line
+        let accentColor = NSColor.controlAccentColor
         let zeroY = plotRect.minY + plotRect.height / 2.0
-        let gridAlpha: CGFloat = isBackdrop ? 0.15 : 1.0
-        ctx.setStrokeColor(NSColor.separatorColor.withAlphaComponent(0.5 * gridAlpha).cgColor)
+
+        // ── 1. Grid ──
+
+        // Frequency grid (vertical lines)
+        let freqGridLines: [Float] = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000]
+        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.04).cgColor)
         ctx.setLineWidth(0.5)
-        ctx.move(to: CGPoint(x: plotRect.minX, y: zeroY))
-        ctx.addLine(to: CGPoint(x: plotRect.maxX, y: zeroY))
-        ctx.strokePath()
-
-        // Dashed dB grid lines
-        let dashPattern: [CGFloat] = [4, 4]
-        ctx.setLineDash(phase: 0, lengths: dashPattern)
-        ctx.setStrokeColor(NSColor.separatorColor.withAlphaComponent(0.15 * gridAlpha).cgColor)
-        let dbStep: Float = maxGainDB <= 12 ? 6 : 12
-        var dbLine = dbStep
-        while dbLine < maxGainDB {
-            for sign: Float in [-1, 1] {
-                let y = gainToY(sign * dbLine, height: plotRect.height) + plotRect.minY
-                ctx.move(to: CGPoint(x: plotRect.minX, y: y))
-                ctx.addLine(to: CGPoint(x: plotRect.maxX, y: y))
-            }
-            dbLine += dbStep
-        }
-        ctx.strokePath()
-
-        // Vertical freq markers
-        let freqMarkers: [Float] = [100, 1000, 10000]
-        for freq in freqMarkers {
+        for freq in freqGridLines {
             let x = freqToX(freq, width: plotRect.width) + plotRect.minX
             ctx.move(to: CGPoint(x: x, y: plotRect.minY))
             ctx.addLine(to: CGPoint(x: x, y: plotRect.maxY))
         }
         ctx.strokePath()
-        ctx.setLineDash(phase: 0, lengths: [])
 
-        // Freq labels (skip in backdrop mode — they'd be hidden by sliders)
-        if !isBackdrop {
-            let labelAttrs: [NSAttributedString.Key: Any] = [
-                .font: NSFont.systemFont(ofSize: 8),
-                .foregroundColor: NSColor.tertiaryLabelColor,
-            ]
-            for freq in freqMarkers {
-                let x = freqToX(freq, width: plotRect.width) + plotRect.minX
-                let label = freq >= 1000 ? "\(Int(freq / 1000))k" : "\(Int(freq))"
-                let str = NSAttributedString(string: label, attributes: labelAttrs)
-                str.draw(at: CGPoint(x: x + 2, y: plotRect.minY + 1))
+        // dB grid (horizontal lines)
+        let dbStep: Float = 6
+        var dbLine = -maxGainDB
+        while dbLine <= maxGainDB {
+            let y = gainToY(dbLine, height: plotRect.height) + plotRect.minY
+            if abs(dbLine) < 0.1 {
+                // 0 dB line — brighter
+                ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.10).cgColor)
+                ctx.setLineWidth(0.75)
+            } else {
+                ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.04).cgColor)
+                ctx.setLineWidth(0.5)
             }
+            ctx.move(to: CGPoint(x: plotRect.minX, y: y))
+            ctx.addLine(to: CGPoint(x: plotRect.maxX, y: y))
+            ctx.strokePath()
+            dbLine += dbStep
         }
 
-        // Layer 1: Biquad composite response (filled area behind)
-        let biquadPts = biquadPoints(plotRect: plotRect)
-        if !biquadPts.isEmpty {
-            let biquadFill = CGMutablePath()
-            biquadFill.move(to: CGPoint(x: biquadPts[0].x, y: zeroY))
-            for pt in biquadPts { biquadFill.addLine(to: pt) }
-            biquadFill.addLine(to: CGPoint(x: biquadPts.last!.x, y: zeroY))
-            biquadFill.closeSubpath()
+        // ── 2. Biquad computation ──
+
+        let frequencies = BiquadResponse.logFrequencies(count: 512)
+        let allCoeffs = bands.map { BiquadResponse.coefficients(for: $0, sampleRate: sampleRate) }
+
+        // Per-band responses
+        let perBandGains: [[Double]] = allCoeffs.map { coeffs in
+            frequencies.map { coeffs.gainDB(at: $0, sampleRate: sampleRate) }
+        }
+
+        // Composite response
+        let compositeGains: [Double] = (0..<frequencies.count).map { i in
+            perBandGains.reduce(0.0) { $0 + $1[i] }
+        }
+
+        // Map to pixel coordinates
+        let compositePts: [CGPoint] = zip(frequencies, compositeGains).map { freq, gain in
+            let t = log10(freq / 20.0) / 3.0
+            let clamped = min(max(Float(gain), -maxGainDB), maxGainDB)
+            let x = CGFloat(t) * plotRect.width + plotRect.minX
+            let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+            return CGPoint(x: x, y: y)
+        }
+
+        // ── 3. Band ghost fills ──
+
+        for bandGains in perBandGains {
+            let ghostPath = CGMutablePath()
+            var first = true
+            for (i, freq) in frequencies.enumerated() {
+                let t = log10(freq / 20.0) / 3.0
+                let clamped = min(max(Float(bandGains[i]), -maxGainDB), maxGainDB)
+                let x = CGFloat(t) * plotRect.width + plotRect.minX
+                let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+                if first { ghostPath.move(to: CGPoint(x: x, y: y)); first = false }
+                else { ghostPath.addLine(to: CGPoint(x: x, y: y)) }
+            }
+            // Close to zero line
+            let lastT = log10(frequencies.last! / 20.0) / 3.0
+            let firstT = log10(frequencies.first! / 20.0) / 3.0
+            ghostPath.addLine(to: CGPoint(x: CGFloat(lastT) * plotRect.width + plotRect.minX, y: zeroY))
+            ghostPath.addLine(to: CGPoint(x: CGFloat(firstT) * plotRect.width + plotRect.minX, y: zeroY))
+            ghostPath.closeSubpath()
 
             ctx.saveGState()
-            ctx.addPath(biquadFill)
+            ctx.addPath(ghostPath)
             ctx.clip()
-            let biquadFillAlpha: CGFloat = isBackdrop ? 0.08 : 0.12
-            ctx.setFillColor(NSColor.controlAccentColor.withAlphaComponent(biquadFillAlpha).cgColor)
+            ctx.setFillColor(accentColor.withAlphaComponent(0.035).cgColor)
             ctx.fill(plotRect)
             ctx.restoreGState()
+        }
 
-            // Biquad stroke — slightly different shade to distinguish from spline
-            let biquadStroke = CGMutablePath()
-            biquadStroke.move(to: biquadPts[0])
-            for pt in biquadPts.dropFirst() { biquadStroke.addLine(to: pt) }
-            let biquadStrokeAlpha: CGFloat = isBackdrop ? 0.35 : 0.6
-            ctx.setStrokeColor(NSColor.controlAccentColor.blended(withFraction: 0.3, of: .systemTeal)!.withAlphaComponent(biquadStrokeAlpha).cgColor)
-            ctx.setLineWidth(isBackdrop ? 0.75 : 1.0)
-            ctx.addPath(biquadStroke)
+        // ── 4. Composite fill (different opacity for boost vs cut) ──
+
+        if !compositePts.isEmpty {
+            let fillPath = CGMutablePath()
+            fillPath.move(to: CGPoint(x: compositePts[0].x, y: zeroY))
+            for pt in compositePts { fillPath.addLine(to: pt) }
+            fillPath.addLine(to: CGPoint(x: compositePts.last!.x, y: zeroY))
+            fillPath.closeSubpath()
+
+            ctx.saveGState()
+            ctx.addPath(fillPath)
+            ctx.clip()
+            // Boost region (above zero line)
+            ctx.setFillColor(accentColor.withAlphaComponent(0.10).cgColor)
+            ctx.fill(CGRect(x: plotRect.minX, y: zeroY,
+                            width: plotRect.width, height: plotRect.maxY - zeroY))
+            // Cut region (below zero line)
+            ctx.setFillColor(accentColor.withAlphaComponent(0.06).cgColor)
+            ctx.fill(CGRect(x: plotRect.minX, y: plotRect.minY,
+                            width: plotRect.width, height: zeroY - plotRect.minY))
+            ctx.restoreGState()
+        }
+
+        // ── 5. Composite line ──
+
+        if !compositePts.isEmpty {
+            let curvePath = CGMutablePath()
+            curvePath.move(to: compositePts[0])
+            for pt in compositePts.dropFirst() { curvePath.addLine(to: pt) }
+            ctx.setStrokeColor(accentColor.withAlphaComponent(0.65).cgColor)
+            ctx.setLineWidth(1.5)
+            ctx.setLineJoin(.round)
+            ctx.addPath(curvePath)
             ctx.strokePath()
         }
 
-        // Layer 2: Spline / approximation curve (thin stroke on top)
+        // ── 6. Anchor dots ──
+
+        if isBackdrop {
+            for band in bands {
+                let freq = Double(band.frequency)
+                let compositeDB = allCoeffs.reduce(0.0) { $0 + $1.gainDB(at: freq, sampleRate: sampleRate) }
+                let t = log10(freq / 20.0) / 3.0
+                let clamped = min(max(Float(compositeDB), -maxGainDB), maxGainDB)
+                let x = CGFloat(t) * plotRect.width + plotRect.minX
+                let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+
+                // Drop line from anchor to zero
+                ctx.setStrokeColor(accentColor.withAlphaComponent(0.15).cgColor)
+                ctx.setLineWidth(0.75)
+                ctx.move(to: CGPoint(x: x, y: y))
+                ctx.addLine(to: CGPoint(x: x, y: zeroY))
+                ctx.strokePath()
+
+                // Outer circle
+                let outerR: CGFloat = 4
+                let outerRect = CGRect(x: x - outerR, y: y - outerR, width: outerR * 2, height: outerR * 2)
+                ctx.setFillColor(NSColor.controlBackgroundColor.cgColor)
+                ctx.fillEllipse(in: outerRect)
+                ctx.setStrokeColor(accentColor.withAlphaComponent(0.60).cgColor)
+                ctx.setLineWidth(1.5)
+                ctx.strokeEllipse(in: outerRect)
+
+                // Inner dot
+                let innerR: CGFloat = 1.5
+                let innerRect = CGRect(x: x - innerR, y: y - innerR, width: innerR * 2, height: innerR * 2)
+                ctx.setFillColor(accentColor.withAlphaComponent(0.70).cgColor)
+                ctx.fillEllipse(in: innerRect)
+            }
+        }
+
+        // ── 7. Spline (dashed gray, on top) ──
+
         var curvePoints: [CGPoint]
         if isBackdrop {
             curvePoints = splinePoints(plotRect: plotRect)
@@ -316,7 +398,7 @@ final class FrequencyResponseView: NSView {
             curvePoints = []
             for i in 0...sampleCount {
                 let t = Float(i) / Float(sampleCount)
-                let freq = 20.0 * pow(1000.0, t) // 20 to 20000
+                let freq = 20.0 * pow(1000.0, t)
                 let gain = compositeGain(at: freq)
                 let clamped = min(max(gain, -maxGainDB), maxGainDB)
                 let x = CGFloat(t) * plotRect.width + plotRect.minX
@@ -326,34 +408,50 @@ final class FrequencyResponseView: NSView {
         }
 
         if !curvePoints.isEmpty {
-            // Stroke-only — the biquad fill provides the filled area
-            let curvePath = CGMutablePath()
-            curvePath.move(to: curvePoints[0])
-            for pt in curvePoints.dropFirst() { curvePath.addLine(to: pt) }
-            let strokeAlpha: CGFloat = isBackdrop ? 0.4 : 0.6
-            ctx.setStrokeColor(NSColor.secondaryLabelColor.withAlphaComponent(strokeAlpha).cgColor)
+            let splinePath = CGMutablePath()
+            splinePath.move(to: curvePoints[0])
+            for pt in curvePoints.dropFirst() { splinePath.addLine(to: pt) }
+            ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.30).cgColor)
             ctx.setLineWidth(isBackdrop ? 0.75 : 1.0)
             ctx.setLineDash(phase: 0, lengths: [4, 3])
-            ctx.addPath(curvePath)
+            ctx.addPath(splinePath)
             ctx.strokePath()
             ctx.setLineDash(phase: 0, lengths: [])
         }
 
-        // Band markers (skip in backdrop mode — sliders serve as markers)
+        // ── 8. Band markers (standalone mode only) ──
+
         if !isBackdrop {
-            let markerRadius: CGFloat = 4
             for band in bands {
-                let x = freqToX(band.frequency, width: plotRect.width) + plotRect.minX
-                let actualGain = compositeGain(at: band.frequency)
-                let clamped = min(max(actualGain, -maxGainDB), maxGainDB)
+                let freq = Double(band.frequency)
+                let compositeDB = allCoeffs.isEmpty ? 0.0 :
+                    allCoeffs.reduce(0.0) { $0 + $1.gainDB(at: freq, sampleRate: sampleRate) }
+                let t = log10(freq / 20.0) / 3.0
+                let clamped = min(max(Float(compositeDB), -maxGainDB), maxGainDB)
+                let x = CGFloat(t) * plotRect.width + plotRect.minX
                 let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
-                let markerRect = CGRect(x: x - markerRadius, y: y - markerRadius,
-                                         width: markerRadius * 2, height: markerRadius * 2)
-                ctx.setFillColor(NSColor.controlAccentColor.cgColor)
-                ctx.fillEllipse(in: markerRect)
-                ctx.setStrokeColor(NSColor.controlBackgroundColor.cgColor)
-                ctx.setLineWidth(1)
-                ctx.strokeEllipse(in: markerRect)
+
+                // Drop line
+                ctx.setStrokeColor(accentColor.withAlphaComponent(0.15).cgColor)
+                ctx.setLineWidth(0.75)
+                ctx.move(to: CGPoint(x: x, y: y))
+                ctx.addLine(to: CGPoint(x: x, y: zeroY))
+                ctx.strokePath()
+
+                // Outer circle
+                let outerR: CGFloat = 4
+                let outerRect = CGRect(x: x - outerR, y: y - outerR, width: outerR * 2, height: outerR * 2)
+                ctx.setFillColor(NSColor.controlBackgroundColor.cgColor)
+                ctx.fillEllipse(in: outerRect)
+                ctx.setStrokeColor(accentColor.withAlphaComponent(0.60).cgColor)
+                ctx.setLineWidth(1.5)
+                ctx.strokeEllipse(in: outerRect)
+
+                // Inner dot
+                let innerR: CGFloat = 1.5
+                let innerRect = CGRect(x: x - innerR, y: y - innerR, width: innerR * 2, height: innerR * 2)
+                ctx.setFillColor(accentColor.withAlphaComponent(0.70).cgColor)
+                ctx.fillEllipse(in: innerRect)
             }
         }
 

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -114,21 +114,6 @@ final class FrequencyResponseView: NSView {
         return total
     }
 
-    /// Biquad composite response points at 512 log-spaced frequencies.
-    private func biquadPoints(plotRect: CGRect) -> [CGPoint] {
-        guard !bands.isEmpty else { return [] }
-        let frequencies = BiquadResponse.logFrequencies(count: 512)
-        let gains = BiquadResponse.compositeResponse(
-            bands: bands, sampleRate: sampleRate, frequencies: frequencies)
-        return zip(frequencies, gains).map { freq, gain in
-            let t = log10(freq / 20.0) / 3.0
-            let clamped = min(max(Float(gain), -maxGainDB), maxGainDB)
-            let x = CGFloat(t) * plotRect.width + plotRect.minX
-            let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
-            return CGPoint(x: x, y: y)
-        }
-    }
-
     /// Catmull-Rom spline through band control points in pixel-X space.
     /// Uses actual column center positions so the curve passes through every handle.
     private func splinePoints(plotRect: CGRect) -> [CGPoint] {
@@ -192,8 +177,9 @@ final class FrequencyResponseView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
         let b = bounds
+        let labelMargin: CGFloat = isBackdrop ? 16 : 0
         let inset: CGFloat = isBackdrop ? 0 : 4
-        var plotRect = b.insetBy(dx: inset, dy: inset)
+        var plotRect = b.insetBy(dx: inset + labelMargin, dy: inset)
 
         // In backdrop mode, align the gain axis to the slider track area.
         // Computed here (not in layout()) because the slider lives in a sibling
@@ -231,7 +217,6 @@ final class FrequencyResponseView: NSView {
         ctx.clip(to: plotRect)
 
         let accentColor = NSColor.controlAccentColor
-        let zeroY = plotRect.minY + plotRect.height / 2.0
 
         // ── 1. Grid ──
 
@@ -288,6 +273,8 @@ final class FrequencyResponseView: NSView {
             let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
             return CGPoint(x: x, y: y)
         }
+
+        let zeroY = gainToY(0, height: plotRect.height) + plotRect.minY
 
         // ── 3. Band ghost fills ──
 
@@ -385,6 +372,27 @@ final class FrequencyResponseView: NSView {
                 let innerRect = CGRect(x: x - innerR, y: y - innerR, width: innerR * 2, height: innerR * 2)
                 ctx.setFillColor(accentColor.withAlphaComponent(0.70).cgColor)
                 ctx.fillEllipse(in: innerRect)
+
+                // Anchor dB label
+                let compositeDBf = Float(compositeDB)
+                let labelAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 8, weight: .regular),
+                    .foregroundColor: NSColor.white.withAlphaComponent(0.35),
+                ]
+                let dbText: String
+                if compositeDBf == Float(Int(compositeDBf)) {
+                    dbText = String(format: "%+d", Int(compositeDBf))
+                } else {
+                    dbText = String(format: "%+.1f", compositeDBf)
+                }
+                let str = NSAttributedString(string: dbText, attributes: labelAttrs)
+                let size = str.size()
+                var labelX = x + 6
+                if labelX + size.width > plotRect.maxX {
+                    labelX = x - 6 - size.width
+                }
+                let labelY = min(max(y + 3, plotRect.minY), plotRect.maxY - size.height)
+                str.draw(at: CGPoint(x: labelX, y: labelY))
             }
         }
 
@@ -452,10 +460,55 @@ final class FrequencyResponseView: NSView {
                 let innerRect = CGRect(x: x - innerR, y: y - innerR, width: innerR * 2, height: innerR * 2)
                 ctx.setFillColor(accentColor.withAlphaComponent(0.70).cgColor)
                 ctx.fillEllipse(in: innerRect)
+
+                // Anchor dB label
+                let compositeDBf = Float(compositeDB)
+                let labelAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 8, weight: .regular),
+                    .foregroundColor: NSColor.white.withAlphaComponent(0.35),
+                ]
+                let dbText: String
+                if compositeDBf == Float(Int(compositeDBf)) {
+                    dbText = String(format: "%+d", Int(compositeDBf))
+                } else {
+                    dbText = String(format: "%+.1f", compositeDBf)
+                }
+                let str = NSAttributedString(string: dbText, attributes: labelAttrs)
+                let size = str.size()
+                var labelX = x + 6
+                if labelX + size.width > plotRect.maxX {
+                    labelX = x - 6 - size.width
+                }
+                let labelY = min(max(y + 3, plotRect.minY), plotRect.maxY - size.height)
+                str.draw(at: CGPoint(x: labelX, y: labelY))
             }
         }
 
         ctx.restoreGState()
+
+        // ── dB axis labels — drawn in the 16px margins outside the plot clip ──
+        if isBackdrop {
+            let axisAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 8, weight: .regular),
+                .foregroundColor: NSColor.white.withAlphaComponent(0.20),
+            ]
+            let maxInt = Int(maxGainDB)
+            let axisLabels: [(Float, String)] = [
+                (maxGainDB, "+\(maxInt)"),
+                (0, "0"),
+                (-maxGainDB, "-\(maxInt)"),
+            ]
+            for (db, text) in axisLabels {
+                let y = gainToY(db, height: plotRect.height) + plotRect.minY
+                let str = NSAttributedString(string: text, attributes: axisAttrs)
+                let size = str.size()
+                let centerY = y - size.height / 2.0
+                // Left margin: right-aligned within the 16px gap
+                str.draw(at: CGPoint(x: plotRect.minX - size.width - 2, y: centerY))
+                // Right margin: left-aligned within the 16px gap
+                str.draw(at: CGPoint(x: plotRect.maxX + 2, y: centerY))
+            }
+        }
     }
 }
 
@@ -955,8 +1008,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         bandsWrapper.addSubview(slidersContainer)
 
         // Pin curve to fill the wrapper
-        curveView.leadingAnchor.constraint(equalTo: bandsWrapper.leadingAnchor).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: bandsWrapper.trailingAnchor).isActive = true
+        curveView.leadingAnchor.constraint(equalTo: bandsWrapper.leadingAnchor, constant: -16).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: bandsWrapper.trailingAnchor, constant: 16).isActive = true
         curveView.topAnchor.constraint(equalTo: bandsWrapper.topAnchor).isActive = true
         curveView.bottomAnchor.constraint(equalTo: bandsWrapper.bottomAnchor).isActive = true
 

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -33,6 +33,7 @@ final class ClickThroughView: NSView {
 final class FrequencyResponseView: NSView {
     private var bands: [EQBand] = []
     private var maxGainDB: Float = 12
+    private var sampleRate: Double = 48000
 
     /// When true, draws with transparent background (for use as slider backdrop).
     var isBackdrop = false
@@ -43,9 +44,10 @@ final class FrequencyResponseView: NSView {
     /// All band sliders — used to compute column center X at draw time.
     var allSliders: [NSSlider] = []
 
-    func updateBands(_ bands: [EQBand], maxGainDB: Float) {
+    func updateBands(_ bands: [EQBand], maxGainDB: Float, sampleRate: Double) {
         self.bands = bands
         self.maxGainDB = maxGainDB
+        self.sampleRate = sampleRate
         needsDisplay = true
     }
 
@@ -110,6 +112,21 @@ final class FrequencyResponseView: NSView {
             total += bandGain(for: band, at: freq)
         }
         return total
+    }
+
+    /// Biquad composite response points at 512 log-spaced frequencies.
+    private func biquadPoints(plotRect: CGRect) -> [CGPoint] {
+        guard !bands.isEmpty else { return [] }
+        let frequencies = BiquadResponse.logFrequencies(count: 512)
+        let gains = BiquadResponse.compositeResponse(
+            bands: bands, sampleRate: sampleRate, frequencies: frequencies)
+        return zip(frequencies, gains).map { freq, gain in
+            let t = log10(freq / 20.0) / 3.0
+            let clamped = min(max(Float(gain), -maxGainDB), maxGainDB)
+            let x = CGFloat(t) * plotRect.width + plotRect.minX
+            let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+            return CGPoint(x: x, y: y)
+        }
     }
 
     /// Catmull-Rom spline through band control points in pixel-X space.
@@ -262,7 +279,35 @@ final class FrequencyResponseView: NSView {
             }
         }
 
-        // Composite curve — backdrop uses spline through column positions, standalone uses true response
+        // Layer 1: Biquad composite response (filled area behind)
+        let biquadPts = biquadPoints(plotRect: plotRect)
+        if !biquadPts.isEmpty {
+            let biquadFill = CGMutablePath()
+            biquadFill.move(to: CGPoint(x: biquadPts[0].x, y: zeroY))
+            for pt in biquadPts { biquadFill.addLine(to: pt) }
+            biquadFill.addLine(to: CGPoint(x: biquadPts.last!.x, y: zeroY))
+            biquadFill.closeSubpath()
+
+            ctx.saveGState()
+            ctx.addPath(biquadFill)
+            ctx.clip()
+            let biquadFillAlpha: CGFloat = isBackdrop ? 0.08 : 0.12
+            ctx.setFillColor(NSColor.controlAccentColor.withAlphaComponent(biquadFillAlpha).cgColor)
+            ctx.fill(plotRect)
+            ctx.restoreGState()
+
+            // Biquad stroke — slightly different shade to distinguish from spline
+            let biquadStroke = CGMutablePath()
+            biquadStroke.move(to: biquadPts[0])
+            for pt in biquadPts.dropFirst() { biquadStroke.addLine(to: pt) }
+            let biquadStrokeAlpha: CGFloat = isBackdrop ? 0.35 : 0.6
+            ctx.setStrokeColor(NSColor.controlAccentColor.blended(withFraction: 0.3, of: .systemTeal)!.withAlphaComponent(biquadStrokeAlpha).cgColor)
+            ctx.setLineWidth(isBackdrop ? 0.75 : 1.0)
+            ctx.addPath(biquadStroke)
+            ctx.strokePath()
+        }
+
+        // Layer 2: Spline / approximation curve (thin stroke on top)
         var curvePoints: [CGPoint]
         if isBackdrop {
             curvePoints = splinePoints(plotRect: plotRect)
@@ -280,28 +325,12 @@ final class FrequencyResponseView: NSView {
             }
         }
 
-        let fillAlpha: CGFloat = isBackdrop ? 0.08 : 0.15
-        let strokeAlpha: CGFloat = isBackdrop ? 0.4 : 0.8
-
-        // Filled area from curve to 0dB line
         if !curvePoints.isEmpty {
-            let fillPath = CGMutablePath()
-            fillPath.move(to: CGPoint(x: curvePoints[0].x, y: zeroY))
-            for pt in curvePoints { fillPath.addLine(to: pt) }
-            fillPath.addLine(to: CGPoint(x: curvePoints.last!.x, y: zeroY))
-            fillPath.closeSubpath()
-
-            ctx.saveGState()
-            ctx.addPath(fillPath)
-            ctx.clip()
-            ctx.setFillColor(NSColor.controlAccentColor.withAlphaComponent(fillAlpha).cgColor)
-            ctx.fill(plotRect)
-            ctx.restoreGState()
-
-            // Stroke curve
+            // Stroke-only — the biquad fill provides the filled area
             let curvePath = CGMutablePath()
             curvePath.move(to: curvePoints[0])
             for pt in curvePoints.dropFirst() { curvePath.addLine(to: pt) }
+            let strokeAlpha: CGFloat = isBackdrop ? 0.5 : 0.9
             ctx.setStrokeColor(NSColor.controlAccentColor.withAlphaComponent(strokeAlpha).cgColor)
             ctx.setLineWidth(isBackdrop ? 1.0 : 1.5)
             ctx.addPath(curvePath)
@@ -1094,7 +1123,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
 
     private func updateCurveView() {
-        curveView.updateBands(audioEngine.activePreset.bands, maxGainDB: audioEngine.maxGainDB)
+        curveView.updateBands(audioEngine.activePreset.bands, maxGainDB: audioEngine.maxGainDB, sampleRate: audioEngine.outputSampleRate)
     }
 
     private func populatePresetPicker() {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -330,11 +330,13 @@ final class FrequencyResponseView: NSView {
             let curvePath = CGMutablePath()
             curvePath.move(to: curvePoints[0])
             for pt in curvePoints.dropFirst() { curvePath.addLine(to: pt) }
-            let strokeAlpha: CGFloat = isBackdrop ? 0.5 : 0.9
-            ctx.setStrokeColor(NSColor.controlAccentColor.withAlphaComponent(strokeAlpha).cgColor)
-            ctx.setLineWidth(isBackdrop ? 1.0 : 1.5)
+            let strokeAlpha: CGFloat = isBackdrop ? 0.4 : 0.6
+            ctx.setStrokeColor(NSColor.secondaryLabelColor.withAlphaComponent(strokeAlpha).cgColor)
+            ctx.setLineWidth(isBackdrop ? 0.75 : 1.0)
+            ctx.setLineDash(phase: 0, lengths: [4, 3])
             ctx.addPath(curvePath)
             ctx.strokePath()
+            ctx.setLineDash(phase: 0, lengths: [])
         }
 
         // Band markers (skip in backdrop mode — sliders serve as markers)

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -177,7 +177,7 @@ final class FrequencyResponseView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
         let b = bounds
-        let labelMargin: CGFloat = isBackdrop ? 16 : 0
+        let labelMargin: CGFloat = isBackdrop ? 28 : 0
         let inset: CGFloat = isBackdrop ? 0 : 4
         var plotRect = b.insetBy(dx: inset + labelMargin, dy: inset)
 
@@ -1008,8 +1008,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         bandsWrapper.addSubview(slidersContainer)
 
         // Pin curve to fill the wrapper
-        curveView.leadingAnchor.constraint(equalTo: bandsWrapper.leadingAnchor, constant: -16).isActive = true
-        curveView.trailingAnchor.constraint(equalTo: bandsWrapper.trailingAnchor, constant: 16).isActive = true
+        curveView.leadingAnchor.constraint(equalTo: bandsWrapper.leadingAnchor, constant: -28).isActive = true
+        curveView.trailingAnchor.constraint(equalTo: bandsWrapper.trailingAnchor, constant: 28).isActive = true
         curveView.topAnchor.constraint(equalTo: bandsWrapper.topAnchor).isActive = true
         curveView.bottomAnchor.constraint(equalTo: bandsWrapper.bottomAnchor).isActive = true
 
@@ -1020,8 +1020,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         slidersContainer.bottomAnchor.constraint(equalTo: bandsWrapper.bottomAnchor).isActive = true
 
         mainStack.addArrangedSubview(bandsWrapper)
-        bandsWrapper.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 16).isActive = true
-        bandsWrapper.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -16).isActive = true
+        bandsWrapper.leadingAnchor.constraint(greaterThanOrEqualTo: mainStack.leadingAnchor, constant: 28).isActive = true
+        bandsWrapper.trailingAnchor.constraint(lessThanOrEqualTo: mainStack.trailingAnchor, constant: -28).isActive = true
 
         // Divider below bands
         let bottomDivider = NSBox()

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.10</string>
+	<string>0.11</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,13 @@ else
     echo "Binary updated"
 fi
 
-# Always update Info.plist
-cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"
+# Always update Info.plist — then re-sign if it changed (plist change invalidates signature)
+if ! cmp -s Sources/iQualize/Info.plist "$APP/Contents/Info.plist"; then
+    cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"
+    codesign --force --sign "Apple Development" --entitlements iQualize.entitlements "$APP" 2>/dev/null && echo "Re-signed (Info.plist changed)"
+else
+    cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"
+fi
 
 # Strip provenance xattr to prevent macOS security policy launch blocks
 xattr -rc "$APP" 2>/dev/null


### PR DESCRIPTION
## Summary

**Biquad Frequency Response Curve**
- Accurate biquad frequency response using Audio EQ Cookbook formulas for all 7 filter types (bell, low/high shelf, low/high pass, band pass, notch)
- Per-band ghost fills showing individual filter contribution shapes
- Composite response fill with split boost/cut opacity
- Composite response line (accent color, 65% opacity, 1.5px)
- Anchor dots with drop lines at each band's frequency on the composite curve
- Anchor dB labels on every dot (8px, regular weight, 35% opacity)
- Axis labels (+12, 0, -12 dB) in left/right margins outside the graph

**Visual Grid**
- 10 vertical frequency lines (20Hz–20kHz, log-spaced)
- Horizontal dB lines at 6dB intervals with brighter 0dB center line

**Curve Styling**
- Spline (connecting slider knobs) rendered as dashed gray line to distinguish from biquad response
- CurveView extends 16px into window margins for axis label placement

**New Presets**
- American Rap (808-heavy sub-bass, mid scoop, vocal presence)
- German Rap (warm mid-bass, vocal clarity, balanced brightness)

**Infrastructure**
- `BiquadResponse.swift`: pure DSP math (biquad coefficients, magnitude response, composite computation)
- `AudioEngine.swift`: exposes actual output device sample rate for accurate curves near Nyquist
- `install.sh`: re-signs app when only Info.plist changes (fixes launch failures after version bump)

## Pre-Landing Review
1 issue — 1 auto-fixed (removed dead `biquadPoints()` method). No critical issues.

## Test plan
- [x] `swift build` compiles cleanly
- [x] App launches successfully after install
- [x] Biquad curve visible behind EQ sliders with correct shapes for all filter types
- [x] Anchor dots, dB labels, and axis labels render correctly
- [x] Spline appears as dashed gray line on top of biquad curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)