### PR TITLE
feat: per-channel L/R EQ with split channel mode

### DIFF
--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -20,6 +20,13 @@ nonisolated(unsafe) private var rtScratchBuffer: UnsafeMutablePointer<Float>?
 nonisolated(unsafe) private var rtScratchCapacity: Int = 0
 nonisolated(unsafe) private var rtBalanceLeft: Float = 1.0
 nonisolated(unsafe) private var rtBalanceRight: Float = 1.0
+/// Per-channel biquad filter chains for split channel mode.
+/// Only active when rtSplitChannelActive is true.
+/// Channels 2+ (e.g. 5.1/7.1 surround) pass through unprocessed — per-channel
+/// EQ for >2 channels is a separate feature.
+nonisolated(unsafe) private var rtBiquadChainL: BiquadFilterChain?
+nonisolated(unsafe) private var rtBiquadChainR: BiquadFilterChain?
+nonisolated(unsafe) private var rtSplitChannelActive: Bool = false
 
 /// AVAudioSourceNode render block: pulls interleaved audio from ring buffer,
 /// deinterleaves into separate channel buffers for the non-interleaved AVAudioEngine format.
@@ -55,6 +62,18 @@ private func renderCallback(
             outData[f] = scratch[f * ch + channelIndex] * gain
         }
     }
+
+    // Apply per-channel biquad EQ when split channel mode is active.
+    // This runs INSTEAD of AVAudioUnitEQ (which is bypassed in split mode).
+    if rtSplitChannelActive {
+        if bufferList.count > 0, let outL = bufferList[0].mData?.assumingMemoryBound(to: Float.self) {
+            rtBiquadChainL?.process(outL, frameCount: frames)
+        }
+        if bufferList.count > 1, let outR = bufferList[1].mData?.assumingMemoryBound(to: Float.self) {
+            rtBiquadChainR?.process(outR, frameCount: frames)
+        }
+    }
+
     return noErr
 }
 
@@ -104,6 +123,13 @@ final class AudioEngine {
         didSet {
             rtBalanceLeft = balance <= 0 ? 1.0 : 1.0 - balance
             rtBalanceRight = balance >= 0 ? 1.0 : 1.0 + balance
+        }
+    }
+
+    var splitChannelActive: Bool = false {
+        didSet {
+            rtSplitChannelActive = splitChannelActive
+            applyBands()
         }
     }
 
@@ -292,7 +318,15 @@ final class AudioEngine {
             }
         }
         eqNode.globalGain = 0
-        eqNode.bypass = bypassed || activePreset.isFlat
+        if splitChannelActive && !bypassed {
+            // Split channel mode: bypass AVAudioUnitEQ, set up biquad chains
+            eqNode.bypass = true
+            rtBiquadChainL = BiquadFilterChain(bands: activePreset.bands, sampleRate: sampleRate)
+            rtBiquadChainR = BiquadFilterChain(bands: activePreset.rightBands ?? activePreset.bands, sampleRate: sampleRate)
+            rtSplitChannelActive = true
+        } else {
+            eqNode.bypass = bypassed || activePreset.isFlat
+        }
         self.eq = eqNode
 
         // Peak limiter: dynamic limiting at 0 dBFS (replaces static preamp hack)
