### PR TITLE
fix: resolve UI sync, keyboard shortcuts, and spectrum visibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.27.1] - 2026-04-23
+
+### Fixed
+- Menu bar preset changes now sync to the EQ window (picker, sliders, curve)
+- Spectrum lines visible in Light mode — pre-EQ is cyan, post-EQ is orange (previously both white, invisible on light backgrounds)
+- Cmd+B (Bypass EQ) and Cmd+, (Settings) now work as global keyboard shortcuts from the EQ window via the main menu bar
+- Pre/Post-EQ spectrum toggle state syncs from EQ window to Settings window
+- Dragging a slider selects that band for arrow key navigation
+
 ## [0.27.0] - 2026-04-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -106,29 +106,31 @@ Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (octaves, 0.05
 
 ### Keyboard & Scroll
 
-- Click a band to select it (accent-colored border indicator)
+- Click a band or drag its slider to select it (accent-colored border indicator)
 - Arrow Up/Down to adjust gain (±0.5 dB per step)
 - Arrow Left/Right to adjust frequency (semitone steps)
 - Tab / Shift+Tab to cycle between bands
 - Scroll wheel over sliders to adjust gain
 - Scroll wheel over frequency/Q inputs to adjust those values
+- Cmd+B — toggle Bypass EQ (works from the EQ window or menu bar)
+- Cmd+, — open Settings
 - Rapid adjustments coalesced into single undo entries
 
 ### Menu Bar
 
-- Open iQualize (Cmd+,) — first item in the menu for quick access
+- Open iQualize — first item in the menu for quick access
 - Option+click the menu bar icon to open the EQ window directly (skips the menu)
-- Presets submenu with checkmarks and active preset name in parent item
+- Presets submenu with checkmarks and active preset name in parent item — changes sync to the EQ window in real time
 - Bypass EQ toggle (Cmd+B) — pass audio through unprocessed
 - Current output device display
 - About iQualize — shows version info
 
 ### Settings
 
-Accessible via the gear icon in the EQ window or the Settings item in the menu bar.
+Accessible via the gear icon in the EQ window, the Settings item in the menu bar, or Cmd+,.
 
-- **Audio**: Peak Limiter toggle
-- **Display**: Q / Octave bandwidth display toggle
+- **Audio**: Peak Limiter toggle, Max Gain range (±6/12/18/24 dB), Auto Scale toggle
+- **Display**: Pre-EQ / Post-EQ spectrum toggles, Q / Octave bandwidth display toggle
 - **General**: Hide from Dock toggle, Start at Login toggle
 
 ### Spectrum Analyzer
@@ -138,7 +140,7 @@ Accessible via the gear icon in the EQ window or the Settings item in the menu b
 - 2048-point FFT via Accelerate vDSP with Hann windowing and log-frequency binning
 - Smooth Catmull-Rom spline rendering with peak hold lines
 - Lock-free double-buffered audio-to-UI transfer for glitch-free 60fps updates
-- Monochrome white/gray spectrum layers with z-ordered rendering; blue EQ response curve is the only colored element
+- Distinct spectrum colors: cyan for pre-EQ, orange for post-EQ — visible in both Light and Dark appearance modes
 - Spectrum toggle states persist across app restarts
 
 ### Stereo Balance

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -96,6 +96,15 @@ final class FrequencyResponseView: NSView {
         }
     }()
 
+    // Appearance-aware colors for spectrum and grid
+    private var isDarkAppearance: Bool {
+        effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+
+    private var preEqColor: NSColor { .systemCyan }
+    private var postEqColor: NSColor { .systemOrange }
+    private var gridColor: NSColor { isDarkAppearance ? .white : .black }
+
     // Animation state
     private var currentDisplayMax: Double = 12.0
     private var currentDisplayMin: Double = -12.0
@@ -328,7 +337,7 @@ final class FrequencyResponseView: NSView {
         ctx.saveGState()
         ctx.beginPath()
         addCatmullRomSpline(points, to: ctx, moveToStart: true)
-        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.40).cgColor)
+        ctx.setStrokeColor(preEqColor.withAlphaComponent(0.50).cgColor)
         ctx.setLineWidth(1.5)
         ctx.setLineJoin(.round)
         ctx.setLineCap(.round)
