### PR TITLE
docs: link to architecture blog post from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Accessible via the gear icon in the EQ window, the Settings item in the menu bar
 
 ## Architecture
 
+> For the long version — why CATap, what fought back, and how the audio graph came together — read the blog post: [Building iQualize - A System-Wide EQ That Doesn't Suck](https://darius.codes/writing/building-iqualize).
+
 iQualize uses Core Audio Taps (CATap), introduced in macOS 14.2, to intercept system audio without a virtual audio device. Virtual devices (like BlackHole or eqMac's driver approach) create a secondary audio path — you lose system volume control, break some DRM-protected audio, and add latency. CATap captures the audio stream directly from the HAL, processes it in-process, and sends it to the output device.
 
 ```


### PR DESCRIPTION
Addresses suggestion #9 in #60 — adds a one-line pointer at the top of the README's Architecture section to the blog post: [Building iQualize - A System-Wide EQ That Doesn't Suck](https://darius.codes/writing/building-iqualize).

## Test plan
- [ ] README's Architecture section renders the link on github.com
- [ ] Link opens to the blog post