@@ -372,6 +406,8 @@ final class AudioEngine {
 
         rtRingBuffer = nil
         ringBuffer = nil
+        rtBiquadChainL = nil
+        rtBiquadChainR = nil
 
         // Remove spectrum taps before stopping engine
         sourceNode?.removeTap(onBus: 0)
@@ -416,43 +452,70 @@ final class AudioEngine {
 
     private func applyBands(from old: EQPresetData? = nil) {
         guard let eq else { return }
-        let newCount = activePreset.bands.count
-        let oldCount = old?.bands.count ?? 0
 
-        for (i, band) in activePreset.bands.enumerated() {
-            let eqBand = eq.bands[i]
-            if i >= oldCount {
-                // New band — configure fully
-                eqBand.filterType = band.filterType.avType
-                eqBand.frequency = band.frequency
-                eqBand.bandwidth = band.bandwidth
-                eqBand.gain = band.gain
-                eqBand.bypass = false
-            } else if let oldBand = old?.bands[i] {
-                // Existing band — only update changed params
-                if band.filterType != oldBand.filterType { eqBand.filterType = band.filterType.avType }
-                if band.frequency != oldBand.frequency { eqBand.frequency = band.frequency }
-                if band.gain != oldBand.gain { eqBand.gain = band.gain }
-                if band.bandwidth != oldBand.bandwidth { eqBand.bandwidth = band.bandwidth }
+        if splitChannelActive && !bypassed {
+            // Split channel mode: bypass AVAudioUnitEQ, use custom biquad chains
+            eq.bypass = true
+            let sr = outputSampleRate
+
+            let leftBands = activePreset.bands
+            let rightBands = activePreset.rightBands ?? activePreset.bands
+
+            if let chainL = rtBiquadChainL {
+                chainL.updateCoefficients(bands: leftBands, sampleRate: sr)
             } else {
-                // No old data — write everything
-                eqBand.filterType = band.filterType.avType
-                eqBand.frequency = band.frequency
-                eqBand.gain = band.gain
-                eqBand.bandwidth = band.bandwidth
+                rtBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sr)
             }
+
+            if let chainR = rtBiquadChainR {
+                chainR.updateCoefficients(bands: rightBands, sampleRate: sr)
+            } else {
+                rtBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sr)
+            }
+        } else {
+            // Linked mode: use AVAudioUnitEQ, disable biquad chains
+            rtBiquadChainL = nil
+            rtBiquadChainR = nil
+
+            let newCount = activePreset.bands.count
+            let oldCount = old?.bands.count ?? 0
+
+            for (i, band) in activePreset.bands.enumerated() {
+                let eqBand = eq.bands[i]
+                if i >= oldCount {
+                    // New band — configure fully
+                    eqBand.filterType = band.filterType.avType
+                    eqBand.frequency = band.frequency
+                    eqBand.bandwidth = band.bandwidth
+                    eqBand.gain = band.gain
+                    eqBand.bypass = false
+                } else if let oldBand = old?.bands[i] {
+                    // Existing band — only update changed params
+                    if band.filterType != oldBand.filterType { eqBand.filterType = band.filterType.avType }
+                    if band.frequency != oldBand.frequency { eqBand.frequency = band.frequency }
+                    if band.gain != oldBand.gain { eqBand.gain = band.gain }
+                    if band.bandwidth != oldBand.bandwidth { eqBand.bandwidth = band.bandwidth }
+                } else {
+                    // No old data — write everything
+                    eqBand.filterType = band.filterType.avType
+                    eqBand.frequency = band.frequency
+                    eqBand.gain = band.gain
+                    eqBand.bandwidth = band.bandwidth
+                }
+            }
+
+            // Bypass bands that are no longer active
+            if newCount < oldCount {
+                for i in newCount..<oldCount {
+                    eq.bands[i].bypass = true
+                }
+            }
+
+            eq.globalGain = 0
+            eq.bypass = bypassed || activePreset.isFlat
         }
 
-        // Bypass bands that are no longer active
-        if newCount < oldCount {
-            for i in newCount..<oldCount {
-                eq.bands[i].bypass = true
-            }
-        }
-
-        eq.globalGain = 0
         limiter?.bypass = !peakLimiter || bypassed
-        eq.bypass = bypassed || activePreset.isFlat
     }
 
     // MARK: - Device Change Handling

--- a/Sources/iQualize/BiquadFilter.swift
+++ b/Sources/iQualize/BiquadFilter.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+// MARK: - Normalized Biquad Coefficients
+
+/// Pre-normalized biquad coefficients (divided by a0) for real-time processing.
+struct NormalizedBiquadCoeffs: Sendable {
+    let b0: Float, b1: Float, b2: Float
+    let a1: Float, a2: Float
+
+    init(from raw: BiquadCoefficients) {
+        let a0 = Float(raw.a0)
+        b0 = Float(raw.b0) / a0
+        b1 = Float(raw.b1) / a0
+        b2 = Float(raw.b2) / a0
+        a1 = Float(raw.a1) / a0
+        a2 = Float(raw.a2) / a0
+    }
+
+    static let passthrough = NormalizedBiquadCoeffs(b0: 1, b1: 0, b2: 0, a1: 0, a2: 0)
+
+    private init(b0: Float, b1: Float, b2: Float, a1: Float, a2: Float) {
+        self.b0 = b0; self.b1 = b1; self.b2 = b2; self.a1 = a1; self.a2 = a2
+    }
+}
+
+// MARK: - Biquad Filter Chain
+
+/// Real-time biquad filter chain for per-channel EQ processing.
+/// Maintains filter state (delay elements) per band.
+/// Designed for use on the Core Audio IO thread — no allocations after setup.
+final class BiquadFilterChain: @unchecked Sendable {
+    /// Per-band coefficients.
+    private var coeffs: [NormalizedBiquadCoeffs]
+    /// Per-band delay state: z1, z2 (Direct Form II Transposed).
+    private var z1: [Float]
+    private var z2: [Float]
+    private var bandCount: Int
+
+    init(bands: [EQBand], sampleRate: Double) {
+        bandCount = bands.count
+        coeffs = bands.map { band in
+            NormalizedBiquadCoeffs(from: BiquadResponse.coefficients(for: band, sampleRate: sampleRate))
+        }
+        z1 = [Float](repeating: 0, count: bandCount)
+        z2 = [Float](repeating: 0, count: bandCount)
+    }
+
+    /// Update coefficients from new band parameters. Resets state if band count changed.
+    func updateCoefficients(bands: [EQBand], sampleRate: Double) {
+        let newCount = bands.count
+        let newCoeffs = bands.map { band in
+            NormalizedBiquadCoeffs(from: BiquadResponse.coefficients(for: band, sampleRate: sampleRate))
+        }
+
+        if newCount != bandCount {
+            z1 = [Float](repeating: 0, count: newCount)
+            z2 = [Float](repeating: 0, count: newCount)
+            bandCount = newCount
+        }
+
+        coeffs = newCoeffs
+    }
+
+    /// Process audio samples in-place using Direct Form II Transposed.
+    /// Called on the Core Audio IO thread.
+    func process(_ buffer: UnsafeMutablePointer<Float>, frameCount: Int) {
+        for b in 0..<bandCount {
+            let c = coeffs[b]
+            var s1 = z1[b]
+            var s2 = z2[b]
+
+            for f in 0..<frameCount {
+                let x = buffer[f]
+                let y = c.b0 * x + s1
+                s1 = c.b1 * x - c.a1 * y + s2
+                s2 = c.b2 * x - c.a2 * y
+                buffer[f] = y
+            }
+
+            // Flush denormals to zero
+            if abs(s1) < 1e-15 { s1 = 0 }
+            if abs(s2) < 1e-15 { s2 = 0 }
+
+            z1[b] = s1
+            z2[b] = s2
+        }
+    }
+
+    /// Reset all filter state (e.g., when switching presets to avoid transients).
+    func reset() {
+        for i in 0..<bandCount {
+            z1[i] = 0
+            z2[i] = 0
+        }
+    }
+}

--- a/Sources/iQualize/EQModels.swift
+++ b/Sources/iQualize/EQModels.swift
@@ -37,6 +37,13 @@ enum FilterType: String, Codable, CaseIterable, Equatable, Sendable {
     }
 }
 
+// MARK: - EQ Channel
+
+enum EQChannel: String, Codable, Sendable {
+    case left
+    case right
+}
+
 // MARK: - EQ Band
 
 struct EQBand: Codable, Equatable, Sendable {
@@ -67,10 +74,42 @@ struct EQPresetData: Codable, Equatable, Sendable, Identifiable {
     let id: UUID
     var name: String
     var bands: [EQBand]
+    /// Right channel bands. When nil, the preset is in linked (stereo) mode.
+    /// When non-nil, `bands` represents the left channel and `rightBands` the right.
+    var rightBands: [EQBand]?
     let isBuiltIn: Bool
 
     var isFlat: Bool {
-        bands.allSatisfy { $0.gain == 0 && $0.filterType == .parametric }
+        let bandsFlat = bands.allSatisfy { $0.gain == 0 && $0.filterType == .parametric }
+        guard let right = rightBands else { return bandsFlat }
+        return bandsFlat && right.allSatisfy { $0.gain == 0 && $0.filterType == .parametric }
+    }
+
+    var isSplitChannel: Bool { rightBands != nil }
+
+    func bands(for channel: EQChannel) -> [EQBand] {
+        switch channel {
+        case .left: return bands
+        case .right: return rightBands ?? bands
+        }
+    }
+
+    mutating func setBands(_ newBands: [EQBand], for channel: EQChannel) {
+        switch channel {
+        case .left: bands = newBands
+        case .right: rightBands = newBands
+        }
+    }
+
+    /// Enable split channel mode by copying current bands to right channel.
+    mutating func enableSplitChannel() {
+        guard rightBands == nil else { return }
+        rightBands = bands
+    }
+
+    /// Disable split channel mode, keeping left channel bands.
+    mutating func disableSplitChannel() {
+        rightBands = nil
     }
 }
 

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -15,6 +15,8 @@ struct iQualizeState: Codable {
     var hideFromDock: Bool
     var startAtLogin: Bool
     var balance: Float
+    var splitChannelEnabled: Bool
+    var activeChannel: String?
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -28,12 +30,14 @@ struct iQualizeState: Codable {
         postEqSpectrumEnabled: false,
         hideFromDock: false,
         startAtLogin: false,
-        balance: 0.0
+        balance: 0.0,
+        splitChannelEnabled: false,
+        activeChannel: nil
     )
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -46,6 +50,8 @@ struct iQualizeState: Codable {
         self.hideFromDock = hideFromDock
         self.startAtLogin = startAtLogin
         self.balance = balance
+        self.splitChannelEnabled = splitChannelEnabled
+        self.activeChannel = activeChannel
     }
 
     init(from decoder: Decoder) throws {
@@ -62,6 +68,8 @@ struct iQualizeState: Codable {
         hideFromDock = (try? container.decode(Bool.self, forKey: .hideFromDock)) ?? false
         startAtLogin = (try? container.decode(Bool.self, forKey: .startAtLogin)) ?? false
         balance = (try? container.decode(Float.self, forKey: .balance)) ?? 0.0
+        splitChannelEnabled = (try? container.decode(Bool.self, forKey: .splitChannelEnabled)) ?? false
+        activeChannel = try? container.decode(String.self, forKey: .activeChannel)
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -69,6 +69,8 @@ final class ClickThroughView: NSView {
 @MainActor
 final class FrequencyResponseView: NSView {
     private var bands: [EQBand] = []
+    /// Bands for the inactive channel in split mode (nil when in linked mode).
+    private var inactiveBands: [EQBand]?
     private var maxGainDB: Float = 12
     private var sampleRate: Double = 48000
     private var autoScale: Bool = true
@@ -117,7 +119,8 @@ final class FrequencyResponseView: NSView {
     /// All band sliders — used to compute column center X at draw time.
     var allSliders: [NSSlider] = []
 
-    func updateBands(_ bands: [EQBand], maxGainDB: Float, sampleRate: Double, autoScale: Bool) {
+    func updateBands(_ bands: [EQBand], rightBands: [EQBand]? = nil, maxGainDB: Float, sampleRate: Double, autoScale: Bool) {
+        self.inactiveBands = rightBands
         let targetGains = bands.map { $0.gain }
 
         // Resize displayGains to match new band count, lerping instead of snapping
@@ -727,6 +730,33 @@ final class FrequencyResponseView: NSView {
             ctx.strokePath()
         }
 
+        // ── 5b. Inactive channel curve (split mode only) ──
+
+        if let inactiveBands, !inactiveBands.isEmpty {
+            let inactiveGains = BiquadResponse.compositeResponse(
+                bands: inactiveBands, sampleRate: sampleRate, frequencies: frequencies
+            )
+            let inactivePts: [CGPoint] = zip(frequencies, inactiveGains).map { freq, gain in
+                let t = log10(freq / 20.0) / 3.0
+                let clamped = clampToDisplayRange(Float(gain))
+                let x = CGFloat(t) * plotRect.width + plotRect.minX
+                let y = gainToY(clamped, height: plotRect.height) + plotRect.minY
+                return CGPoint(x: x, y: y)
+            }
+
+            if !inactivePts.isEmpty {
+                let inactivePath = CGMutablePath()
+                inactivePath.move(to: inactivePts[0])
+                for pt in inactivePts.dropFirst() { inactivePath.addLine(to: pt) }
+                ctx.setStrokeColor(NSColor.systemOrange.withAlphaComponent(0.30).cgColor)
+                ctx.setLineWidth(1.0)
+                ctx.setLineDash(phase: 0, lengths: [3, 2])
+                ctx.addPath(inactivePath)
+                ctx.strokePath()
+                ctx.setLineDash(phase: 0, lengths: [])
+            }
+        }
+
         // ── 6. Anchor dots ──
 
         if isBackdrop {
@@ -1210,6 +1240,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var postEqSpectrumCheckbox: NSButton!
     private var balanceSlider: NSSlider!
     private var balanceValueLabel: NSTextField!
+    private var channelSegment: NSSegmentedControl!
+    private var activeChannel: EQChannel = .left
     /// Effective max gain: 24 dB when auto-scale is on, otherwise the user-selected value.
     private var effectiveMaxGainDB: Float {
         (autoScaleCheckbox?.state == .on) ? 24 : audioEngine.maxGainDB
@@ -1266,7 +1298,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             guard let self else { return false }
             if self.window?.firstResponder is NSTextView { return false }
 
-            let bands = self.audioEngine.activePreset.bands
+            let bands = self.activeBands
             guard !bands.isEmpty else { return false }
 
             switch event.keyCode {
@@ -1578,6 +1610,23 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         balanceSeparator.boxType = .separator
         balanceSeparator.widthAnchor.constraint(equalToConstant: 1).isActive = true
 
+        // Channel mode segmented control: Linked / L / R
+        channelSegment = NSSegmentedControl(labels: ["Linked", "L", "R"], trackingMode: .selectOne,
+                                            target: self, action: #selector(channelSegmentChanged(_:)))
+        channelSegment.controlSize = .small
+        channelSegment.font = .systemFont(ofSize: 10)
+        if savedState.splitChannelEnabled {
+            activeChannel = EQChannel(rawValue: savedState.activeChannel ?? "left") ?? .left
+            channelSegment.selectedSegment = activeChannel == .right ? 2 : 1
+            audioEngine.splitChannelActive = true
+        } else {
+            channelSegment.selectedSegment = 0
+        }
+
+        let channelSeparator = NSBox()
+        channelSeparator.boxType = .separator
+        channelSeparator.widthAnchor.constraint(equalToConstant: 1).isActive = true
+
         bottomRow.addArrangedSubview(bypassCheckbox)
         bottomRow.addArrangedSubview(preEqSpectrumCheckbox)
         bottomRow.addArrangedSubview(postEqSpectrumCheckbox)
@@ -1586,6 +1635,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         bottomRow.addArrangedSubview(balanceSlider)
         bottomRow.addArrangedSubview(balanceLabelR)
         bottomRow.addArrangedSubview(balanceValueLabel)
+        bottomRow.addArrangedSubview(channelSeparator)
+        bottomRow.addArrangedSubview(channelSegment)
         bottomRow.addArrangedSubview(spacer)
         bottomRow.addArrangedSubview(maxGainLabel)
         bottomRow.addArrangedSubview(maxGainPicker)
@@ -1619,7 +1670,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         qLabels.removeAll()
         filterTypePickers.removeAll()
 
-        let bands = audioEngine.activePreset.bands
+        let bands = activeBands
         let canAdd = bands.count < EQPresetData.maxBandCount
 
         for (i, band) in bands.enumerated() {
@@ -1639,9 +1690,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             gainLabel.setContentHuggingPriority(.required, for: .vertical)
             gainLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 50).isActive = true
             gainLabel.onFocus = { [weak self] in
-                guard let self, i < self.audioEngine.activePreset.bands.count else { return }
+                guard let self, i < self.activeBands.count else { return }
                 self.selectBand(nil)
-                gainLabel.stringValue = Self.formatRawFloat(self.audioEngine.activePreset.bands[i].gain)
+                gainLabel.stringValue = Self.formatRawFloat(self.activeBands[i].gain)
             }
             gainLabel.onScroll = { [weak self] direction in
                 self?.scrollAdjustGain(at: i, direction: direction)
@@ -1673,9 +1724,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             freqLabel.setContentHuggingPriority(.required, for: .vertical)
             freqLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 50).isActive = true
             freqLabel.onFocus = { [weak self] in
-                guard let self, i < self.audioEngine.activePreset.bands.count else { return }
+                guard let self, i < self.activeBands.count else { return }
                 self.selectBand(nil)
-                freqLabel.stringValue = Self.formatRawFloat(self.audioEngine.activePreset.bands[i].frequency)
+                freqLabel.stringValue = Self.formatRawFloat(self.activeBands[i].frequency)
             }
             freqLabel.onScroll = { [weak self] direction in
                 self?.scrollAdjustFrequency(at: i, direction: direction)
@@ -1692,9 +1743,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             qLabel.setContentHuggingPriority(.required, for: .vertical)
             qLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 50).isActive = true
             qLabel.onFocus = { [weak self] in
-                guard let self, i < self.audioEngine.activePreset.bands.count else { return }
+                guard let self, i < self.activeBands.count else { return }
                 self.selectBand(nil)
-                qLabel.stringValue = Self.formatRawFloat(self.audioEngine.activePreset.bands[i].bandwidth)
+                qLabel.stringValue = Self.formatRawFloat(self.activeBands[i].bandwidth)
             }
             qLabel.onScroll = { [weak self] direction in
                 self?.scrollAdjustBandwidth(at: i, direction: direction)
@@ -1821,6 +1872,21 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         isModified = false
         resetButton.isEnabled = false
         populatePresetPicker()
+
+        // Sync split channel state to match the loaded preset
+        if audioEngine.activePreset.isSplitChannel {
+            if !audioEngine.splitChannelActive {
+                audioEngine.splitChannelActive = true
+            }
+            channelSegment.selectedSegment = activeChannel == .right ? 2 : 1
+        } else {
+            if audioEngine.splitChannelActive {
+                audioEngine.splitChannelActive = false
+            }
+            activeChannel = .left
+            channelSegment.selectedSegment = 0
+        }
+
         buildSliders()
         updateDeleteButton()
         updateOutputLabel()
@@ -1836,7 +1902,14 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
 
     private func updateCurveView() {
-        curveView.updateBands(audioEngine.activePreset.bands, maxGainDB: effectiveMaxGainDB, sampleRate: audioEngine.outputSampleRate, autoScale: autoScaleCheckbox.state == .on)
+        let preset = audioEngine.activePreset
+        curveView.updateBands(
+            activeBands,
+            rightBands: preset.isSplitChannel ? preset.bands(for: activeChannel == .left ? .right : .left) : nil,
+            maxGainDB: effectiveMaxGainDB,
+            sampleRate: audioEngine.outputSampleRate,
+            autoScale: autoScaleCheckbox.state == .on
+        )
     }
 
     private func populatePresetPicker() {
@@ -1898,6 +1971,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             id: UUID(),
             name: forkName,
             bands: audioEngine.activePreset.bands,
+            rightBands: audioEngine.activePreset.rightBands,
             isBuiltIn: false
         )
         audioEngine.activePreset = custom
@@ -1990,7 +2064,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
 
     private func moveBandSelection(forward: Bool) {
-        let count = audioEngine.activePreset.bands.count
+        let count = activeBands.count
         guard count > 0 else { return }
 
         let newIndex: Int
@@ -2026,37 +2100,33 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     private func adjustGainViaKeyboard(delta: Float) {
         guard let index = selectedBandIndex,
-              index < audioEngine.activePreset.bands.count else { return }
+              index < activeBands.count else { return }
         beginKeyboardAdjustIfNeeded()
         forkIfBuiltIn()
 
-        var preset = audioEngine.activePreset
-        let maxDB = audioEngine.maxGainDB
-        let newGain = min(max(preset.bands[index].gain + delta, -maxDB), maxDB)
-        guard newGain != preset.bands[index].gain else { return }
+        let maxDB = effectiveMaxGainDB
+        let newGain = min(max(activeBands[index].gain + delta, -maxDB), maxDB)
+        guard newGain != activeBands[index].gain else { return }
 
-        preset.bands[index].gain = newGain
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in bands[index].gain = newGain }
         sliders[index].doubleValue = Double(newGain)
-        gainLabels[index].stringValue = preset.bands[index].gainLabel
+        gainLabels[index].stringValue = activeBands[index].gainLabel
         markModified()
         updateCurveView()
     }
 
     private func adjustFrequencyViaKeyboard(up: Bool) {
         guard let index = selectedBandIndex,
-              index < audioEngine.activePreset.bands.count else { return }
+              index < activeBands.count else { return }
         beginKeyboardAdjustIfNeeded()
         forkIfBuiltIn()
 
-        var preset = audioEngine.activePreset
         let semitone: Float = pow(2.0, 1.0 / 12.0)
         let factor = up ? semitone : (1.0 / semitone)
-        let newFreq = min(max(preset.bands[index].frequency * factor, 20), 20000)
+        let newFreq = min(max(activeBands[index].frequency * factor, 20), 20000)
 
-        preset.bands[index].frequency = newFreq
-        audioEngine.activePreset = preset
-        freqLabels[index].stringValue = preset.bands[index].frequencyLabel
+        modifyActivePresetBands { bands in bands[index].frequency = newFreq }
+        freqLabels[index].stringValue = activeBands[index].frequencyLabel
         markModified()
         updateCurveView()
     }
@@ -2064,54 +2134,48 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     // MARK: - Scroll Wheel Adjustments
 
     private func scrollAdjustGain(at index: Int, direction: CGFloat) {
-        guard index < audioEngine.activePreset.bands.count else { return }
+        guard index < activeBands.count else { return }
         beginKeyboardAdjustIfNeeded()
         forkIfBuiltIn()
 
-        var preset = audioEngine.activePreset
-        let maxDB = audioEngine.maxGainDB
+        let maxDB = effectiveMaxGainDB
         let delta: Float = direction > 0 ? 0.5 : -0.5
-        let newGain = min(max(preset.bands[index].gain + delta, -maxDB), maxDB)
-        guard newGain != preset.bands[index].gain else { return }
+        let newGain = min(max(activeBands[index].gain + delta, -maxDB), maxDB)
+        guard newGain != activeBands[index].gain else { return }
 
-        preset.bands[index].gain = newGain
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in bands[index].gain = newGain }
         sliders[index].doubleValue = Double(newGain)
-        gainLabels[index].stringValue = preset.bands[index].gainLabel
+        gainLabels[index].stringValue = activeBands[index].gainLabel
         markModified()
         updateCurveView()
     }
 
     private func scrollAdjustFrequency(at index: Int, direction: CGFloat) {
-        guard index < audioEngine.activePreset.bands.count else { return }
+        guard index < activeBands.count else { return }
         beginKeyboardAdjustIfNeeded()
         forkIfBuiltIn()
 
-        var preset = audioEngine.activePreset
         let semitone: Float = pow(2.0, 1.0 / 12.0)
         let factor = direction > 0 ? semitone : (1.0 / semitone)
-        let newFreq = min(max(preset.bands[index].frequency * factor, 20), 20000)
+        let newFreq = min(max(activeBands[index].frequency * factor, 20), 20000)
 
-        preset.bands[index].frequency = newFreq
-        audioEngine.activePreset = preset
-        freqLabels[index].stringValue = preset.bands[index].frequencyLabel
+        modifyActivePresetBands { bands in bands[index].frequency = newFreq }
+        freqLabels[index].stringValue = activeBands[index].frequencyLabel
         markModified()
         updateCurveView()
     }
 
     private func scrollAdjustBandwidth(at index: Int, direction: CGFloat) {
-        guard index < audioEngine.activePreset.bands.count else { return }
+        guard index < activeBands.count else { return }
         beginKeyboardAdjustIfNeeded()
         forkIfBuiltIn()
 
-        var preset = audioEngine.activePreset
         let delta: Float = direction > 0 ? 0.1 : -0.1
-        let newQ = min(max(preset.bands[index].bandwidth + delta, 0.1), 10)
-        guard newQ != preset.bands[index].bandwidth else { return }
+        let newQ = min(max(activeBands[index].bandwidth + delta, 0.1), 10)
+        guard newQ != activeBands[index].bandwidth else { return }
 
-        preset.bands[index].bandwidth = newQ
-        audioEngine.activePreset = preset
-        qLabels[index].stringValue = preset.bands[index].bandwidthLabel
+        modifyActivePresetBands { bands in bands[index].bandwidth = newQ }
+        qLabels[index].stringValue = activeBands[index].bandwidthLabel
         markModified()
         updateCurveView()
     }
@@ -2145,6 +2209,88 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         } else {
             balanceValueLabel.stringValue = "\(Int(value * 100))R"
         }
+    }
+
+    // MARK: - Split Channel Helpers
+
+    /// The bands for the currently active channel (or left/only bands in linked mode).
+    private var activeBands: [EQBand] {
+        audioEngine.activePreset.bands(for: activeChannel)
+    }
+
+    /// Modify the active channel's band at the given index in-place.
+    private func modifyActivePresetBands(_ transform: (inout [EQBand]) -> Void) {
+        var preset = audioEngine.activePreset
+        var bands = preset.bands(for: activeChannel)
+        transform(&bands)
+        preset.setBands(bands, for: activeChannel)
+        audioEngine.activePreset = preset
+    }
+
+    @objc private func channelSegmentChanged(_ sender: NSSegmentedControl) {
+        let oldPreset = audioEngine.activePreset
+        var state = iQualizeState.load()
+
+        switch sender.selectedSegment {
+        case 0: // Linked
+            if audioEngine.activePreset.isSplitChannel {
+                let preset = audioEngine.activePreset
+                let leftBands = preset.bands(for: .left)
+                let rightBands = preset.bands(for: .right)
+
+                if leftBands != rightBands {
+                    let alert = NSAlert()
+                    alert.messageText = "Merge to Linked Mode?"
+                    alert.informativeText = "The right channel has different EQ settings. Switching to Linked will keep only the left channel's bands."
+                    alert.addButton(withTitle: "Reset to Left")
+                    alert.addButton(withTitle: "Cancel")
+                    alert.alertStyle = .warning
+
+                    let response = alert.runModal()
+                    if response == .alertSecondButtonReturn {
+                        // Revert segmented control to previous selection
+                        sender.selectedSegment = activeChannel == .right ? 2 : 1
+                        return
+                    }
+                }
+
+                var mutablePreset = preset
+                mutablePreset.disableSplitChannel()
+                audioEngine.activePreset = mutablePreset
+                audioEngine.splitChannelActive = false
+            }
+            activeChannel = .left
+            state.splitChannelEnabled = false
+            state.activeChannel = nil
+        case 1: // L
+            activeChannel = .left
+            if !audioEngine.activePreset.isSplitChannel {
+                var preset = audioEngine.activePreset
+                preset.enableSplitChannel()
+                audioEngine.activePreset = preset
+                audioEngine.splitChannelActive = true
+            }
+            state.splitChannelEnabled = true
+            state.activeChannel = EQChannel.left.rawValue
+        case 2: // R
+            activeChannel = .right
+            if !audioEngine.activePreset.isSplitChannel {
+                var preset = audioEngine.activePreset
+                preset.enableSplitChannel()
+                audioEngine.activePreset = preset
+                audioEngine.splitChannelActive = true
+            }
+            state.splitChannelEnabled = true
+            state.activeChannel = EQChannel.right.rawValue
+        default:
+            break
+        }
+
+        state.save()
+        buildSliders()
+        updateCurveView()
+        markModified()
+        registerUndo("Change Channel Mode", oldPreset: oldPreset)
     }
 
     @objc private func toggleBypass(_ sender: NSButton) {
@@ -2198,26 +2344,23 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
 
     @objc private func addBandAtIndex(_ sender: NSMenuItem) {
-        guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        guard activeBands.count < EQPresetData.maxBandCount else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
 
         let insertionIndex: Int
         if sender.tag >= 0 {
-            // "Add Band to Left" — insert at this index
             insertionIndex = sender.tag
         } else {
-            // "Add Band to Right" — negative tag encodes -(originalIndex + 1), insert after
             insertionIndex = (-sender.tag - 1) + 1
         }
 
-        let clampedIndex = min(insertionIndex, preset.bands.count)
-        // Use the band the user clicked as the reference (for "right", look back one index)
-        let refIndex = sender.tag >= 0 ? clampedIndex : max(0, clampedIndex - 1)
-        let reference = refIndex < preset.bands.count ? preset.bands[refIndex] : (preset.bands.last ?? EQBand(frequency: 1000, gain: 0))
-        preset.bands.insert(EQBand(frequency: reference.frequency, gain: reference.gain, bandwidth: reference.bandwidth, filterType: reference.filterType), at: clampedIndex)
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in
+            let clampedIndex = min(insertionIndex, bands.count)
+            let refIndex = sender.tag >= 0 ? clampedIndex : max(0, clampedIndex - 1)
+            let reference = refIndex < bands.count ? bands[refIndex] : (bands.last ?? EQBand(frequency: 1000, gain: 0))
+            bands.insert(EQBand(frequency: reference.frequency, gain: reference.gain, bandwidth: reference.bandwidth, filterType: reference.filterType), at: clampedIndex)
+        }
         buildSliders()
         markModified()
         registerUndo("Add Band", oldPreset: oldPreset)
@@ -2225,14 +2368,14 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     private func reorderBand(from: Int, to: Int) {
         guard from != to,
-              from < audioEngine.activePreset.bands.count,
-              to <= audioEngine.activePreset.bands.count else { return }
+              from < activeBands.count,
+              to <= activeBands.count else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        let band = preset.bands.remove(at: from)
-        preset.bands.insert(band, at: to)
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in
+            let band = bands.remove(at: from)
+            bands.insert(band, at: to)
+        }
         buildSliders()
         markModified()
         registerUndo("Reorder Band", oldPreset: oldPreset)
@@ -2240,12 +2383,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     @objc private func moveBandLeft(_ sender: NSMenuItem) {
         let index = sender.tag
-        guard index > 0, index < audioEngine.activePreset.bands.count else { return }
+        guard index > 0, index < activeBands.count else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        preset.bands.swapAt(index, index - 1)
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in bands.swapAt(index, index - 1) }
         buildSliders()
         markModified()
         registerUndo("Move Band Left", oldPreset: oldPreset)
@@ -2253,12 +2394,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     @objc private func moveBandRight(_ sender: NSMenuItem) {
         let index = sender.tag
-        guard index < audioEngine.activePreset.bands.count - 1 else { return }
+        guard index < activeBands.count - 1 else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        preset.bands.swapAt(index, index + 1)
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in bands.swapAt(index, index + 1) }
         buildSliders()
         markModified()
         registerUndo("Move Band Right", oldPreset: oldPreset)
@@ -2266,10 +2405,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     @objc private func deleteBandFromMenu(_ sender: NSMenuItem) {
         let index = sender.tag
-        guard index < audioEngine.activePreset.bands.count,
-              audioEngine.activePreset.bands.count > EQPresetData.minBandCount else { return }
+        guard index < activeBands.count,
+              activeBands.count > EQPresetData.minBandCount else { return }
 
-        let band = audioEngine.activePreset.bands[index]
+        let band = activeBands[index]
         let alert = NSAlert()
         alert.messageText = "Delete Band?"
         alert.informativeText = "Remove the \(band.frequencyLabel) band at \(band.gainLabel)?"
@@ -2281,50 +2420,61 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        preset.bands.remove(at: index)
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in bands.remove(at: index) }
         buildSliders()
         markModified()
         registerUndo("Delete Band", oldPreset: oldPreset)
     }
 
     @objc private func addBandLeft(_ sender: Any) {
-        guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        guard activeBands.count < EQPresetData.maxBandCount else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        let leftmost = preset.bands.first ?? EQBand(frequency: 100, gain: 0)
-        preset.bands.insert(EQBand(frequency: leftmost.frequency, gain: leftmost.gain, bandwidth: leftmost.bandwidth, filterType: leftmost.filterType), at: 0)
-        audioEngine.activePreset = preset
+        let leftmost = activeBands.first ?? EQBand(frequency: 100, gain: 0)
+        modifyActivePresetBands { bands in
+            bands.insert(EQBand(frequency: leftmost.frequency, gain: leftmost.gain, bandwidth: leftmost.bandwidth, filterType: leftmost.filterType), at: 0)
+        }
         buildSliders()
         markModified()
         registerUndo("Add Band", oldPreset: oldPreset)
     }
 
     @objc private func addBandRight(_ sender: Any) {
-        guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        guard activeBands.count < EQPresetData.maxBandCount else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        let rightmost = preset.bands.last ?? EQBand(frequency: 1000, gain: 0)
-        preset.bands.append(EQBand(frequency: rightmost.frequency, gain: rightmost.gain, bandwidth: rightmost.bandwidth, filterType: rightmost.filterType))
-        audioEngine.activePreset = preset
+        let rightmost = activeBands.last ?? EQBand(frequency: 1000, gain: 0)
+        modifyActivePresetBands { bands in
+            bands.append(EQBand(frequency: rightmost.frequency, gain: rightmost.gain, bandwidth: rightmost.bandwidth, filterType: rightmost.filterType))
+        }
         buildSliders()
         markModified()
         registerUndo("Add Band", oldPreset: oldPreset)
     }
 
     @objc private func addSuggestedBand(_ sender: NSMenuItem) {
-        guard audioEngine.activePreset.bands.count < EQPresetData.maxBandCount else { return }
+        guard activeBands.count < EQPresetData.maxBandCount else { return }
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        let freq = preset.suggestNewBandFrequency()
-        let newBand = EQBand(frequency: freq, gain: 0, bandwidth: 1.0)
-        let insertIndex = preset.bands.firstIndex(where: { $0.frequency > freq }) ?? preset.bands.count
-        preset.bands.insert(newBand, at: insertIndex)
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in
+            // Find the largest frequency gap in the active channel's bands
+            let sorted = bands.map(\.frequency).sorted()
+            var bestFreq: Float = 1000
+            var bestGap: Float = 0
+            if !sorted.isEmpty {
+                bestFreq = sorted[0] / 2; bestGap = log2(sorted[0] / 20)
+                for i in 1..<sorted.count {
+                    let gap = log2(sorted[i] / sorted[i - 1])
+                    if gap > bestGap { bestGap = gap; bestFreq = sqrt(sorted[i] * sorted[i - 1]) }
+                }
+                let topGap = log2(20000 / sorted.last!)
+                if topGap > bestGap { bestFreq = sorted.last! * 2 }
+                bestFreq = min(max(bestFreq, 20), 20000)
+            }
+            let newBand = EQBand(frequency: bestFreq, gain: 0, bandwidth: 1.0)
+            let insertIndex = bands.firstIndex(where: { $0.frequency > bestFreq }) ?? bands.count
+            bands.insert(newBand, at: insertIndex)
+        }
         buildSliders()
         markModified()
         registerUndo("Add Band", oldPreset: oldPreset)
@@ -2339,9 +2489,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     func controlTextDidEndEditing(_ notification: Notification) {
         guard let field = notification.object as? UnitTextField else { return }
         let index = field.tag
-        guard index < audioEngine.activePreset.bands.count else { return }
+        guard index < activeBands.count else { return }
 
-        let band = audioEngine.activePreset.bands[index]
+        let band = activeBands[index]
 
         if gainLabels.contains(field) {
             let text = field.stringValue.trimmingCharacters(in: .whitespaces)
@@ -2351,15 +2501,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                 if clamped != band.gain {
                     let oldPreset = audioEngine.activePreset
                     forkIfBuiltIn()
-                    var preset = audioEngine.activePreset
-                    preset.bands[index].gain = clamped
-                    audioEngine.activePreset = preset
+                    modifyActivePresetBands { bands in bands[index].gain = clamped }
                     sliders[index].doubleValue = Double(clamped)
                     markModified()
                     registerUndo("Change Gain", oldPreset: oldPreset)
                 }
             }
-            field.stringValue = audioEngine.activePreset.bands[index].gainLabel
+            field.stringValue = activeBands[index].gainLabel
         } else if freqLabels.contains(field) {
             let text = field.stringValue.trimmingCharacters(in: .whitespaces)
             if let value = Float(text) {
@@ -2367,14 +2515,12 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                 if clamped != band.frequency {
                     let oldPreset = audioEngine.activePreset
                     forkIfBuiltIn()
-                    var preset = audioEngine.activePreset
-                    preset.bands[index].frequency = clamped
-                    audioEngine.activePreset = preset
+                    modifyActivePresetBands { bands in bands[index].frequency = clamped }
                     markModified()
                     registerUndo("Change Frequency", oldPreset: oldPreset)
                 }
             }
-            field.stringValue = audioEngine.activePreset.bands[index].frequencyLabel
+            field.stringValue = activeBands[index].frequencyLabel
         } else if qLabels.contains(field) {
             let text = field.stringValue.trimmingCharacters(in: .whitespaces)
             if let value = Float(text), value > 0 {
@@ -2382,14 +2528,12 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                 if clamped != band.bandwidth {
                     let oldPreset = audioEngine.activePreset
                     forkIfBuiltIn()
-                    var preset = audioEngine.activePreset
-                    preset.bands[index].bandwidth = clamped
-                    audioEngine.activePreset = preset
+                    modifyActivePresetBands { bands in bands[index].bandwidth = clamped }
                     markModified()
                     registerUndo("Change Bandwidth", oldPreset: oldPreset)
                 }
             }
-            field.stringValue = audioEngine.activePreset.bands[index].bandwidthLabel
+            field.stringValue = activeBands[index].bandwidthLabel
         }
         updateCurveView()
     }
@@ -2400,17 +2544,30 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
               let preset = presetStore.preset(for: id) else { return }
         audioEngine.activePreset = preset
         savedPresetSnapshot = preset
+
+        // Sync split channel state to match the loaded preset
+        if preset.isSplitChannel {
+            audioEngine.splitChannelActive = true
+            if activeChannel != .left && activeChannel != .right { activeChannel = .left }
+            channelSegment.selectedSegment = activeChannel == .right ? 2 : 1
+        } else {
+            audioEngine.splitChannelActive = false
+            activeChannel = .left
+            channelSegment.selectedSegment = 0
+        }
+
         buildSliders()
         updateDeleteButton()
         isModified = false
         resetButton.isEnabled = false
         updateWindowTitle()
+        updateCurveView()
         saveState()
     }
 
     @objc private func sliderMoved(_ sender: NSSlider) {
         let index = sender.tag
-        guard index < audioEngine.activePreset.bands.count else { return }
+        guard index < activeBands.count else { return }
 
         // Snapshot at drag start for coalesced undo
         if sliderDragSnapshot == nil {
@@ -2418,13 +2575,14 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         }
 
         forkIfBuiltIn()
-        let gain = Float(sender.doubleValue)
+        let maxDB = effectiveMaxGainDB
+        let gain = min(max(Float(sender.doubleValue), -maxDB), maxDB)
 
-        var preset = audioEngine.activePreset
-        preset.bands[index].gain = gain
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in
+            bands[index].gain = gain
+        }
 
-        gainLabels[index].stringValue = preset.bands[index].gainLabel
+        gainLabels[index].stringValue = activeBands[index].gainLabel
         updateCurveView()
         markModified()
 
@@ -2438,17 +2596,17 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     @objc private func filterTypeChanged(_ sender: NSPopUpButton) {
         let index = sender.tag
-        guard index < audioEngine.activePreset.bands.count,
+        guard index < activeBands.count,
               let selectedType = sender.selectedItem?.representedObject as? FilterType else { return }
 
-        let band = audioEngine.activePreset.bands[index]
+        let band = activeBands[index]
         guard selectedType != band.filterType else { return }
 
         let oldPreset = audioEngine.activePreset
         forkIfBuiltIn()
-        var preset = audioEngine.activePreset
-        preset.bands[index].filterType = selectedType
-        audioEngine.activePreset = preset
+        modifyActivePresetBands { bands in
+            bands[index].filterType = selectedType
+        }
         updateCurveView()
         markModified()
         registerUndo("Change Filter Type", oldPreset: oldPreset)
@@ -2534,6 +2692,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             id: UUID(),
             name: name,
             bands: audioEngine.activePreset.bands,
+            rightBands: audioEngine.activePreset.rightBands,
             isBuiltIn: false
         )
         presetStore.saveCustomPreset(newPreset)
@@ -2670,7 +2829,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
                     presetStore.deleteCustomPreset(id: existing.id)
                 }
 
-                let preset = EQPresetData(id: UUID(), name: importName, bands: decoded.bands, isBuiltIn: false)
+                let preset = EQPresetData(id: UUID(), name: importName, bands: decoded.bands, rightBands: decoded.rightBands, isBuiltIn: false)
                 presetStore.saveCustomPreset(preset)
                 lastImported = preset
                 importCount += 1

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.19.0</string>
+	<string>0.20.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.19</string>
+	<string>0.20.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Adds independent left/right channel EQ via custom biquad filters in the render callback, since `AVAudioUnitEQ` has no per-channel API
- New channel segmented control (Linked/L/R) with dual frequency response curves and full preset/undo support
- Confirmation dialog when switching to Linked mode with different L/R bands to prevent silent data loss
- Consistent gain clamping across all input methods (slider, keyboard, scroll, text field)

Fixes #48