### PR TITLE
Add 'Add Suggested Band' context menu option

### DIFF
--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -1483,6 +1483,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                 addRight.tag = -(i + 1) // negative tag encodes "insert after index i"
                 menu.addItem(addRight)
 
+                let addSuggested = NSMenuItem(title: "Add Suggested Band", action: #selector(addSuggestedBand(_:)), keyEquivalent: "")
+                addSuggested.target = self
+                menu.addItem(addSuggested)
+
                 menu.addItem(.separator())
             }
 
@@ -2005,6 +2009,21 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         var preset = audioEngine.activePreset
         let rightmost = preset.bands.last ?? EQBand(frequency: 1000, gain: 0)
         preset.bands.append(EQBand(frequency: rightmost.frequency, gain: rightmost.gain, bandwidth: rightmost.bandwidth, filterType: rightmost.filterType))
+        audioEngine.activePreset = preset
+        buildSliders()
+        markModified()
+        registerUndo("Add Band", oldPreset: oldPreset)
+    }
+
+    @objc private func addSuggestedBand(_ sender: NSMenuItem) {
+        guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        let oldPreset = audioEngine.activePreset
+        forkIfBuiltIn()
+        var preset = audioEngine.activePreset
+        let freq = preset.suggestNewBandFrequency()
+        let newBand = EQBand(frequency: freq, gain: 0, bandwidth: 1.0)
+        let insertIndex = preset.bands.firstIndex(where: { $0.frequency > freq }) ?? preset.bands.count
+        preset.bands.insert(newBand, at: insertIndex)
         audioEngine.activePreset = preset
         buildSliders()
         markModified()

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0</string>
+	<string>0.14.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.13</string>
+	<string>0.14</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Adds "Add Suggested Band" to each band's right-click context menu
- Uses `suggestNewBandFrequency()` to find the largest spectral gap and inserts a new band at the correct sorted position (gain 0, bandwidth 1.0)
- Left/right hover buttons and "Add Band to Left/Right" context menu items keep their original copy-edge-band behavior
- Version bumped to 0.14.0

## Test plan
- [ ] Right-click any band → "Add Suggested Band" appears in context menu
- [ ] Clicking it adds a band at a frequency that fills the largest gap
- [ ] New band has gain 0 and bandwidth 1.0, inserted in sorted order
- [ ] +L/+R hover buttons still duplicate the edge band as before

Fixes #21