@@ -355,7 +364,7 @@ final class FrequencyResponseView: NSView {
         addCatmullRomSpline(points, to: ctx)
         ctx.addLine(to: CGPoint(x: points.last!.x, y: plotRect.minY))
         ctx.closePath()
-        ctx.setFillColor(NSColor.white.withAlphaComponent(0.15).cgColor)
+        ctx.setFillColor(postEqColor.withAlphaComponent(0.15).cgColor)
         ctx.fillPath()
         ctx.restoreGState()
 
@@ -363,7 +372,7 @@ final class FrequencyResponseView: NSView {
         ctx.saveGState()
         ctx.beginPath()
         addCatmullRomSpline(points, to: ctx, moveToStart: true)
-        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.50).cgColor)
+        ctx.setStrokeColor(postEqColor.withAlphaComponent(0.60).cgColor)
         ctx.setLineWidth(1.5)
         ctx.setLineJoin(.round)
         ctx.setLineCap(.round)
@@ -577,12 +586,12 @@ final class FrequencyResponseView: NSView {
             }
             if preEqSpectrumEnabled, let data = preEqSpectrumData {
                 drawSpectrumPeakHold(data, in: spectrumRect, ctx: ctx,
-                                     color: NSColor.white.withAlphaComponent(0.20),
+                                     color: preEqColor.withAlphaComponent(0.30),
                                      lineWidth: 1.0)
             }
             if postEqSpectrumEnabled, let data = postEqSpectrumData {
                 drawSpectrumPeakHold(data, in: spectrumRect, ctx: ctx,
-                                     color: NSColor.white.withAlphaComponent(0.25),
+                                     color: postEqColor.withAlphaComponent(0.35),
                                      lineWidth: 1.0)
             }
 
@@ -598,7 +607,7 @@ final class FrequencyResponseView: NSView {
 
         // Frequency grid (vertical lines)
         let freqGridLines: [Float] = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000]
-        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.04).cgColor)
+        ctx.setStrokeColor(gridColor.withAlphaComponent(0.04).cgColor)
         ctx.setLineWidth(0.5)
         for freq in freqGridLines {
             let x = freqToX(freq, width: plotRect.width) + plotRect.minX
@@ -620,10 +629,10 @@ final class FrequencyResponseView: NSView {
             guard y >= plotRect.minY && y <= plotRect.maxY else { dbLine += dbStep; continue }
             if abs(dbLine) < 0.1 {
                 // 0 dB line — brighter
-                ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.10).cgColor)
+                ctx.setStrokeColor(gridColor.withAlphaComponent(0.10).cgColor)
                 ctx.setLineWidth(0.75)
             } else {
-                ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.04).cgColor)
+                ctx.setStrokeColor(gridColor.withAlphaComponent(0.04).cgColor)
                 ctx.setLineWidth(0.5)
             }
             ctx.move(to: CGPoint(x: plotRect.minX, y: y))
@@ -794,7 +803,7 @@ final class FrequencyResponseView: NSView {
                 let compositeDBf = Float(compositeDB)
                 let labelAttrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.systemFont(ofSize: 8, weight: .regular),
-                    .foregroundColor: NSColor.white.withAlphaComponent(0.35),
+                    .foregroundColor: gridColor.withAlphaComponent(0.35),
                 ]
                 let dbText: String
                 if compositeDBf == Float(Int(compositeDBf)) {
@@ -836,7 +845,7 @@ final class FrequencyResponseView: NSView {
             let splinePath = CGMutablePath()
             splinePath.move(to: curvePoints[0])
             for pt in curvePoints.dropFirst() { splinePath.addLine(to: pt) }
-            ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.30).cgColor)
+            ctx.setStrokeColor(gridColor.withAlphaComponent(0.30).cgColor)
             ctx.setLineWidth(isBackdrop ? 0.75 : 1.0)
             ctx.setLineDash(phase: 0, lengths: [4, 3])
             ctx.addPath(splinePath)
