### PR TITLE
feat: stereo balance control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.19.0] - 2026-04-01
+
+### Added
+- Stereo balance control — L/R balance slider in the bottom bar with snap-to-center and double-click reset
+- Balance persists across app restarts
+
 ## [0.18.0] - 2026-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to iQualize will be documented in this file.
 - Stereo balance control — L/R balance slider in the bottom bar with snap-to-center and double-click reset
 - Balance persists across app restarts
 
+### Fixed
+- Menu bar actions (toggle bypass, open/close window, switch preset) no longer overwrite settings saved by the EQ window
+
 ## [0.18.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (Q factor — 
 - Monochrome white/gray spectrum layers with z-ordered rendering; blue EQ response curve is the only colored element
 - Spectrum toggle states persist across app restarts
 
+### Stereo Balance
+
+- L/R balance slider in the bottom bar, centered by default
+- Snap-to-center with double-click reset
+- Applied as per-channel gain in the audio render callback
+
 ### System Integration
 
 - Automatic output device switching and reconnection

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -18,6 +18,8 @@ nonisolated(unsafe) private var rtChannelCount: UInt32 = 2
 /// Scratch buffer for deinterleaving (allocated once, reused).
 nonisolated(unsafe) private var rtScratchBuffer: UnsafeMutablePointer<Float>?
 nonisolated(unsafe) private var rtScratchCapacity: Int = 0
+nonisolated(unsafe) private var rtBalanceLeft: Float = 1.0
+nonisolated(unsafe) private var rtBalanceRight: Float = 1.0
 
 /// AVAudioSourceNode render block: pulls interleaved audio from ring buffer,
 /// deinterleaves into separate channel buffers for the non-interleaved AVAudioEngine format.
