### PR TITLE
remove: low latency feature (v0.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.15.1] - 2026-03-30
+
+### Removed
+- "Low Latency" toggle from EQ window and menu bar — it only changed ring buffer capacity without meaningfully reducing latency, while increasing audio glitch risk
+
 ## [0.15.0] - 2026-03-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ open /Applications/iQualize.app
 - Catmull-Rom spline interpolation connecting slider knob positions (dashed gray line)
 - Adjustable max gain range: ±6, ±12, ±18, or ±24 dB
 - Anti-clipping preamp — automatically reduces gain to prevent digital clipping
-- Low Latency mode (50ms buffer) for real-time monitoring
 - Smooth, glitch-free parameter updates — only changed values are written to the audio unit
 
 ### Band Management
@@ -94,7 +93,7 @@ Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (Q factor — 
 
 - Quick preset selection with checkmarks
 - Bypass EQ toggle (Cmd+B) — pass audio through unprocessed
-- Peak Limiter and Low Latency toggles
+- Peak Limiter toggle
 - Current output device display
 - Open EQ window (Cmd+,)
 

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -87,10 +87,6 @@ final class AudioEngine {
         didSet { applyBands() }
     }
 
-    var lowLatency: Bool = false {
-        didSet { if isRunning { rebuildEngine() } }
-    }
-
     var bypassed: Bool = false {
         didSet { applyBands() }
     }
@@ -241,7 +237,7 @@ final class AudioEngine {
         }
 
         // 5. Set up ring buffer + AVAudioEngine with EQ
-        let bufferSeconds = lowLatency ? 0.05 : 0.5
+        let bufferSeconds = 0.5
         let ringBuf = AudioRingBuffer(capacityFrames: Int(sampleRate * bufferSeconds), channels: Int(channels))
         self.ringBuffer = ringBuf
         rtRingBuffer = ringBuf
@@ -402,18 +398,6 @@ final class AudioEngine {
 
         eq.globalGain = preventClipping ? activePreset.preampGain : 0
         eq.bypass = bypassed || activePreset.isFlat
-    }
-
-    private func rebuildEngine() {
-        let wasRunning = isRunning
-        if wasRunning { stop() }
-        if wasRunning {
-            do {
-                try start()
-            } catch {
-                self.error = error.localizedDescription
-            }
-        }
     }
 
     // MARK: - Device Change Handling

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -6,7 +6,6 @@ struct iQualizeState: Codable {
     var isEnabled: Bool
     var selectedPresetID: UUID
     var preventClipping: Bool
-    var lowLatency: Bool
     var windowOpen: Bool
     var maxGainDB: Float
     var bypassed: Bool
@@ -16,7 +15,6 @@ struct iQualizeState: Codable {
         isEnabled: false,
         selectedPresetID: EQPresetData.flat.id,
         preventClipping: true,
-        lowLatency: false,
         windowOpen: false,
         maxGainDB: 12,
         bypassed: false,
@@ -36,18 +34,16 @@ struct iQualizeState: Codable {
         case isEnabled
         case selectedPresetID
         case preventClipping
-        case lowLatency
         case windowOpen
         case maxGainDB
         case bypassed
         case autoScale
     }
 
-    init(isEnabled: Bool, selectedPresetID: UUID, preventClipping: Bool, lowLatency: Bool = false, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true) {
+    init(isEnabled: Bool, selectedPresetID: UUID, preventClipping: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.preventClipping = preventClipping
-        self.lowLatency = lowLatency
         self.windowOpen = windowOpen
         self.maxGainDB = maxGainDB
         self.bypassed = bypassed
@@ -58,7 +54,6 @@ struct iQualizeState: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         isEnabled = (try? container.decode(Bool.self, forKey: .isEnabled)) ?? false
         preventClipping = (try? container.decode(Bool.self, forKey: .preventClipping)) ?? true
-        lowLatency = (try? container.decode(Bool.self, forKey: .lowLatency)) ?? false
         windowOpen = (try? container.decode(Bool.self, forKey: .windowOpen)) ?? false
         maxGainDB = (try? container.decode(Float.self, forKey: .maxGainDB)) ?? 12
         bypassed = (try? container.decode(Bool.self, forKey: .bypassed)) ?? false

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -997,7 +997,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var filterTypePickers: [NSPopUpButton] = []
     private var bypassCheckbox: NSButton!
     private var clippingCheckbox: NSButton!
-    private var lowLatencyCheckbox: NSButton!
     private var maxGainPicker: NSPopUpButton!
     private var autoScaleCheckbox: NSButton!
     /// Effective max gain: 24 dB when auto-scale is on, otherwise the user-selected value.
@@ -1293,10 +1292,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                                      target: self, action: #selector(toggleClipping(_:)))
         clippingCheckbox.state = audioEngine.preventClipping ? .on : .off
 
-        lowLatencyCheckbox = NSButton(checkboxWithTitle: "Low Latency",
-                                       target: self, action: #selector(toggleLowLatency(_:)))
-        lowLatencyCheckbox.state = audioEngine.lowLatency ? .on : .off
-
         let bottomRow = NSStackView()
         bottomRow.orientation = .horizontal
         bottomRow.distribution = .fill
@@ -1330,7 +1325,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         bottomRow.addArrangedSubview(maxGainLabel)
         bottomRow.addArrangedSubview(maxGainPicker)
         bottomRow.addArrangedSubview(autoScaleCheckbox)
-        bottomRow.addArrangedSubview(lowLatencyCheckbox)
         bottomRow.addArrangedSubview(clippingCheckbox)
 
         mainStack.addArrangedSubview(bottomRow)
@@ -1567,7 +1561,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         updateOutputLabel()
         bypassCheckbox.state = audioEngine.bypassed ? .on : .off
         clippingCheckbox.state = audioEngine.preventClipping ? .on : .off
-        lowLatencyCheckbox.state = audioEngine.lowLatency ? .on : .off
         let autoOn = iQualizeState.load().autoScale
         autoScaleCheckbox.state = autoOn ? .on : .off
         maxGainPicker.isEnabled = !autoOn
@@ -1869,13 +1862,6 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         audioEngine.preventClipping = sender.state == .on
         var state = iQualizeState.load()
         state.preventClipping = audioEngine.preventClipping
-        state.save()
-    }
-
-    @objc private func toggleLowLatency(_ sender: NSButton) {
-        audioEngine.lowLatency = sender.state == .on
-        var state = iQualizeState.load()
-        state.lowLatency = audioEngine.lowLatency
         state.save()
     }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.0</string>
+	<string>0.15.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.15</string>
+	<string>0.15.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -31,7 +31,6 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
             audioEngine.activePreset = preset
         }
         audioEngine.preventClipping = state.preventClipping
-        audioEngine.lowLatency = state.lowLatency
         audioEngine.maxGainDB = state.maxGainDB
         audioEngine.bypassed = state.bypassed
         audioEngine.setEnabled(true)
@@ -99,13 +98,6 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         clippingItem.target = self
         clippingItem.state = audioEngine.preventClipping ? .on : .off
         menu.addItem(clippingItem)
-
-        // Low Latency toggle
-        let latencyItem = NSMenuItem(title: "Low Latency",
-                                      action: #selector(toggleLowLatency(_:)), keyEquivalent: "")
-        latencyItem.target = self
-        latencyItem.state = audioEngine.lowLatency ? .on : .off
-        menu.addItem(latencyItem)
 
         menu.addItem(.separator())
 
@@ -190,12 +182,6 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     @objc private func toggleClipping(_ sender: NSMenuItem) {
         audioEngine.preventClipping.toggle()
         state.preventClipping = audioEngine.preventClipping
-        state.save()
-    }
-
-    @objc private func toggleLowLatency(_ sender: NSMenuItem) {
-        audioEngine.lowLatency.toggle()
-        state.lowLatency = audioEngine.lowLatency
         state.save()
     }
 


### PR DESCRIPTION
## Summary

Remove the "Low Latency" toggle from the EQ window and menu bar. The toggle only changed the ring buffer capacity (500ms → 50ms) without meaningfully reducing perceived audio latency. In practice, it just increased the risk of audio glitches (underruns/pops) by reducing jitter tolerance.

**Changes:**
- **AudioEngine.swift** — removed `lowLatency` property, hardcoded `bufferSeconds = 0.5`, removed unused `rebuildEngine()` method
- **EQWindowController.swift** — removed checkbox from bottom row, property declaration, state sync, and toggle handler
- **MenuBarController.swift** — removed menu item, state restore on init, and toggle handler
- **EQPreset.swift** — removed `lowLatency` from `iQualizeState` struct (existing user settings with the old key are harmlessly ignored by the decoder)

## Pre-Landing Review
No issues found.

## Plan Completion
5/5 plan items DONE.

## Test plan
- [x] App builds and launches successfully
- [x] "Low Latency" checkbox gone from EQ window bottom row
- [x] "Low Latency" menu item gone from menu bar dropdown
- [x] No compilation errors or warnings related to the change
- [x] Pre-landing review: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)