@@ -882,7 +891,7 @@ final class FrequencyResponseView: NSView {
                 let compositeDBf = Float(compositeDB)
                 let labelAttrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.systemFont(ofSize: 8, weight: .regular),
-                    .foregroundColor: NSColor.white.withAlphaComponent(0.35),
+                    .foregroundColor: gridColor.withAlphaComponent(0.35),
                 ]
                 let dbText: String
                 if compositeDBf == Float(Int(compositeDBf)) {
@@ -907,7 +916,7 @@ final class FrequencyResponseView: NSView {
         if isBackdrop {
             let axisAttrs: [NSAttributedString.Key: Any] = [
                 .font: NSFont.systemFont(ofSize: 8, weight: .regular),
-                .foregroundColor: NSColor.white.withAlphaComponent(0.20),
+                .foregroundColor: gridColor.withAlphaComponent(0.20),
             ]
             let displayMaxInt = Int(round(currentDisplayMax))
             let displayMinInt = Int(round(currentDisplayMin))
@@ -1968,7 +1977,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     // MARK: - Sync UI ↔ Engine
 
-    private func syncUIToPreset() {
+    func syncUIToPreset() {
         savedPresetSnapshot = audioEngine.activePreset
         isModified = false
         resetButton.isEnabled = false
@@ -2548,6 +2557,10 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         if on { curveView.startAnimationIfNeeded() }
     }
 
+    func syncBypass(_ on: Bool) {
+        bypassCheckbox.state = on ? .on : .off
+    }
+
     func syncBandwidthMode(asQ: Bool) {
         showBandwidthAsQ = asQ
         bandwidthModeSegment.selectedSegment = asQ ? 0 : 1
@@ -2789,6 +2802,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     @objc private func sliderMoved(_ sender: NSSlider) {
         let index = sender.tag
         guard index < activeBands.count else { return }
+        selectBand(index)
 
         // Snapshot at drag start for coalesced undo
         if sliderDragSnapshot == nil {

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.27.0</string>
+	<string>0.27.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.27</string>
+	<string>0.27.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -159,6 +159,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         var s = iQualizeState.load()
         s.selectedPresetID = preset.id
         s.save()
+        eqWindowController?.syncUIToPreset()
     }
 
     @objc private func openEQSettings(_ sender: NSMenuItem) {
@@ -207,6 +208,25 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         s.bypassed = audioEngine.bypassed
         s.save()
         updateIcon()
+    }
+
+    func showSettings() {
+        if settingsWindowController == nil {
+            settingsWindowController = SettingsWindowController(
+                audioEngine: audioEngine, eqWindowController: eqWindowController)
+        }
+        settingsWindowController?.updateEQWindowController(eqWindowController)
+        settingsWindowController?.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func toggleBypassFromMenu() {
+        audioEngine.bypassed.toggle()
+        var s = iQualizeState.load()
+        s.bypassed = audioEngine.bypassed
+        s.save()
+        updateIcon()
+        eqWindowController?.syncBypass(audioEngine.bypassed)
     }
 
     @objc private func showAbout(_ sender: NSMenuItem) {

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -3,7 +3,7 @@ import ServiceManagement
 
 @available(macOS 14.2, *)
 @MainActor
-final class SettingsWindowController: NSWindowController {
+final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let audioEngine: AudioEngine
     private weak var eqWindowController: EQWindowController?
 
@@ -30,6 +30,7 @@ final class SettingsWindowController: NSWindowController {
         window.center()
 
         super.init(window: window)
+        window.delegate = self
 
         let contentView = buildContent()
         window.contentView = contentView
@@ -41,6 +42,17 @@ final class SettingsWindowController: NSWindowController {
 
     func updateEQWindowController(_ controller: EQWindowController?) {
         eqWindowController = controller
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        let state = iQualizeState.load()
+        peakLimiterCheckbox.state = audioEngine.peakLimiter ? .on : .off
+        maxGainPicker.selectItem(withTag: Int(audioEngine.maxGainDB))
+        autoScaleCheckbox.state = state.autoScale ? .on : .off
+        maxGainPicker.isEnabled = !state.autoScale
+        preEqCheckbox.state = state.preEqSpectrumEnabled ? .on : .off
+        postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
+        bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
     }
 
     private func buildContent() -> NSView {

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -5,7 +5,7 @@ import ServiceManagement
 
 @available(macOS 14.2, *)
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var menuBarController: MenuBarController!
     private var audioEngine: AudioEngine!
     private var presetStore: PresetStore!
@@ -93,6 +93,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.terminate(nil)
     }
 
+    @objc func openSettings(_ sender: Any?) {
+        menuBarController?.showSettings()
+    }
+
+    @objc func toggleBypass(_ sender: Any?) {
+        menuBarController?.toggleBypassFromMenu()
+    }
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(toggleBypass(_:)) {
+            menuItem.state = audioEngine?.bypassed == true ? .on : .off
+        }
+        return true
+    }
+
     private func setupMainMenu() {
         let mainMenu = NSMenu()
 
@@ -100,6 +115,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let appMenuItem = NSMenuItem()
         let appMenu = NSMenu()
         appMenu.addItem(withTitle: "About iQualize", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(.separator())
+        let settingsItem = NSMenuItem(title: "Settings…", action: #selector(openSettings(_:)), keyEquivalent: ",")
+        appMenu.addItem(settingsItem)
         appMenu.addItem(.separator())
         let quitItem = NSMenuItem(title: "Quit iQualize", action: #selector(realQuit(_:)), keyEquivalent: "q")
         quitItem.target = NSApp.delegate as? AppDelegate
@@ -120,6 +138,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
+
+        // Controls menu (Bypass EQ)
+        let controlsMenuItem = NSMenuItem()
+        let controlsMenu = NSMenu(title: "Controls")
+        let bypassItem = NSMenuItem(title: "Bypass EQ", action: #selector(toggleBypass(_:)), keyEquivalent: "b")
+        bypassItem.target = self
+        controlsMenu.addItem(bypassItem)
+        controlsMenuItem.submenu = controlsMenu
+        mainMenu.addItem(controlsMenuItem)
 
         NSApp.mainMenu = mainMenu
     }


### PR DESCRIPTION
## Summary

Addresses bugs 1-6 from #60:

- **Menu bar preset sync**: selecting a preset from the menu bar now updates the EQ window (picker, sliders, curve)
- **Spectrum visibility**: Pre-EQ (cyan) and Post-EQ (orange) spectrum lines are now visible in both Light and Dark mode with distinct colors; grid lines also adapt to appearance
- **CMD+B / CMD+,**: added Bypass EQ and Settings to the main menu bar so keyboard shortcuts work when the EQ window is focused
- **Settings sync**: Settings window refreshes checkbox state from source of truth on focus, fixing one-way sync from EQ window
- **Arrow key navigation**: dragging a slider now selects that band, enabling immediate arrow key adjustments

## Test plan

- [x] Change preset in menu bar → EQ window updates label, sliders, and curve
- [x] Toggle Light/Dark appearance → spectrum lines visible in both, Pre-EQ cyan, Post-EQ orange
- [x] CMD+B toggles bypass from EQ window, checkmark in Controls menu
- [x] CMD+, opens Settings from EQ window
- [x] Toggle Pre/Post EQ in main window → open Settings → checkboxes match
- [x] Drag a slider → arrow keys adjust that band's gain/frequency