### PR TITLE
Add MIT license and download install docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Darius
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ It just works.
 
 ## Install
 
+### Download (recommended)
+
+Grab the latest `.dmg` from [Releases](https://github.com/DariusCorvus/iqualize/releases), open it, and drag iQualize to Applications.
+
+iQualize is unsigned. Apple charges $99/year for a developer certificate. If macOS blocks the app, run:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/iQualize.app
+```
+
+### Build from source
+
 ```bash
 bash install.sh          # builds, signs, installs to /Applications
 open /Applications/iQualize.app

--- a/README.md
+++ b/README.md
@@ -169,56 +169,6 @@ The ring buffer decouples the real-time IOProc callback from AVAudioEngine's pul
 
 iQualize detects the output device's sample rate and converts internally so the audio plays back correctly regardless of what device you're on. Bluetooth sends stereo (2ch) only — SBC, AAC, and aptX all max out at 2 channels. If your speaker system supports 5.1 (e.g. Teufel Concept E via USB), the hardware handles channel routing and upmixing (Dolby Pro Logic II etc) on its end.
 
-## Roadmap
-
-Prioritized by impact vs effort. Score = impact (1-5) x ease (1-5). Higher = do first.
-
-### Low-hanging fruit (score 15+)
-
-| Feature | Impact | Ease | Score | Notes |
-|---|---|---|---|---|
-| Smart frequency suggestions | 3 | 5 | 15 | New bands fill the largest spectral gap instead of copying the edge band |
-| ~~Keyboard shortcuts for bands~~ | ~~3~~ | ~~5~~ | ~~15~~ | ✅ Done in v0.13.0 — Arrow keys for gain/freq, Tab to cycle bands, scroll wheel on sliders/inputs |
-| ~~Visual frequency response curve~~ | ~~5~~ | ~~3~~ | ~~15~~ | ✅ Done in v0.11.0 — biquad response curve with ghost fills, anchor dots, axis labels |
-
-### High impact, moderate effort (score 10-14)
-
-| Feature | Impact | Ease | Score | Notes |
-|---|---|---|---|---|
-| ~~Filter types per band~~ | ~~5~~ | ~~3~~ | ~~15~~ | ✅ Done in v0.10.0 — Bell, low/high shelf, low/high pass, notch, bandpass |
-| Per-band bypass | 4 | 3 | 12 | Set individual band gain to 0 without losing saved value, toggle in UI |
-| Drag-on-curve editing | 5 | 2 | 10 | Drag band nodes directly on the response curve — needs hit testing, coordinate mapping |
-| ~~Real-time spectrum analyzer~~ | ~~5~~ | ~~2~~ | ~~10~~ | ✅ Done in v0.16.0 — dual pre/post-EQ FFT spectrum with Catmull-Rom splines, peak hold lines |
-| ~~Peak hold markers~~ | ~~3~~ | ~~4~~ | ~~12~~ | ✅ Done in v0.16.0 — included in spectrum analyzer as peak hold spline lines |
-| Filter slope selection | 3 | 4 | 12 | 6/12/24/48 dB/oct for pass filters — expose existing Core Audio param |
-| Per-band solo | 3 | 3 | 9 | Mute all other bands, play only the selected band's affected range |
-| Menu bar level meter | 3 | 3 | 9 | RMS/peak meter from the output buffer, render in menu bar icon |
-| Sparkle auto-updates | 3 | 3 | 9 | Standard for Mac apps, one-time setup |
-
-### Differentiators (score 5-9, higher effort but competitive moat)
-
-| Feature | Impact | Ease | Score | Notes |
-|---|---|---|---|---|
-| Per-app volume mixer | 5 | 2 | 10 | Independent volume per app. Requires per-process audio taps — significant Core Audio work |
-| Per-app EQ routing | 5 | 1 | 5 | Different EQ per app. Same tap challenge as above but with per-stream EQ instances |
-| AutoEQ headphone profiles | 5 | 2 | 10 | Import from the open-source AutoEQ database. Match headphone model, apply corrective curve |
-| Preset sharing / community | 4 | 2 | 8 | Web directory or GitHub repo of .iqpreset files, in-app browse and import |
-| Mid/Side processing | 4 | 2 | 8 | Encode L/R to Mid/Side, EQ independently, decode back. Matrix math in the audio buffer |
-| L/R independent EQ | 3 | 3 | 9 | Separate curves per channel — simpler than Mid/Side, just duplicate the EQ chain |
-| Shortcuts integration | 3 | 3 | 9 | macOS Shortcuts actions for preset switching, bypass toggle — good for automation |
-
-### Moonshots (high effort, high reward)
-
-| Feature | Impact | Ease | Score | Notes |
-|---|---|---|---|---|
-| Audiogram hearing compensation | 5 | 1 | 5 | Built-in hearing test (play tones, user marks threshold), generate corrective L/R curve. Nobody does this well on macOS — huge accessibility angle, press-worthy |
-| Room correction via mic | 5 | 1 | 5 | Play test tones through speakers, record with Mac mic, compute room response, generate inverse EQ. Pro studio feature at consumer level |
-| AU plugin hosting | 5 | 1 | 5 | Load third-party Audio Unit effects into the signal chain. Opens the entire AU plugin ecosystem |
-| Dynamic EQ | 4 | 1 | 4 | Bands activate based on signal threshold — compressor married to EQ. Requires sidechain analysis per band |
-| Linear phase mode | 3 | 1 | 3 | FIR filter implementation, preserves phase coherence. High latency, mastering use case |
-| Auto-gain compensation | 3 | 2 | 6 | Maintain perceived loudness while EQ changes. Integrate over frequency-weighted gain |
-| Multichannel-aware EQ | 4 | 1 | 4 | Per-channel or per-group curves for 5.1/7.1 setups. Needs channel routing UI |
-
 ---
 
 I build tools that shouldn't need to exist.


### PR DESCRIPTION
## Summary
- Add MIT license to the repo
- Update README with download install instructions and Gatekeeper workaround (`xattr -dr`)

## Notes
GitHub release v0.17.0 with DMG already created: https://github.com/DariusCorvus/iqualize/releases/tag/v0.17.0