### PR TITLE
feat: dock quit hides to menu bar instead of terminating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.27.0] - 2026-04-13
+
+### Changed
+- Dock quit now hides to menu bar instead of terminating — right-clicking the dock icon and choosing Quit closes windows and hides the dock icon, but iQualize keeps running in the menu bar with audio processing active. Use the menu bar's "Quit iQualize" or Cmd+Q to fully quit.
+
 ## [0.26.0] - 2026-04-13
 
 ### Added

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.26.0</string>
+	<string>0.27.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.26</string>
+	<string>0.27</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -220,6 +220,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
 
     @objc private func quit(_ sender: NSMenuItem) {
         audioEngine.stop()
+        (NSApp.delegate as? AppDelegate)?.isRealQuit = true
         NSApp.terminate(nil)
     }
 

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -65,7 +65,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateNow
         }
         // Dock quit: hide to menu bar instead of terminating
-        for window in NSApp.windows where window.isVisible {
+        // Only close titled windows (EQ, Settings) — not internal status item windows
+        for window in NSApp.windows where window.isVisible && window.styleMask.contains(.titled) {
             window.close()
         }
         NSApp.setActivationPolicy(.accessory)

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var audioEngine: AudioEngine!
     private var presetStore: PresetStore!
     private var wasRunningBeforeSleep = false
+    var isRealQuit = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Check screen/audio capture permission — CATap requires it
@@ -33,6 +34,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Sleep/wake handling
+        // System shutdown/restart — allow real termination
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.willPowerOffNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isRealQuit = true
+            }
+        }
+
+        // Sleep/wake handling
         NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.willSleepNotification, object: nil, queue: .main
         ) { [weak self] _ in
@@ -49,6 +60,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if isRealQuit {
+            return .terminateNow
+        }
+        // Dock quit: hide to menu bar instead of terminating
+        for window in NSApp.windows where window.isVisible {
+            window.close()
+        }
+        NSApp.setActivationPolicy(.accessory)
+        var state = iQualizeState.load()
+        state.hideFromDock = true
+        state.windowOpen = false
+        state.save()
+        return .terminateCancel
+    }
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !flag {
             menuBarController?.openEQWindow()
@@ -60,6 +87,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         audioEngine.stop()
     }
 
+    @objc func realQuit(_ sender: Any?) {
+        isRealQuit = true
+        NSApp.terminate(nil)
+    }
+
     private func setupMainMenu() {
         let mainMenu = NSMenu()
 
@@ -68,7 +100,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let appMenu = NSMenu()
         appMenu.addItem(withTitle: "About iQualize", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
         appMenu.addItem(.separator())
-        appMenu.addItem(withTitle: "Quit iQualize", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: "Quit iQualize", action: #selector(realQuit(_:)), keyEquivalent: "q")
+        quitItem.target = NSApp.delegate as? AppDelegate
+        appMenu.addItem(quitItem)
         appMenuItem.submenu = appMenu
         mainMenu.addItem(appMenuItem)
 


### PR DESCRIPTION
## Summary
- Dock right-click → Quit now closes windows and hides to menu bar instead of killing the app
- Audio processing stays active, menu bar icon remains accessible
- Menu bar "Quit iQualize" and Cmd+Q still fully terminate
- System shutdown/restart handled correctly via `willPowerOffNotification`
- Bump version to 0.27.0

## How it works
An `isRealQuit` flag on AppDelegate distinguishes dock quit (macOS-initiated, flag not set) from explicit quit (menu bar or Cmd+Q, flag set). `applicationShouldTerminate` checks the flag — returns `.terminateCancel` for dock quit (hides the app) or `.terminateNow` for real quit.

## Test plan
- [x] Build and launch with dock icon visible
- [x] Right-click dock → Quit → windows close, dock icon disappears, menu bar icon stays, audio keeps playing
- [x] Click menu bar icon → Open iQualize → window reopens
- [x] Menu bar → Quit iQualize → app fully terminates
- [x] Cmd+Q → app fully terminates