### PR TITLE
feat(0.28.0): GitHub link, post-EQ bypass UX, custom spectrum colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.28.0] - 2026-05-01
+
+### Added
+- About iQualize alert now has a "View on GitHub" button that opens the project page in your default browser (#60)
+
 ## [0.27.1] - 2026-04-23
 
 ### Fixed

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.27.1</string>
+	<string>0.28.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.27.1</string>
+	<string>0.28.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -235,7 +235,12 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         alert.informativeText = "System-wide audio equalizer for macOS.\nVersion \(version)"
         alert.alertStyle = .informational
-        alert.runModal()
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "View on GitHub")
+        if alert.runModal() == .alertSecondButtonReturn,
+           let url = URL(string: "https://github.com/DariusCorvus/iqualize") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     @objc private func quit(_ sender: NSMenuItem) {


### PR DESCRIPTION
Four UX improvements bundled into 0.28.0, all prompted by feedback in #60.

## Summary
- **About iQualize → View on GitHub** button opens https://github.com/DariusCorvus/iqualize. OK stays the default. Addresses suggestion #7.
- **Post-EQ disabled while bypassed** — checkbox + color wells + reset buttons all disable when EQ is bypassed, since post-EQ would just mirror pre-EQ. User's enabled-preference is preserved across the bypass toggle. Bypass changes from any source (menu bar item, Cmd+B, EQ window checkbox) propagate to both windows.
- **Custom spectrum line colors** — Settings → Display now has a native `NSColorWell` next to each spectrum checkbox with a `↺` reset button. Picks persist as `#RRGGBB` sRGB strings; nil falls back to the dynamic system color (cyan / orange) which auto-adapts to dark/light mode.
- **Per-spectrum fill control** — each spectrum has a `Fill` checkbox in an indented sub-row plus its own fill color well + reset. Pre-EQ fill defaults off, Post-EQ fill defaults on (matches the previous look). Pre/post-EQ drawing is now unified through a single `drawSpectrumFillAndStroke` helper.

## Test plan
- [x] `swift build` succeeds
- [x] `bash install.sh` and app launches cleanly
- [ ] About iQualize: two buttons, Return dismisses, View on GitHub opens the repo
- [ ] Toggle bypass via menu bar / EQ window / Cmd+B → all Post-EQ controls (checkbox, line well, fill checkbox, fill well, both resets) disable everywhere; line + fill disappear
- [ ] Pre-EQ line well opens system color panel; pick a color → spectrum line redraws live; persists across relaunch
- [ ] Toggle Pre-EQ Fill on → cyan fill appears; turn off → fill disappears
- [ ] Pick a custom Pre-EQ fill color (different from line) → fill redraws independently of line
- [ ] Reset buttons return to system cyan / orange and clear the persisted hex
- [ ] Manually corrupt a hex value in state → app falls back to system color, no crash