### PR TITLE
chore: bump version and changelog (v0.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 All notable changes to iQualize will be documented in this file.
 
-## [0.23.0] - 2026-04-01
+## [0.24.0] - 2026-04-13
 
 ### Added
-- Q/Octave bandwidth display toggle — bandwidth values now display as Q factor (default) or octaves, with correct conversion using Audio EQ Cookbook formulas
 - Global Settings window — consolidates Peak Limiter, Max Gain, Auto Scale, Pre/Post-EQ Spectrum, Bandwidth mode, Hide from Dock, and Start at Login into a dedicated settings panel (Cmd+,)
 - Gear icon in EQ window bottom bar to open Settings directly
 - Two-row bottom bar layout — top row for session controls (bypass, gain, balance, channel mode), bottom row for display and audio settings
@@ -18,6 +17,11 @@ All notable changes to iQualize will be documented in this file.
 ### Fixed
 - `syncMaxGain` now calls `updateCurveView()` so the response curve redraws when gain range changes from Settings
 - Force-unwrap on `NSImage(systemSymbolName:)` replaced with safe fallback
+
+## [0.23.0] - 2026-04-01
+
+### Added
+- Q/Octave bandwidth display toggle — bandwidth values now display as Q factor (default) or octaves, with correct conversion using Audio EQ Cookbook formulas
 
 ## [0.22.0] - 2026-04-01
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.23.0</string>
+	<string>0.24.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.23.0</string>
+	<string>0.24</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Bump version to 0.24.0
- Add v0.24.0 changelog entry for the settings window and bottom bar redesign that landed in #56