### PR TITLE
feat: menu bar UX improvements and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ open /Applications/iQualize.app
 - Axis labels and detailed frequency/dB grid overlay
 - Catmull-Rom spline interpolation connecting slider knob positions (dashed gray line)
 - Adjustable max gain range: ±6, ±12, ±18, or ±24 dB — or auto-scale to fit the current curve (up to ±24 dB)
+- Input gain (±24 dB) — pre-EQ level control for proper gain staging
+- Output gain (±24 dB) — post-EQ level control, applied before the peak limiter
 - Dynamic peak limiter (AUPeakLimiter) — prevents digital clipping at 0 dBFS
 - Smooth, glitch-free parameter updates — only changed values are written to the audio unit
 
@@ -113,13 +115,14 @@ Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (Q factor — 
 
 ### Menu Bar
 
+- Open iQualize (Cmd+,) — first item in the menu for quick access
+- Option+click the menu bar icon to open the EQ window directly (skips the menu)
 - Presets submenu with checkmarks and active preset name in parent item
 - Bypass EQ toggle (Cmd+B) — pass audio through unprocessed
 - Peak Limiter toggle
 - Hide from Dock toggle — run as a menu bar-only app
 - Start at Login toggle — launch automatically when you log in
 - Current output device display
-- Open EQ window (Cmd+,)
 - About iQualize — shows version info
 
 ### Spectrum Analyzer
@@ -167,6 +170,13 @@ iQualize uses Core Audio Taps (CATap), introduced in macOS 14.2, to intercept sy
 │                            ▼                    │
 │                    AVAudioUnitEQ                 │
 │                    (parametric EQ)               │
+│                            │                    │
+│                            ▼                    │
+│                    Output Gain Node              │
+│                    (AVAudioUnitEQ, 0 bands)      │
+│                            │                    │
+│                            ▼                    │
+│                    AUPeakLimiter                  │
 │                            │                    │
 │                            ▼                    │
 │                    Output Device                 │

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -20,6 +20,7 @@ nonisolated(unsafe) private var rtScratchBuffer: UnsafeMutablePointer<Float>?
 nonisolated(unsafe) private var rtScratchCapacity: Int = 0
 nonisolated(unsafe) private var rtBalanceLeft: Float = 1.0
 nonisolated(unsafe) private var rtBalanceRight: Float = 1.0
+nonisolated(unsafe) private var rtInputGain: Float = 1.0
 /// Per-channel biquad filter chains for split channel mode.
 /// Only active when rtSplitChannelActive is true.
 /// Channels 2+ (e.g. 5.1/7.1 surround) pass through unprocessed — per-channel
@@ -59,7 +60,7 @@ private func renderCallback(
         let channelIndex = i
         let gain = channelIndex == 0 ? rtBalanceLeft : rtBalanceRight
         for f in 0..<frames {
-            outData[f] = scratch[f * ch + channelIndex] * gain
+            outData[f] = scratch[f * ch + channelIndex] * rtInputGain * gain
         }
     }
 
@@ -92,6 +93,7 @@ final class AudioEngine {
     private var procID: AudioDeviceIOProcID?
     private var engine: AVAudioEngine?
     private var eq: AVAudioUnitEQ?
+    private var outputGainEQ: AVAudioUnitEQ?
     private var limiter: AVAudioUnitEffect?
     private var ringBuffer: AudioRingBuffer?
     private var tapUUID = UUID()
@@ -131,6 +133,16 @@ final class AudioEngine {
             rtSplitChannelActive = splitChannelActive
             applyBands()
         }
+    }
+
+    var inputGainDB: Float = 0.0 {
+        didSet {
+            rtInputGain = powf(10, inputGainDB / 20)
+        }
+    }
+
+    var outputGainDB: Float = 0.0 {
+        didSet { outputGainEQ?.globalGain = outputGainDB }
     }
 
     var maxGainDB: Float = 12
@@ -345,11 +357,17 @@ final class AudioEngine {
         limiterNode.bypass = !peakLimiter || bypassed
         self.limiter = limiterNode
 
+        let outputGainNode = AVAudioUnitEQ(numberOfBands: 0)
+        outputGainNode.globalGain = outputGainDB
+        self.outputGainEQ = outputGainNode
+
         avEngine.attach(sourceNode)
         avEngine.attach(eqNode)
+        avEngine.attach(outputGainNode)
         avEngine.attach(limiterNode)
         avEngine.connect(sourceNode, to: eqNode, format: format)
-        avEngine.connect(eqNode, to: limiterNode, format: format)
+        avEngine.connect(eqNode, to: outputGainNode, format: format)
+        avEngine.connect(outputGainNode, to: limiterNode, format: format)
         avEngine.connect(limiterNode, to: avEngine.outputNode, format: format)
 
         try avEngine.start()

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -17,6 +17,8 @@ struct iQualizeState: Codable {
     var balance: Float
     var splitChannelEnabled: Bool
     var activeChannel: String?
+    var inputGainDB: Float
+    var outputGainDB: Float
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -32,12 +34,14 @@ struct iQualizeState: Codable {
         startAtLogin: false,
         balance: 0.0,
         splitChannelEnabled: false,
-        activeChannel: nil
+        activeChannel: nil,
+        inputGainDB: 0.0,
+        outputGainDB: 0.0
     )
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -52,6 +56,8 @@ struct iQualizeState: Codable {
         self.balance = balance
         self.splitChannelEnabled = splitChannelEnabled
         self.activeChannel = activeChannel
+        self.inputGainDB = inputGainDB
+        self.outputGainDB = outputGainDB
     }
 
     init(from decoder: Decoder) throws {
@@ -70,6 +76,8 @@ struct iQualizeState: Codable {
         balance = (try? container.decode(Float.self, forKey: .balance)) ?? 0.0
         splitChannelEnabled = (try? container.decode(Bool.self, forKey: .splitChannelEnabled)) ?? false
         activeChannel = try? container.decode(String.self, forKey: .activeChannel)
+        inputGainDB = (try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0.0
+        outputGainDB = (try? container.decode(Float.self, forKey: .outputGainDB)) ?? 0.0
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -1241,6 +1241,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     private var balanceSlider: NSSlider!
     private var balanceValueLabel: NSTextField!
     private var channelSegment: NSSegmentedControl!
+    private var inputGainSlider: NSSlider!
+    private var inputGainValueLabel: NSTextField!
+    private var outputGainSlider: NSSlider!
+    private var outputGainValueLabel: NSTextField!
     private var activeChannel: EQChannel = .left
     /// Effective max gain: 24 dB when auto-scale is on, otherwise the user-selected value.
     private var effectiveMaxGainDB: Float {
@@ -1627,6 +1631,54 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         channelSeparator.boxType = .separator
         channelSeparator.widthAnchor.constraint(equalToConstant: 1).isActive = true
 
+        // Input gain slider
+        let inputGainSeparator = NSBox()
+        inputGainSeparator.boxType = .separator
+        inputGainSeparator.widthAnchor.constraint(equalToConstant: 1).isActive = true
+
+        let inputGainLabel = NSTextField(labelWithString: "In:")
+        inputGainLabel.font = .systemFont(ofSize: 11)
+
+        inputGainSlider = NSSlider(value: Double(savedState.inputGainDB), minValue: -24, maxValue: 24,
+                                   target: self, action: #selector(inputGainChanged(_:)))
+        inputGainSlider.isContinuous = true
+        inputGainSlider.widthAnchor.constraint(equalToConstant: 80).isActive = true
+
+        let inputGainDoubleClick = NSClickGestureRecognizer(target: self, action: #selector(resetInputGain(_:)))
+        inputGainDoubleClick.numberOfClicksRequired = 2
+        inputGainSlider.addGestureRecognizer(inputGainDoubleClick)
+
+        inputGainValueLabel = NSTextField(labelWithString: "0 dB")
+        inputGainValueLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        inputGainValueLabel.textColor = .secondaryLabelColor
+        inputGainValueLabel.widthAnchor.constraint(equalToConstant: 36).isActive = true
+        inputGainValueLabel.alignment = .center
+        updateInputGainLabel(savedState.inputGainDB)
+
+        audioEngine.inputGainDB = savedState.inputGainDB
+
+        // Output gain slider
+        let outputGainLabel = NSTextField(labelWithString: "Out:")
+        outputGainLabel.font = .systemFont(ofSize: 11)
+
+        outputGainSlider = NSSlider(value: Double(savedState.outputGainDB), minValue: -24, maxValue: 24,
+                                    target: self, action: #selector(outputGainChanged(_:)))
+        outputGainSlider.isContinuous = true
+        outputGainSlider.widthAnchor.constraint(equalToConstant: 80).isActive = true
+
+        let outputGainDoubleClick = NSClickGestureRecognizer(target: self, action: #selector(resetOutputGain(_:)))
+        outputGainDoubleClick.numberOfClicksRequired = 2
+        outputGainSlider.addGestureRecognizer(outputGainDoubleClick)
+
+        outputGainValueLabel = NSTextField(labelWithString: "0 dB")
+        outputGainValueLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        outputGainValueLabel.textColor = .secondaryLabelColor
+        outputGainValueLabel.widthAnchor.constraint(equalToConstant: 36).isActive = true
+        outputGainValueLabel.alignment = .center
+        updateOutputGainLabel(savedState.outputGainDB)
+
+        audioEngine.outputGainDB = savedState.outputGainDB
+
         bottomRow.addArrangedSubview(bypassCheckbox)
         bottomRow.addArrangedSubview(preEqSpectrumCheckbox)
         bottomRow.addArrangedSubview(postEqSpectrumCheckbox)
@@ -1637,6 +1689,13 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         bottomRow.addArrangedSubview(balanceValueLabel)
         bottomRow.addArrangedSubview(channelSeparator)
         bottomRow.addArrangedSubview(channelSegment)
+        bottomRow.addArrangedSubview(inputGainSeparator)
+        bottomRow.addArrangedSubview(inputGainLabel)
+        bottomRow.addArrangedSubview(inputGainSlider)
+        bottomRow.addArrangedSubview(inputGainValueLabel)
+        bottomRow.addArrangedSubview(outputGainLabel)
+        bottomRow.addArrangedSubview(outputGainSlider)
+        bottomRow.addArrangedSubview(outputGainValueLabel)
         bottomRow.addArrangedSubview(spacer)
         bottomRow.addArrangedSubview(maxGainLabel)
         bottomRow.addArrangedSubview(maxGainPicker)
@@ -2208,6 +2267,66 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
             balanceValueLabel.stringValue = "\(Int(-value * 100))L"
         } else {
             balanceValueLabel.stringValue = "\(Int(value * 100))R"
+        }
+    }
+
+    @objc private func inputGainChanged(_ sender: NSSlider) {
+        var value = Float(sender.doubleValue)
+        if abs(value) < 0.5 { value = 0; sender.doubleValue = 0 }
+        audioEngine.inputGainDB = value
+        updateInputGainLabel(value)
+        var state = iQualizeState.load()
+        state.inputGainDB = value
+        state.save()
+    }
+
+    @objc private func resetInputGain(_ sender: NSClickGestureRecognizer) {
+        inputGainSlider.doubleValue = 0
+        audioEngine.inputGainDB = 0
+        updateInputGainLabel(0)
+        var state = iQualizeState.load()
+        state.inputGainDB = 0
+        state.save()
+    }
+
+    private func updateInputGainLabel(_ value: Float) {
+        let rounded = Int(value.rounded())
+        if rounded == 0 {
+            inputGainValueLabel.stringValue = "0 dB"
+        } else if rounded > 0 {
+            inputGainValueLabel.stringValue = "+\(rounded) dB"
+        } else {
+            inputGainValueLabel.stringValue = "\(rounded) dB"
+        }
+    }
+
+    @objc private func outputGainChanged(_ sender: NSSlider) {
+        var value = Float(sender.doubleValue)
+        if abs(value) < 0.5 { value = 0; sender.doubleValue = 0 }
+        audioEngine.outputGainDB = value
+        updateOutputGainLabel(value)
+        var state = iQualizeState.load()
+        state.outputGainDB = value
+        state.save()
+    }
+
+    @objc private func resetOutputGain(_ sender: NSClickGestureRecognizer) {
+        outputGainSlider.doubleValue = 0
+        audioEngine.outputGainDB = 0
+        updateOutputGainLabel(0)
+        var state = iQualizeState.load()
+        state.outputGainDB = 0
+        state.save()
+    }
+
+    private func updateOutputGainLabel(_ value: Float) {
+        let rounded = Int(value.rounded())
+        if rounded == 0 {
+            outputGainValueLabel.stringValue = "0 dB"
+        } else if rounded > 0 {
+            outputGainValueLabel.stringValue = "+\(rounded) dB"
+        } else {
+            outputGainValueLabel.stringValue = "\(rounded) dB"
         }
     }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.1</string>
+	<string>0.21.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.20.1</string>
+	<string>0.21.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -52,6 +52,15 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     private func populateMenu(_ menu: NSMenu) {
         menu.removeAllItems()
 
+        // Open standalone window
+        let openItem = NSMenuItem(title: "Open iQualize",
+                                   action: #selector(openEQSettings(_:)), keyEquivalent: ",")
+        openItem.keyEquivalentModifierMask = [.command]
+        openItem.target = self
+        menu.addItem(openItem)
+
+        menu.addItem(.separator())
+
         // Presets submenu
         let presetMenuItem = NSMenuItem(title: "Presets (\(audioEngine.activePreset.name))",
                                          action: nil, keyEquivalent: "")
@@ -119,15 +128,6 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         loginItem.target = self
         loginItem.state = SMAppService.mainApp.status == .enabled ? .on : .off
         menu.addItem(loginItem)
-
-        menu.addItem(.separator())
-
-        // Open standalone window
-        let openItem = NSMenuItem(title: "Open iQualize",
-                                   action: #selector(openEQSettings(_:)), keyEquivalent: ",")
-        openItem.keyEquivalentModifierMask = [.command]
-        openItem.target = self
-        menu.addItem(openItem)
 
         menu.addItem(.separator())
 

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -46,6 +46,12 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     // MARK: - NSMenuDelegate — build menu fresh each time it opens
 
     func menuNeedsUpdate(_ menu: NSMenu) {
+        if NSEvent.modifierFlags.contains(.option) {
+            menu.removeAllItems()
+            menu.cancelTracking()
+            openEQWindow()
+            return
+        }
         populateMenu(menu)
     }
 


### PR DESCRIPTION
## Summary
- Move "Open iQualize" to the top of the menu bar dropdown for quick access
- Add Option+click on menu bar icon to open EQ window directly (skips menu)
- Update README with input/output gain docs, Option+click shortcut, and updated architecture diagram

Follow-up to #53.