### PR TITLE
feat: spectrum color customization, fill toggle, and bypass UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to iQualize will be documented in this file.
 
 ### Added
 - About iQualize alert now has a "View on GitHub" button that opens the project page in your default browser (#60)
+- Custom Pre-EQ and Post-EQ spectrum colors — each spectrum now has a color well in Settings → Display with a reset button to return to the dynamic system color
 
 ### Changed
 - Post-EQ Spectrum checkbox is disabled and the post-EQ line is hidden while EQ is bypassed (post-EQ would just mirror pre-EQ in that state); your preference is preserved and restored when bypass turns off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to iQualize will be documented in this file.
 ### Added
 - About iQualize alert now has a "View on GitHub" button that opens the project page in your default browser (#60)
 
+### Changed
+- Post-EQ Spectrum checkbox is disabled and the post-EQ line is hidden while EQ is bypassed (post-EQ would just mirror pre-EQ in that state); your preference is preserved and restored when bypass turns off
+
 ## [0.27.1] - 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to iQualize will be documented in this file.
 
 ### Added
 - About iQualize alert now has a "View on GitHub" button that opens the project page in your default browser (#60)
-- Custom Pre-EQ and Post-EQ spectrum colors — each spectrum now has a color well in Settings → Display with a reset button to return to the dynamic system color
+- Custom Pre-EQ and Post-EQ spectrum colors — each spectrum has a line color and an optional fill (with its own color) in Settings → Display, with reset buttons to return to the dynamic system color. Pre-EQ now supports fill too (off by default; Post-EQ defaults to on, matching the previous look)
 
 ### Changed
 - Post-EQ Spectrum checkbox is disabled and the post-EQ line is hidden while EQ is bypassed (post-EQ would just mirror pre-EQ in that state); your preference is preserved and restored when bypass turns off

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,4 @@ If the app fails to launch ("can't be opened" error), debug and fix before proce
 - `Sources/iQualize/BiquadResponse.swift` — biquad filter frequency response calculation (Audio EQ Cookbook)
 - `Sources/iQualize/SpectrumAnalyzer.swift` — real-time FFT spectrum analysis via Accelerate vDSP
 - `Sources/iQualize/SpectrumData.swift` — lock-free double-buffered audio-to-UI data transfer
+- `Sources/iQualize/ColorHex.swift` — NSColor ↔ #RRGGBB sRGB hex helpers for persisting user-picked spectrum colors

--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (octaves, 0.05
 - Open iQualize — first item in the menu for quick access
 - Option+click the menu bar icon to open the EQ window directly (skips the menu)
 - Presets submenu with checkmarks and active preset name in parent item — changes sync to the EQ window in real time
-- Bypass EQ toggle (Cmd+B) — pass audio through unprocessed
+- Bypass EQ toggle (Cmd+B) — pass audio through unprocessed; while bypassed, the Post-EQ spectrum line and its color/fill controls are hidden/disabled (post-EQ would otherwise just mirror pre-EQ)
 - Current output device display
-- About iQualize — shows version info
+- About iQualize — shows version and a "View on GitHub" button that opens the project page in your default browser
 
 ### Settings
 
 Accessible via the gear icon in the EQ window, the Settings item in the menu bar, or Cmd+,.
 
 - **Audio**: Peak Limiter toggle, Max Gain range (±6/12/18/24 dB), Auto Scale toggle
-- **Display**: Pre-EQ / Post-EQ spectrum toggles, Q / Octave bandwidth display toggle
+- **Display**: Pre-EQ / Post-EQ spectrum toggles, per-spectrum line color picker, per-spectrum Fill toggle with its own color picker, reset buttons to return to the dynamic system colors, Q / Octave bandwidth display toggle
 - **General**: Hide from Dock toggle, Start at Login toggle
 
 ### Spectrum Analyzer
@@ -140,8 +140,10 @@ Accessible via the gear icon in the EQ window, the Settings item in the menu bar
 - 2048-point FFT via Accelerate vDSP with Hann windowing and log-frequency binning
 - Smooth Catmull-Rom spline rendering with peak hold lines
 - Lock-free double-buffered audio-to-UI transfer for glitch-free 60fps updates
-- Distinct spectrum colors: cyan for pre-EQ, orange for post-EQ — visible in both Light and Dark appearance modes
-- Spectrum toggle states persist across app restarts
+- Customizable line and fill colors per spectrum (Settings → Display) — defaults to cyan for pre-EQ, orange for post-EQ, both adapting to Light and Dark appearance; reset returns to the dynamic system color
+- Per-spectrum fill toggle (off by default for pre-EQ, on for post-EQ) with its own color, independent from the line color
+- Post-EQ spectrum auto-hides when EQ bypass is active (post-EQ would otherwise just mirror pre-EQ)
+- Spectrum toggle states, fill toggles, and color choices persist across app restarts
 
 ### Stereo Balance
 

--- a/Sources/iQualize/ColorHex.swift
+++ b/Sources/iQualize/ColorHex.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+extension NSColor {
+    /// Returns "#RRGGBB" by converting to sRGB first; nil if conversion fails.
+    var srgbHexRGB: String? {
+        guard let c = usingColorSpace(.sRGB) else { return nil }
+        let r = Int(round(c.redComponent * 255))
+        let g = Int(round(c.greenComponent * 255))
+        let b = Int(round(c.blueComponent * 255))
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+
+    /// Parses "#RRGGBB" or "RRGGBB" into an sRGB NSColor; nil if malformed.
+    convenience init?(srgbHexRGB: String) {
+        var s = srgbHexRGB.trimmingCharacters(in: .whitespacesAndNewlines)
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let v = UInt32(s, radix: 16) else { return nil }
+        let r = CGFloat((v >> 16) & 0xFF) / 255.0
+        let g = CGFloat((v >> 8) & 0xFF) / 255.0
+        let b = CGFloat(v & 0xFF) / 255.0
+        self.init(srgbRed: r, green: g, blue: b, alpha: 1.0)
+    }
+}

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -20,6 +20,10 @@ struct iQualizeState: Codable {
     var inputGainDB: Float
     var outputGainDB: Float
     var showBandwidthAsQ: Bool
+    /// User-picked Pre-EQ spectrum color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
+    var preEqSpectrumColorHex: String?
+    /// User-picked Post-EQ spectrum color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
+    var postEqSpectrumColorHex: String?
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -43,7 +47,7 @@ struct iQualizeState: Codable {
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, showBandwidthAsQ: Bool = true) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, showBandwidthAsQ: Bool = true, preEqSpectrumColorHex: String? = nil, postEqSpectrumColorHex: String? = nil) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -61,6 +65,8 @@ struct iQualizeState: Codable {
         self.inputGainDB = inputGainDB
         self.outputGainDB = outputGainDB
         self.showBandwidthAsQ = showBandwidthAsQ
+        self.preEqSpectrumColorHex = preEqSpectrumColorHex
+        self.postEqSpectrumColorHex = postEqSpectrumColorHex
     }
 
     init(from decoder: Decoder) throws {
@@ -82,6 +88,8 @@ struct iQualizeState: Codable {
         inputGainDB = (try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0.0
         outputGainDB = (try? container.decode(Float.self, forKey: .outputGainDB)) ?? 0.0
         showBandwidthAsQ = (try? container.decode(Bool.self, forKey: .showBandwidthAsQ)) ?? true
+        preEqSpectrumColorHex = try? container.decode(String.self, forKey: .preEqSpectrumColorHex)
+        postEqSpectrumColorHex = try? container.decode(String.self, forKey: .postEqSpectrumColorHex)
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -20,10 +20,16 @@ struct iQualizeState: Codable {
     var inputGainDB: Float
     var outputGainDB: Float
     var showBandwidthAsQ: Bool
-    /// User-picked Pre-EQ spectrum color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
-    var preEqSpectrumColorHex: String?
-    /// User-picked Post-EQ spectrum color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
-    var postEqSpectrumColorHex: String?
+    /// User-picked Pre-EQ line color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
+    var preEqLineColorHex: String?
+    /// User-picked Post-EQ line color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
+    var postEqLineColorHex: String?
+    /// User-picked Pre-EQ fill color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
+    var preEqFillColorHex: String?
+    /// User-picked Post-EQ fill color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
+    var postEqFillColorHex: String?
+    var preEqFillEnabled: Bool
+    var postEqFillEnabled: Bool
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -42,12 +48,14 @@ struct iQualizeState: Codable {
         activeChannel: nil,
         inputGainDB: 0.0,
         outputGainDB: 0.0,
-        showBandwidthAsQ: true
+        showBandwidthAsQ: true,
+        preEqFillEnabled: false,
+        postEqFillEnabled: true
     )
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, showBandwidthAsQ: Bool = true, preEqSpectrumColorHex: String? = nil, postEqSpectrumColorHex: String? = nil) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -65,8 +73,12 @@ struct iQualizeState: Codable {
         self.inputGainDB = inputGainDB
         self.outputGainDB = outputGainDB
         self.showBandwidthAsQ = showBandwidthAsQ
-        self.preEqSpectrumColorHex = preEqSpectrumColorHex
-        self.postEqSpectrumColorHex = postEqSpectrumColorHex
+        self.preEqLineColorHex = preEqLineColorHex
+        self.postEqLineColorHex = postEqLineColorHex
+        self.preEqFillColorHex = preEqFillColorHex
+        self.postEqFillColorHex = postEqFillColorHex
+        self.preEqFillEnabled = preEqFillEnabled
+        self.postEqFillEnabled = postEqFillEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -88,8 +100,12 @@ struct iQualizeState: Codable {
         inputGainDB = (try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0.0
         outputGainDB = (try? container.decode(Float.self, forKey: .outputGainDB)) ?? 0.0
         showBandwidthAsQ = (try? container.decode(Bool.self, forKey: .showBandwidthAsQ)) ?? true
-        preEqSpectrumColorHex = try? container.decode(String.self, forKey: .preEqSpectrumColorHex)
-        postEqSpectrumColorHex = try? container.decode(String.self, forKey: .postEqSpectrumColorHex)
+        preEqLineColorHex = try? container.decode(String.self, forKey: .preEqLineColorHex)
+        postEqLineColorHex = try? container.decode(String.self, forKey: .postEqLineColorHex)
+        preEqFillColorHex = try? container.decode(String.self, forKey: .preEqFillColorHex)
+        postEqFillColorHex = try? container.decode(String.self, forKey: .postEqFillColorHex)
+        preEqFillEnabled = (try? container.decode(Bool.self, forKey: .preEqFillEnabled)) ?? false
+        postEqFillEnabled = (try? container.decode(Bool.self, forKey: .postEqFillEnabled)) ?? true
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -101,8 +101,8 @@ final class FrequencyResponseView: NSView {
         effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     }
 
-    private var preEqColor: NSColor { .systemCyan }
-    private var postEqColor: NSColor { .systemOrange }
+    var preEqColor: NSColor = .systemCyan { didSet { needsDisplay = true } }
+    var postEqColor: NSColor = .systemOrange { didSet { needsDisplay = true } }
     private var gridColor: NSColor { isDarkAppearance ? .white : .black }
 
     // Animation state
@@ -1615,6 +1615,12 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.postEqSpectrumData = audioEngine.postEqAnalyzer.spectrumData
         curveView.preEqSpectrumEnabled = savedState.preEqSpectrumEnabled
         curveView.postEqSpectrumEnabled = savedState.postEqSpectrumEnabled && !audioEngine.bypassed
+        if let hex = savedState.preEqSpectrumColorHex, let c = NSColor(srgbHexRGB: hex) {
+            curveView.preEqColor = c
+        }
+        if let hex = savedState.postEqSpectrumColorHex, let c = NSColor(srgbHexRGB: hex) {
+            curveView.postEqColor = c
+        }
         if savedState.preEqSpectrumEnabled || (savedState.postEqSpectrumEnabled && !audioEngine.bypassed) {
             curveView.startAnimationIfNeeded()
         }
@@ -2562,6 +2568,14 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         let effective = on && !audioEngine.bypassed
         curveView.postEqSpectrumEnabled = effective
         if effective { curveView.startAnimationIfNeeded() }
+    }
+
+    func syncPreEqSpectrumColor(_ color: NSColor) {
+        curveView.preEqColor = color
+    }
+
+    func syncPostEqSpectrumColor(_ color: NSColor) {
+        curveView.postEqColor = color
     }
 
     func syncBypass(_ on: Bool) {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -1263,6 +1263,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
     }
     /// Callback to open the settings window.
     var onOpenSettings: (() -> Void)?
+    /// Callback fired when the user toggles bypass from this window.
+    var onBypassChanged: (() -> Void)?
     private var outputLabel: NSTextField!
     private var newButton: NSButton!
     private var saveControl: NSSegmentedControl!
@@ -1600,6 +1602,7 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         postEqSpectrumCheckbox = NSButton(checkboxWithTitle: "Post-EQ",
                                            target: self, action: #selector(togglePostEqSpectrum(_:)))
         postEqSpectrumCheckbox.state = savedState.postEqSpectrumEnabled ? .on : .off
+        postEqSpectrumCheckbox.isEnabled = !audioEngine.bypassed
 
         bandwidthModeSegment = NSSegmentedControl(labels: ["Q", "Oct"], trackingMode: .selectOne,
                                                    target: self, action: #selector(bandwidthModeChanged(_:)))
@@ -1611,8 +1614,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.preEqSpectrumData = audioEngine.preEqAnalyzer.spectrumData
         curveView.postEqSpectrumData = audioEngine.postEqAnalyzer.spectrumData
         curveView.preEqSpectrumEnabled = savedState.preEqSpectrumEnabled
-        curveView.postEqSpectrumEnabled = savedState.postEqSpectrumEnabled
-        if savedState.preEqSpectrumEnabled || savedState.postEqSpectrumEnabled {
+        curveView.postEqSpectrumEnabled = savedState.postEqSpectrumEnabled && !audioEngine.bypassed
+        if savedState.preEqSpectrumEnabled || (savedState.postEqSpectrumEnabled && !audioEngine.bypassed) {
             curveView.startAnimationIfNeeded()
         }
 
@@ -2468,6 +2471,8 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         var state = iQualizeState.load()
         state.bypassed = audioEngine.bypassed
         state.save()
+        applyPostEqBypassState()
+        onBypassChanged?()
     }
 
     @objc private func toggleClipping(_ sender: NSButton) {
@@ -2506,8 +2511,9 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     @objc private func togglePostEqSpectrum(_ sender: NSButton) {
         let on = sender.state == .on
-        curveView.postEqSpectrumEnabled = on
-        if on { curveView.startAnimationIfNeeded() }
+        let effective = on && !audioEngine.bypassed
+        curveView.postEqSpectrumEnabled = effective
+        if effective { curveView.startAnimationIfNeeded() }
         var state = iQualizeState.load()
         state.postEqSpectrumEnabled = on
         state.save()
@@ -2553,12 +2559,24 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
 
     func syncPostEqSpectrum(_ on: Bool) {
         postEqSpectrumCheckbox.state = on ? .on : .off
-        curveView.postEqSpectrumEnabled = on
-        if on { curveView.startAnimationIfNeeded() }
+        let effective = on && !audioEngine.bypassed
+        curveView.postEqSpectrumEnabled = effective
+        if effective { curveView.startAnimationIfNeeded() }
     }
 
     func syncBypass(_ on: Bool) {
         bypassCheckbox.state = on ? .on : .off
+        applyPostEqBypassState()
+    }
+
+    /// Disables the Post-EQ checkbox and hides the post-EQ spectrum line when EQ is bypassed.
+    /// Restores both when bypass turns off, honoring the user's saved preference.
+    private func applyPostEqBypassState() {
+        let bypassed = audioEngine.bypassed
+        postEqSpectrumCheckbox.isEnabled = !bypassed
+        let effective = (postEqSpectrumCheckbox.state == .on) && !bypassed
+        curveView.postEqSpectrumEnabled = effective
+        if effective { curveView.startAnimationIfNeeded() }
     }
 
     func syncBandwidthMode(asQ: Bool) {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -101,8 +101,12 @@ final class FrequencyResponseView: NSView {
         effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     }
 
-    var preEqColor: NSColor = .systemCyan { didSet { needsDisplay = true } }
-    var postEqColor: NSColor = .systemOrange { didSet { needsDisplay = true } }
+    var preEqLineColor: NSColor = .systemCyan { didSet { needsDisplay = true } }
+    var preEqFillColor: NSColor = .systemCyan { didSet { needsDisplay = true } }
+    var postEqLineColor: NSColor = .systemOrange { didSet { needsDisplay = true } }
+    var postEqFillColor: NSColor = .systemOrange { didSet { needsDisplay = true } }
+    var preEqFillEnabled: Bool = false { didSet { needsDisplay = true } }
+    var postEqFillEnabled: Bool = true { didSet { needsDisplay = true } }
     private var gridColor: NSColor { isDarkAppearance ? .white : .black }
 
     // Animation state
@@ -323,56 +327,38 @@ final class FrequencyResponseView: NSView {
         }
     }
 
-    /// Draws the Pre-EQ spectrum stroke (no fill, no peak hold).
-    private func drawPreEqLine(
+    /// Draws a spectrum's optional fill and top edge stroke. Pass `fillColor: nil` to draw line-only.
+    private func drawSpectrumFillAndStroke(
         _ data: SpectrumData,
         in plotRect: CGRect,
-        ctx: CGContext
+        ctx: CGContext,
+        fillColor: NSColor?,
+        strokeColor: NSColor,
+        fillAlpha: CGFloat = 0.15,
+        strokeAlpha: CGFloat = 0.60
     ) {
         data.read(specMagnitudes, peaks: specPeaks)
 
         let points = spectrumPoints(specMagnitudes, in: plotRect)
         guard points.count >= 2 else { return }
 
+        if let fillColor {
+            ctx.saveGState()
+            ctx.beginPath()
+            ctx.move(to: CGPoint(x: points[0].x, y: plotRect.minY))
+            ctx.addLine(to: points[0])
+            addCatmullRomSpline(points, to: ctx)
+            ctx.addLine(to: CGPoint(x: points.last!.x, y: plotRect.minY))
+            ctx.closePath()
+            ctx.setFillColor(fillColor.withAlphaComponent(fillAlpha).cgColor)
+            ctx.fillPath()
+            ctx.restoreGState()
+        }
+
         ctx.saveGState()
         ctx.beginPath()
         addCatmullRomSpline(points, to: ctx, moveToStart: true)
-        ctx.setStrokeColor(preEqColor.withAlphaComponent(0.50).cgColor)
-        ctx.setLineWidth(1.5)
-        ctx.setLineJoin(.round)
-        ctx.setLineCap(.round)
-        ctx.strokePath()
-        ctx.restoreGState()
-    }
-
-    /// Draws the Post-EQ spectrum fill and edge stroke (no peak hold).
-    private func drawPostEqFillAndEdge(
-        _ data: SpectrumData,
-        in plotRect: CGRect,
-        ctx: CGContext
-    ) {
-        data.read(specMagnitudes, peaks: specPeaks)
-
-        let points = spectrumPoints(specMagnitudes, in: plotRect)
-        guard points.count >= 2 else { return }
-
-        // Filled area
-        ctx.saveGState()
-        ctx.beginPath()
-        ctx.move(to: CGPoint(x: points[0].x, y: plotRect.minY))
-        ctx.addLine(to: points[0])
-        addCatmullRomSpline(points, to: ctx)
-        ctx.addLine(to: CGPoint(x: points.last!.x, y: plotRect.minY))
-        ctx.closePath()
-        ctx.setFillColor(postEqColor.withAlphaComponent(0.15).cgColor)
-        ctx.fillPath()
-        ctx.restoreGState()
-
-        // Edge line
-        ctx.saveGState()
-        ctx.beginPath()
-        addCatmullRomSpline(points, to: ctx, moveToStart: true)
-        ctx.setStrokeColor(postEqColor.withAlphaComponent(0.60).cgColor)
+        ctx.setStrokeColor(strokeColor.withAlphaComponent(strokeAlpha).cgColor)
         ctx.setLineWidth(1.5)
         ctx.setLineJoin(.round)
         ctx.setLineCap(.round)
@@ -577,21 +563,31 @@ final class FrequencyResponseView: NSView {
             ctx.saveGState()
             ctx.clip(to: spectrumRect)
 
-            // Z-order: Pre-EQ line → Post-EQ fill+edge → Pre-EQ peak → Post-EQ peak
+            // Z-order: Pre-EQ fill+line → Post-EQ fill+line → Pre-EQ peak → Post-EQ peak
             if preEqSpectrumEnabled, let data = preEqSpectrumData {
-                drawPreEqLine(data, in: spectrumRect, ctx: ctx)
+                drawSpectrumFillAndStroke(
+                    data, in: spectrumRect, ctx: ctx,
+                    fillColor: preEqFillEnabled ? preEqFillColor : nil,
+                    strokeColor: preEqLineColor,
+                    strokeAlpha: 0.50
+                )
             }
             if postEqSpectrumEnabled, let data = postEqSpectrumData {
-                drawPostEqFillAndEdge(data, in: spectrumRect, ctx: ctx)
+                drawSpectrumFillAndStroke(
+                    data, in: spectrumRect, ctx: ctx,
+                    fillColor: postEqFillEnabled ? postEqFillColor : nil,
+                    strokeColor: postEqLineColor,
+                    strokeAlpha: 0.60
+                )
             }
             if preEqSpectrumEnabled, let data = preEqSpectrumData {
                 drawSpectrumPeakHold(data, in: spectrumRect, ctx: ctx,
-                                     color: preEqColor.withAlphaComponent(0.30),
+                                     color: preEqLineColor.withAlphaComponent(0.30),
                                      lineWidth: 1.0)
             }
             if postEqSpectrumEnabled, let data = postEqSpectrumData {
                 drawSpectrumPeakHold(data, in: spectrumRect, ctx: ctx,
-                                     color: postEqColor.withAlphaComponent(0.35),
+                                     color: postEqLineColor.withAlphaComponent(0.35),
                                      lineWidth: 1.0)
             }
 
@@ -1615,12 +1611,20 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         curveView.postEqSpectrumData = audioEngine.postEqAnalyzer.spectrumData
         curveView.preEqSpectrumEnabled = savedState.preEqSpectrumEnabled
         curveView.postEqSpectrumEnabled = savedState.postEqSpectrumEnabled && !audioEngine.bypassed
-        if let hex = savedState.preEqSpectrumColorHex, let c = NSColor(srgbHexRGB: hex) {
-            curveView.preEqColor = c
+        if let hex = savedState.preEqLineColorHex, let c = NSColor(srgbHexRGB: hex) {
+            curveView.preEqLineColor = c
         }
-        if let hex = savedState.postEqSpectrumColorHex, let c = NSColor(srgbHexRGB: hex) {
-            curveView.postEqColor = c
+        if let hex = savedState.postEqLineColorHex, let c = NSColor(srgbHexRGB: hex) {
+            curveView.postEqLineColor = c
         }
+        if let hex = savedState.preEqFillColorHex, let c = NSColor(srgbHexRGB: hex) {
+            curveView.preEqFillColor = c
+        }
+        if let hex = savedState.postEqFillColorHex, let c = NSColor(srgbHexRGB: hex) {
+            curveView.postEqFillColor = c
+        }
+        curveView.preEqFillEnabled = savedState.preEqFillEnabled
+        curveView.postEqFillEnabled = savedState.postEqFillEnabled
         if savedState.preEqSpectrumEnabled || (savedState.postEqSpectrumEnabled && !audioEngine.bypassed) {
             curveView.startAnimationIfNeeded()
         }
@@ -2570,13 +2574,12 @@ final class EQWindowController: NSWindowController, NSTextFieldDelegate {
         if effective { curveView.startAnimationIfNeeded() }
     }
 
-    func syncPreEqSpectrumColor(_ color: NSColor) {
-        curveView.preEqColor = color
-    }
-
-    func syncPostEqSpectrumColor(_ color: NSColor) {
-        curveView.postEqColor = color
-    }
+    func syncPreEqLineColor(_ color: NSColor)  { curveView.preEqLineColor  = color }
+    func syncPreEqFillColor(_ color: NSColor)  { curveView.preEqFillColor  = color }
+    func syncPreEqFillEnabled(_ on: Bool)      { curveView.preEqFillEnabled  = on }
+    func syncPostEqLineColor(_ color: NSColor) { curveView.postEqLineColor = color }
+    func syncPostEqFillColor(_ color: NSColor) { curveView.postEqFillColor = color }
+    func syncPostEqFillEnabled(_ on: Bool)     { curveView.postEqFillEnabled = on }
 
     func syncBypass(_ on: Bool) {
         bypassCheckbox.state = on ? .on : .off

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -182,6 +182,11 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
             eqWindowController?.onOpenSettings = { [weak self] in
                 self?.openSettings(NSMenuItem())
             }
+            eqWindowController?.onBypassChanged = { [weak self] in
+                guard let self = self else { return }
+                self.updateIcon()
+                self.settingsWindowController?.syncBypass(self.audioEngine.bypassed)
+            }
             // Track window close to persist state
             NotificationCenter.default.addObserver(
                 self, selector: #selector(windowDidClose(_:)),
@@ -208,6 +213,8 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         s.bypassed = audioEngine.bypassed
         s.save()
         updateIcon()
+        eqWindowController?.syncBypass(audioEngine.bypassed)
+        settingsWindowController?.syncBypass(audioEngine.bypassed)
     }
 
     func showSettings() {
@@ -227,6 +234,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         s.save()
         updateIcon()
         eqWindowController?.syncBypass(audioEngine.bypassed)
+        settingsWindowController?.syncBypass(audioEngine.bypassed)
     }
 
     @objc private func showAbout(_ sender: NSMenuItem) {

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -12,6 +12,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private var autoScaleCheckbox: NSButton!
     private var preEqCheckbox: NSButton!
     private var postEqCheckbox: NSButton!
+    private var preEqColorWell: NSColorWell!
+    private var postEqColorWell: NSColorWell!
+    private var preEqResetButton: NSButton!
+    private var postEqResetButton: NSButton!
     private var bandwidthModeSegment: NSSegmentedControl!
     private var hideFromDockCheckbox: NSButton!
     private var startAtLoginCheckbox: NSButton!
@@ -53,11 +57,17 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         preEqCheckbox.state = state.preEqSpectrumEnabled ? .on : .off
         postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
         postEqCheckbox.isEnabled = !audioEngine.bypassed
+        preEqColorWell.color = (state.preEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
+        postEqColorWell.color = (state.postEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
+        postEqColorWell.isEnabled = !audioEngine.bypassed
+        postEqResetButton.isEnabled = !audioEngine.bypassed
         bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
     }
 
     func syncBypass(_ on: Bool) {
         postEqCheckbox.isEnabled = !on
+        postEqColorWell.isEnabled = !on
+        postEqResetButton.isEnabled = !on
     }
 
     private func buildContent() -> NSView {
@@ -113,13 +123,25 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         preEqCheckbox = NSButton(checkboxWithTitle: "Pre-EQ Spectrum",
                                    target: self, action: #selector(togglePreEqSpectrum(_:)))
         preEqCheckbox.state = state.preEqSpectrumEnabled ? .on : .off
-        mainStack.addArrangedSubview(preEqCheckbox)
+        preEqColorWell = makeColorWell(action: #selector(preEqColorChanged(_:)))
+        preEqColorWell.color = (state.preEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
+        preEqResetButton = makeResetButton(action: #selector(resetPreEqColor(_:)))
+        mainStack.addArrangedSubview(makeSpectrumRow(checkbox: preEqCheckbox,
+                                                     colorWell: preEqColorWell,
+                                                     resetButton: preEqResetButton))
 
         postEqCheckbox = NSButton(checkboxWithTitle: "Post-EQ Spectrum",
                                     target: self, action: #selector(togglePostEqSpectrum(_:)))
         postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
         postEqCheckbox.isEnabled = !audioEngine.bypassed
-        mainStack.addArrangedSubview(postEqCheckbox)
+        postEqColorWell = makeColorWell(action: #selector(postEqColorChanged(_:)))
+        postEqColorWell.color = (state.postEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
+        postEqColorWell.isEnabled = !audioEngine.bypassed
+        postEqResetButton = makeResetButton(action: #selector(resetPostEqColor(_:)))
+        postEqResetButton.isEnabled = !audioEngine.bypassed
+        mainStack.addArrangedSubview(makeSpectrumRow(checkbox: postEqCheckbox,
+                                                     colorWell: postEqColorWell,
+                                                     resetButton: postEqResetButton))
 
         let bwRow = NSStackView()
         bwRow.orientation = .horizontal
@@ -157,6 +179,39 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         let label = NSTextField(labelWithString: title)
         label.font = .boldSystemFont(ofSize: 13)
         return label
+    }
+
+    private func makeColorWell(action: Selector) -> NSColorWell {
+        let well = NSColorWell(style: .minimal)
+        well.target = self
+        well.action = action
+        well.widthAnchor.constraint(equalToConstant: 24).isActive = true
+        well.heightAnchor.constraint(equalToConstant: 18).isActive = true
+        return well
+    }
+
+    private func makeResetButton(action: Selector) -> NSButton {
+        let image = NSImage(systemSymbolName: "arrow.counterclockwise",
+                            accessibilityDescription: "Reset to default")
+        let button = NSButton(image: image ?? NSImage(), target: self, action: action)
+        button.bezelStyle = .accessoryBarAction
+        button.isBordered = false
+        button.toolTip = "Reset to default"
+        return button
+    }
+
+    private func makeSpectrumRow(checkbox: NSButton, colorWell: NSColorWell, resetButton: NSButton) -> NSStackView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 6
+        row.alignment = .centerY
+        row.addArrangedSubview(checkbox)
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        row.addArrangedSubview(spacer)
+        row.addArrangedSubview(colorWell)
+        row.addArrangedSubview(resetButton)
+        return row
     }
 
     // MARK: - Actions
@@ -201,6 +256,38 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         state.postEqSpectrumEnabled = on
         state.save()
         eqWindowController?.syncPostEqSpectrum(on)
+    }
+
+    @objc private func preEqColorChanged(_ sender: NSColorWell) {
+        let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
+        var state = iQualizeState.load()
+        state.preEqSpectrumColorHex = srgb.srgbHexRGB
+        state.save()
+        eqWindowController?.syncPreEqSpectrumColor(srgb)
+    }
+
+    @objc private func postEqColorChanged(_ sender: NSColorWell) {
+        let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
+        var state = iQualizeState.load()
+        state.postEqSpectrumColorHex = srgb.srgbHexRGB
+        state.save()
+        eqWindowController?.syncPostEqSpectrumColor(srgb)
+    }
+
+    @objc private func resetPreEqColor(_ sender: NSButton) {
+        var state = iQualizeState.load()
+        state.preEqSpectrumColorHex = nil
+        state.save()
+        preEqColorWell.color = .systemCyan
+        eqWindowController?.syncPreEqSpectrumColor(.systemCyan)
+    }
+
+    @objc private func resetPostEqColor(_ sender: NSButton) {
+        var state = iQualizeState.load()
+        state.postEqSpectrumColorHex = nil
+        state.save()
+        postEqColorWell.color = .systemOrange
+        eqWindowController?.syncPostEqSpectrumColor(.systemOrange)
     }
 
     @objc private func bandwidthModeChanged(_ sender: NSSegmentedControl) {

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -227,9 +227,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         let image = NSImage(systemSymbolName: "arrow.counterclockwise",
                             accessibilityDescription: "Reset to default")
         let button = NSButton(image: image ?? NSImage(), target: self, action: action)
-        button.bezelStyle = .accessoryBarAction
         button.isBordered = false
         button.toolTip = "Reset to default"
+        button.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 16).isActive = true
         return button
     }
 

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -44,7 +44,8 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
         let contentView = buildContent()
         window.contentView = contentView
-        window.setContentSize(contentView.fittingSize)
+        let fitting = contentView.fittingSize
+        window.setContentSize(NSSize(width: max(fitting.width, 320), height: fitting.height))
     }
 
     @available(*, unavailable)

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -52,7 +52,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         maxGainPicker.isEnabled = !state.autoScale
         preEqCheckbox.state = state.preEqSpectrumEnabled ? .on : .off
         postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
+        postEqCheckbox.isEnabled = !audioEngine.bypassed
         bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
+    }
+
+    func syncBypass(_ on: Bool) {
+        postEqCheckbox.isEnabled = !on
     }
 
     private func buildContent() -> NSView {
@@ -113,6 +118,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         postEqCheckbox = NSButton(checkboxWithTitle: "Post-EQ Spectrum",
                                     target: self, action: #selector(togglePostEqSpectrum(_:)))
         postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
+        postEqCheckbox.isEnabled = !audioEngine.bypassed
         mainStack.addArrangedSubview(postEqCheckbox)
 
         let bwRow = NSStackView()

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -12,10 +12,16 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private var autoScaleCheckbox: NSButton!
     private var preEqCheckbox: NSButton!
     private var postEqCheckbox: NSButton!
-    private var preEqColorWell: NSColorWell!
-    private var postEqColorWell: NSColorWell!
-    private var preEqResetButton: NSButton!
-    private var postEqResetButton: NSButton!
+    private var preEqLineColorWell: NSColorWell!
+    private var postEqLineColorWell: NSColorWell!
+    private var preEqLineResetButton: NSButton!
+    private var postEqLineResetButton: NSButton!
+    private var preEqFillCheckbox: NSButton!
+    private var postEqFillCheckbox: NSButton!
+    private var preEqFillColorWell: NSColorWell!
+    private var postEqFillColorWell: NSColorWell!
+    private var preEqFillResetButton: NSButton!
+    private var postEqFillResetButton: NSButton!
     private var bandwidthModeSegment: NSSegmentedControl!
     private var hideFromDockCheckbox: NSButton!
     private var startAtLoginCheckbox: NSButton!
@@ -56,18 +62,25 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         maxGainPicker.isEnabled = !state.autoScale
         preEqCheckbox.state = state.preEqSpectrumEnabled ? .on : .off
         postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
-        postEqCheckbox.isEnabled = !audioEngine.bypassed
-        preEqColorWell.color = (state.preEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
-        postEqColorWell.color = (state.postEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
-        postEqColorWell.isEnabled = !audioEngine.bypassed
-        postEqResetButton.isEnabled = !audioEngine.bypassed
+        preEqLineColorWell.color = (state.preEqLineColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
+        postEqLineColorWell.color = (state.postEqLineColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
+        preEqFillCheckbox.state = state.preEqFillEnabled ? .on : .off
+        postEqFillCheckbox.state = state.postEqFillEnabled ? .on : .off
+        preEqFillColorWell.color = (state.preEqFillColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
+        postEqFillColorWell.color = (state.postEqFillColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
+        applyPostEqEnabled(!audioEngine.bypassed)
         bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
     }
 
     func syncBypass(_ on: Bool) {
-        postEqCheckbox.isEnabled = !on
-        postEqColorWell.isEnabled = !on
-        postEqResetButton.isEnabled = !on
+        applyPostEqEnabled(!on)
+    }
+
+    private func applyPostEqEnabled(_ enabled: Bool) {
+        for control in [postEqCheckbox, postEqLineColorWell, postEqLineResetButton,
+                        postEqFillCheckbox, postEqFillColorWell, postEqFillResetButton] as [NSControl] {
+            control.isEnabled = enabled
+        }
     }
 
     private func buildContent() -> NSView {
@@ -123,25 +136,45 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         preEqCheckbox = NSButton(checkboxWithTitle: "Pre-EQ Spectrum",
                                    target: self, action: #selector(togglePreEqSpectrum(_:)))
         preEqCheckbox.state = state.preEqSpectrumEnabled ? .on : .off
-        preEqColorWell = makeColorWell(action: #selector(preEqColorChanged(_:)))
-        preEqColorWell.color = (state.preEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
-        preEqResetButton = makeResetButton(action: #selector(resetPreEqColor(_:)))
-        mainStack.addArrangedSubview(makeSpectrumRow(checkbox: preEqCheckbox,
-                                                     colorWell: preEqColorWell,
-                                                     resetButton: preEqResetButton))
+        preEqLineColorWell = makeColorWell(action: #selector(preEqLineColorChanged(_:)))
+        preEqLineColorWell.color = (state.preEqLineColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
+        preEqLineResetButton = makeResetButton(action: #selector(resetPreEqLineColor(_:)))
+        preEqFillCheckbox = NSButton(checkboxWithTitle: "Fill",
+                                      target: self, action: #selector(togglePreEqFill(_:)))
+        preEqFillCheckbox.state = state.preEqFillEnabled ? .on : .off
+        preEqFillColorWell = makeColorWell(action: #selector(preEqFillColorChanged(_:)))
+        preEqFillColorWell.color = (state.preEqFillColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemCyan
+        preEqFillResetButton = makeResetButton(action: #selector(resetPreEqFillColor(_:)))
+        mainStack.addArrangedSubview(makeSpectrumGroup(
+            checkbox: preEqCheckbox,
+            lineWell: preEqLineColorWell, lineReset: preEqLineResetButton,
+            fillCheckbox: preEqFillCheckbox,
+            fillWell: preEqFillColorWell, fillReset: preEqFillResetButton
+        ))
 
         postEqCheckbox = NSButton(checkboxWithTitle: "Post-EQ Spectrum",
                                     target: self, action: #selector(togglePostEqSpectrum(_:)))
         postEqCheckbox.state = state.postEqSpectrumEnabled ? .on : .off
-        postEqCheckbox.isEnabled = !audioEngine.bypassed
-        postEqColorWell = makeColorWell(action: #selector(postEqColorChanged(_:)))
-        postEqColorWell.color = (state.postEqSpectrumColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
-        postEqColorWell.isEnabled = !audioEngine.bypassed
-        postEqResetButton = makeResetButton(action: #selector(resetPostEqColor(_:)))
-        postEqResetButton.isEnabled = !audioEngine.bypassed
-        mainStack.addArrangedSubview(makeSpectrumRow(checkbox: postEqCheckbox,
-                                                     colorWell: postEqColorWell,
-                                                     resetButton: postEqResetButton))
+        postEqLineColorWell = makeColorWell(action: #selector(postEqLineColorChanged(_:)))
+        postEqLineColorWell.color = (state.postEqLineColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
+        postEqLineResetButton = makeResetButton(action: #selector(resetPostEqLineColor(_:)))
+        postEqFillCheckbox = NSButton(checkboxWithTitle: "Fill",
+                                       target: self, action: #selector(togglePostEqFill(_:)))
+        postEqFillCheckbox.state = state.postEqFillEnabled ? .on : .off
+        postEqFillColorWell = makeColorWell(action: #selector(postEqFillColorChanged(_:)))
+        postEqFillColorWell.color = (state.postEqFillColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
+        postEqFillResetButton = makeResetButton(action: #selector(resetPostEqFillColor(_:)))
+        let postEqEnabled = !audioEngine.bypassed
+        for control in [postEqCheckbox, postEqLineColorWell, postEqLineResetButton,
+                        postEqFillCheckbox, postEqFillColorWell, postEqFillResetButton] as [NSControl] {
+            control.isEnabled = postEqEnabled
+        }
+        mainStack.addArrangedSubview(makeSpectrumGroup(
+            checkbox: postEqCheckbox,
+            lineWell: postEqLineColorWell, lineReset: postEqLineResetButton,
+            fillCheckbox: postEqFillCheckbox,
+            fillWell: postEqFillColorWell, fillReset: postEqFillResetButton
+        ))
 
         let bwRow = NSStackView()
         bwRow.orientation = .horizontal
@@ -214,6 +247,25 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         return row
     }
 
+    private func makeSpectrumGroup(checkbox: NSButton,
+                                   lineWell: NSColorWell, lineReset: NSButton,
+                                   fillCheckbox: NSButton,
+                                   fillWell: NSColorWell, fillReset: NSButton) -> NSStackView {
+        let group = NSStackView()
+        group.orientation = .vertical
+        group.alignment = .leading
+        group.spacing = 4
+        group.addArrangedSubview(makeSpectrumRow(checkbox: checkbox,
+                                                  colorWell: lineWell,
+                                                  resetButton: lineReset))
+        let fillRow = makeSpectrumRow(checkbox: fillCheckbox,
+                                       colorWell: fillWell,
+                                       resetButton: fillReset)
+        fillRow.edgeInsets = NSEdgeInsets(top: 0, left: 18, bottom: 0, right: 0)
+        group.addArrangedSubview(fillRow)
+        return group
+    }
+
     // MARK: - Actions
 
     @objc private func togglePeakLimiter(_ sender: NSButton) {
@@ -258,36 +310,84 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         eqWindowController?.syncPostEqSpectrum(on)
     }
 
-    @objc private func preEqColorChanged(_ sender: NSColorWell) {
+    @objc private func preEqLineColorChanged(_ sender: NSColorWell) {
         let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
         var state = iQualizeState.load()
-        state.preEqSpectrumColorHex = srgb.srgbHexRGB
+        state.preEqLineColorHex = srgb.srgbHexRGB
         state.save()
-        eqWindowController?.syncPreEqSpectrumColor(srgb)
+        eqWindowController?.syncPreEqLineColor(srgb)
     }
 
-    @objc private func postEqColorChanged(_ sender: NSColorWell) {
+    @objc private func postEqLineColorChanged(_ sender: NSColorWell) {
         let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
         var state = iQualizeState.load()
-        state.postEqSpectrumColorHex = srgb.srgbHexRGB
+        state.postEqLineColorHex = srgb.srgbHexRGB
         state.save()
-        eqWindowController?.syncPostEqSpectrumColor(srgb)
+        eqWindowController?.syncPostEqLineColor(srgb)
     }
 
-    @objc private func resetPreEqColor(_ sender: NSButton) {
+    @objc private func resetPreEqLineColor(_ sender: NSButton) {
         var state = iQualizeState.load()
-        state.preEqSpectrumColorHex = nil
+        state.preEqLineColorHex = nil
         state.save()
-        preEqColorWell.color = .systemCyan
-        eqWindowController?.syncPreEqSpectrumColor(.systemCyan)
+        preEqLineColorWell.color = .systemCyan
+        eqWindowController?.syncPreEqLineColor(.systemCyan)
     }
 
-    @objc private func resetPostEqColor(_ sender: NSButton) {
+    @objc private func resetPostEqLineColor(_ sender: NSButton) {
         var state = iQualizeState.load()
-        state.postEqSpectrumColorHex = nil
+        state.postEqLineColorHex = nil
         state.save()
-        postEqColorWell.color = .systemOrange
-        eqWindowController?.syncPostEqSpectrumColor(.systemOrange)
+        postEqLineColorWell.color = .systemOrange
+        eqWindowController?.syncPostEqLineColor(.systemOrange)
+    }
+
+    @objc private func togglePreEqFill(_ sender: NSButton) {
+        let on = sender.state == .on
+        var state = iQualizeState.load()
+        state.preEqFillEnabled = on
+        state.save()
+        eqWindowController?.syncPreEqFillEnabled(on)
+    }
+
+    @objc private func togglePostEqFill(_ sender: NSButton) {
+        let on = sender.state == .on
+        var state = iQualizeState.load()
+        state.postEqFillEnabled = on
+        state.save()
+        eqWindowController?.syncPostEqFillEnabled(on)
+    }
+
+    @objc private func preEqFillColorChanged(_ sender: NSColorWell) {
+        let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
+        var state = iQualizeState.load()
+        state.preEqFillColorHex = srgb.srgbHexRGB
+        state.save()
+        eqWindowController?.syncPreEqFillColor(srgb)
+    }
+
+    @objc private func postEqFillColorChanged(_ sender: NSColorWell) {
+        let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
+        var state = iQualizeState.load()
+        state.postEqFillColorHex = srgb.srgbHexRGB
+        state.save()
+        eqWindowController?.syncPostEqFillColor(srgb)
+    }
+
+    @objc private func resetPreEqFillColor(_ sender: NSButton) {
+        var state = iQualizeState.load()
+        state.preEqFillColorHex = nil
+        state.save()
+        preEqFillColorWell.color = .systemCyan
+        eqWindowController?.syncPreEqFillColor(.systemCyan)
+    }
+
+    @objc private func resetPostEqFillColor(_ sender: NSButton) {
+        var state = iQualizeState.load()
+        state.postEqFillColorHex = nil
+        state.save()
+        postEqFillColorWell.color = .systemOrange
+        eqWindowController?.syncPostEqFillColor(.systemOrange)
     }
 
     @objc private func bandwidthModeChanged(_ sender: NSSegmentedControl) {


### PR DESCRIPTION
The follow-up to PR #63. The same 0.28.0 milestone — only the View on GitHub commit landed last time, so this PR brings in the rest plus the doc updates.

## Summary
- **Post-EQ disabled while bypassed** — checkbox + color wells + reset buttons all disable when EQ is bypassed, and the post-EQ line is hidden (post-EQ would just mirror pre-EQ). User's enabled-preference is preserved across the bypass toggle. Bypass changes from any source (menu bar item, Cmd+B, EQ window checkbox) propagate to both windows. Addresses suggestion #5 in #60.
- **Custom spectrum line colors** — Settings → Display now has a native ``NSColorWell`` next to each spectrum checkbox with a ``↺`` reset button. Picks persist as ``#RRGGBB`` sRGB strings; nil falls back to the dynamic system color (cyan / orange) which auto-adapts to dark/light mode.
- **Per-spectrum fill control** — each spectrum has a ``Fill`` checkbox in an indented sub-row plus its own fill color well + reset. Pre-EQ fill defaults off, Post-EQ fill defaults on (matches the previous look). Pre/post-EQ drawing is now unified through a single ``drawSpectrumFillAndStroke`` helper.
- **Settings layout polish** — reset button frame tightened; Settings window honors a 320pt minimum content width so every row has matching left/right margins.
- **Docs updated** — README's Menu Bar, Settings → Display, and Spectrum Analyzer sections plus a CLAUDE.md architecture entry for ``ColorHex.swift``.

## Test plan
- [x] ``swift build`` succeeds
- [x] ``bash install.sh`` and app launches cleanly
- [x] Toggle bypass via menu bar / EQ window / Cmd+B → all Post-EQ controls (checkbox, line well, fill checkbox, fill well, both resets) disable everywhere; line + fill disappear
- [x] Pre-EQ line well opens system color panel; pick a color → spectrum line redraws live; persists across relaunch
- [x] Toggle Pre-EQ Fill on → cyan fill appears; turn off → fill disappears
- [x] Pick a custom Pre-EQ fill color (different from line) → fill redraws independently of line
- [x] Reset buttons return to system cyan / orange and clear the persisted hex
- [x] Settings window has matching left/right margins on every row
- [x] Manually corrupt a hex value in state → app falls back to system color, no crash