@@ -48,8 +50,9 @@ private func renderCallback(
     for i in 0..<bufferList.count {
         guard let outData = bufferList[i].mData?.assumingMemoryBound(to: Float.self) else { continue }
         let channelIndex = i
+        let gain = channelIndex == 0 ? rtBalanceLeft : rtBalanceRight
         for f in 0..<frames {
-            outData[f] = scratch[f * ch + channelIndex]
+            outData[f] = scratch[f * ch + channelIndex] * gain
         }
     }
     return noErr
@@ -95,6 +98,13 @@ final class AudioEngine {
 
     var bypassed: Bool = false {
         didSet { applyBands() }
+    }
+
+    var balance: Float = 0.0 {
+        didSet {
+            rtBalanceLeft = balance <= 0 ? 1.0 : 1.0 - balance
+            rtBalanceRight = balance >= 0 ? 1.0 : 1.0 + balance
+        }
     }
 
     var maxGainDB: Float = 12

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -14,6 +14,7 @@ struct iQualizeState: Codable {
     var postEqSpectrumEnabled: Bool
     var hideFromDock: Bool
     var startAtLogin: Bool
+    var balance: Float
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -26,12 +27,13 @@ struct iQualizeState: Codable {
         preEqSpectrumEnabled: false,
         postEqSpectrumEnabled: false,
         hideFromDock: false,
-        startAtLogin: false
+        startAtLogin: false,
+        balance: 0.0
     )
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -43,6 +45,7 @@ struct iQualizeState: Codable {
         self.postEqSpectrumEnabled = postEqSpectrumEnabled
         self.hideFromDock = hideFromDock
         self.startAtLogin = startAtLogin
+        self.balance = balance
     }
 
     init(from decoder: Decoder) throws {
@@ -58,6 +61,7 @@ struct iQualizeState: Codable {
         postEqSpectrumEnabled = (try? container.decode(Bool.self, forKey: .postEqSpectrumEnabled)) ?? false
         hideFromDock = (try? container.decode(Bool.self, forKey: .hideFromDock)) ?? false
         startAtLogin = (try? container.decode(Bool.self, forKey: .startAtLogin)) ?? false
+        balance = (try? container.decode(Float.self, forKey: .balance)) ?? 0.0
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -1208,6 +1208,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var autoScaleCheckbox: NSButton!
     private var preEqSpectrumCheckbox: NSButton!
     private var postEqSpectrumCheckbox: NSButton!
+    private var balanceSlider: NSSlider!
+    private var balanceValueLabel: NSTextField!
     /// Effective max gain: 24 dB when auto-scale is on, otherwise the user-selected value.
     private var effectiveMaxGainDB: Float {
         (autoScaleCheckbox?.state == .on) ? 24 : audioEngine.maxGainDB
@@ -1547,9 +1549,43 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             curveView.startAnimationIfNeeded()
         }
 
+        // Balance slider
+        let balanceLabelL = NSTextField(labelWithString: "L")
+        balanceLabelL.font = .systemFont(ofSize: 10)
+        balanceLabelL.textColor = .secondaryLabelColor
+
+        balanceSlider = NSSlider(value: Double(savedState.balance), minValue: -1.0, maxValue: 1.0,
+                                 target: self, action: #selector(balanceChanged(_:)))
+        balanceSlider.isContinuous = true
+        balanceSlider.widthAnchor.constraint(equalToConstant: 80).isActive = true
+
+        let doubleClick = NSClickGestureRecognizer(target: self, action: #selector(resetBalance(_:)))
+        doubleClick.numberOfClicksRequired = 2
+        balanceSlider.addGestureRecognizer(doubleClick)
+
+        let balanceLabelR = NSTextField(labelWithString: "R")
+        balanceLabelR.font = .systemFont(ofSize: 10)
+        balanceLabelR.textColor = .secondaryLabelColor
+
+        balanceValueLabel = NSTextField(labelWithString: "C")
+        balanceValueLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        balanceValueLabel.textColor = .secondaryLabelColor
+        balanceValueLabel.widthAnchor.constraint(equalToConstant: 28).isActive = true
+        balanceValueLabel.alignment = .center
+        updateBalanceLabel(savedState.balance)
+
+        let balanceSeparator = NSBox()
+        balanceSeparator.boxType = .separator
+        balanceSeparator.widthAnchor.constraint(equalToConstant: 1).isActive = true
+
         bottomRow.addArrangedSubview(bypassCheckbox)
         bottomRow.addArrangedSubview(preEqSpectrumCheckbox)
         bottomRow.addArrangedSubview(postEqSpectrumCheckbox)
+        bottomRow.addArrangedSubview(balanceSeparator)
+        bottomRow.addArrangedSubview(balanceLabelL)
+        bottomRow.addArrangedSubview(balanceSlider)
+        bottomRow.addArrangedSubview(balanceLabelR)
+        bottomRow.addArrangedSubview(balanceValueLabel)
         bottomRow.addArrangedSubview(spacer)
         bottomRow.addArrangedSubview(maxGainLabel)
         bottomRow.addArrangedSubview(maxGainPicker)
@@ -1790,6 +1826,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         updateOutputLabel()
         bypassCheckbox.state = audioEngine.bypassed ? .on : .off
         clippingCheckbox.state = audioEngine.peakLimiter ? .on : .off
+        balanceSlider.doubleValue = Double(audioEngine.balance)
+        updateBalanceLabel(audioEngine.balance)
         let autoOn = iQualizeState.load().autoScale
         autoScaleCheckbox.state = autoOn ? .on : .off
         maxGainPicker.isEnabled = !autoOn
@@ -2079,6 +2117,35 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
 
     // MARK: - Actions
+
+    @objc private func resetBalance(_ sender: NSClickGestureRecognizer) {
+        balanceSlider.doubleValue = 0
+        audioEngine.balance = 0
+        updateBalanceLabel(0)
+        var state = iQualizeState.load()
+        state.balance = 0
+        state.save()
+    }
+
+    @objc private func balanceChanged(_ sender: NSSlider) {
+        var value = Float(sender.doubleValue)
+        if abs(value) < 0.05 { value = 0; sender.doubleValue = 0 }
+        audioEngine.balance = value
+        updateBalanceLabel(value)
+        var state = iQualizeState.load()
+        state.balance = value
+        state.save()
+    }
+
+    private func updateBalanceLabel(_ value: Float) {
+        if abs(value) < 0.01 {
+            balanceValueLabel.stringValue = "C"
+        } else if value < 0 {
+            balanceValueLabel.stringValue = "\(Int(-value * 100))L"
+        } else {
+            balanceValueLabel.stringValue = "\(Int(value * 100))R"
+        }
+    }
 
     @objc private func toggleBypass(_ sender: NSButton) {
         audioEngine.bypassed = sender.state == .on

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18.0</string>
+	<string>0.19.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.18</string>
+	<string>0.19</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -34,6 +34,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         audioEngine.peakLimiter = state.peakLimiter
         audioEngine.maxGainDB = state.maxGainDB
         audioEngine.bypassed = state.bypassed
+        audioEngine.balance = state.balance
         audioEngine.setEnabled(true)
         updateIcon()
 

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -7,14 +7,13 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private let audioEngine: AudioEngine
     private let presetStore: PresetStore
-    private var state: iQualizeState
     private var eqWindowController: EQWindowController?
 
     init(audioEngine: AudioEngine, presetStore: PresetStore) {
         self.audioEngine = audioEngine
         self.presetStore = presetStore
-        self.state = iQualizeState.load()
         super.init()
+        let state = iQualizeState.load()
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         let menu = NSMenu()
@@ -111,7 +110,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         let dockItem = NSMenuItem(title: "Hide from Dock",
                                    action: #selector(toggleHideFromDock(_:)), keyEquivalent: "")
         dockItem.target = self
-        dockItem.state = state.hideFromDock ? .on : .off
+        dockItem.state = iQualizeState.load().hideFromDock ? .on : .off
         menu.addItem(dockItem)
 
         // Start at Login toggle
@@ -166,8 +165,9 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
               let id = UUID(uuidString: uuidString),
               let preset = presetStore.preset(for: id) else { return }
         audioEngine.activePreset = preset
-        state.selectedPresetID = preset.id
-        state.save()
+        var s = iQualizeState.load()
+        s.selectedPresetID = preset.id
+        s.save()
     }
 
     @objc private func openEQSettings(_ sender: NSMenuItem) {
@@ -185,26 +185,30 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         }
         eqWindowController?.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)
-        state.windowOpen = true
-        state.save()
+        var s = iQualizeState.load()
+        s.windowOpen = true
+        s.save()
     }
 
     @objc private func windowDidClose(_ notification: Notification) {
-        state.windowOpen = false
-        state.save()
+        var s = iQualizeState.load()
+        s.windowOpen = false
+        s.save()
     }
 
     @objc private func toggleBypass(_ sender: NSMenuItem) {
         audioEngine.bypassed.toggle()
-        state.bypassed = audioEngine.bypassed
-        state.save()
+        var s = iQualizeState.load()
+        s.bypassed = audioEngine.bypassed
+        s.save()
         updateIcon()
     }
 
     @objc private func toggleClipping(_ sender: NSMenuItem) {
         audioEngine.peakLimiter.toggle()
-        state.peakLimiter = audioEngine.peakLimiter
-        state.save()
+        var s = iQualizeState.load()
+        s.peakLimiter = audioEngine.peakLimiter
+        s.save()
     }
 
     @objc private func toggleStartAtLogin(_ sender: NSMenuItem) {
@@ -220,15 +224,17 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
             alert.informativeText = error.localizedDescription
             alert.runModal()
         }
-        state.startAtLogin = SMAppService.mainApp.status == .enabled
-        state.save()
+        var s = iQualizeState.load()
+        s.startAtLogin = SMAppService.mainApp.status == .enabled
+        s.save()
     }
 
     @objc private func toggleHideFromDock(_ sender: NSMenuItem) {
-        state.hideFromDock.toggle()
-        state.save()
-        NSApp.setActivationPolicy(state.hideFromDock ? .accessory : .regular)
-        if !state.hideFromDock {
+        var s = iQualizeState.load()
+        s.hideFromDock.toggle()
+        s.save()
+        NSApp.setActivationPolicy(s.hideFromDock ? .accessory : .regular)
+        if !s.hideFromDock {
             NSApp.activate(ignoringOtherApps: true)
         }
     }


### PR DESCRIPTION
## Summary
Adds a stereo balance control to iQualize and fixes a stale state bug in MenuBarController.

**Feature:**
- **Balance slider** in the bottom bar with L/R labels, value display (C / 50L / 50R), snap-to-center, and double-click reset
- Per-channel gain applied via per-sample multiply in the audio render callback, no new audio nodes
- Balance persists across app restarts via `iQualizeState`

**Bug fix:**
- `MenuBarController` cached `iQualizeState` at init and saved the stale copy on every menu action, silently overwriting settings saved by the EQ window. Now uses fresh `iQualizeState.load()` before each save.

Fixes #49

## Pre-Landing Review
No issues found.

## Adversarial Review
Codex adversarial review ran (medium tier). One branch-related finding (#4: multichannel balance) is non-applicable since the engine is hardcoded to stereo. Finding #6 (stale cached state) was fixed in this PR.

## Plan Completion
All plan items DONE.

## Test plan
- [x] `swift build` compiles without errors
- [x] App launches successfully after install
- [x] Balance slider visible in bottom bar, centered by default
- [x] Dragging slider left attenuates right channel, right attenuates left (manual)
- [x] Double-click resets to center (manual)
- [x] Set balance, toggle bypass from menu bar, quit and reopen — balance persists (manual)