### PR TITLE
feat: in-app Help window (issue #60 suggestion #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.29.0] - 2026-05-02
+
+### Added
+- In-app Help window (Cmd+? or "Help…" in the menu bar dropdown) renders the README's Features section directly inside the app — no need to leave for GitHub. Includes a "View latest on GitHub" link for content newer than your installed build (#60, suggestion #8)
+- Standard macOS **Window** and **Help** menus in the OS menu bar (visible when Hide from Dock is off) — Window auto-lists open iQualize windows for keyboard navigation; Help mirrors the in-app Help shortcut
+
 ## [0.28.0] - 2026-05-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,5 @@ If the app fails to launch ("can't be opened" error), debug and fix before proce
 - `Sources/iQualize/SpectrumAnalyzer.swift` — real-time FFT spectrum analysis via Accelerate vDSP
 - `Sources/iQualize/SpectrumData.swift` — lock-free double-buffered audio-to-UI data transfer
 - `Sources/iQualize/ColorHex.swift` — NSColor ↔ #RRGGBB sRGB hex helpers for persisting user-picked spectrum colors
+- `Sources/iQualize/HelpRenderer.swift` — extracts the README's Features section and renders it as HTML via swift-markdown
+- `Sources/iQualize/HelpWindowController.swift` — WKWebView-based Help window; intercepts link clicks to open them in the default browser

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "a9279552b2ceb702a78d50e4a4f994c687a2ec501b7b15a4497316eb24a205a9",
+  "pins" : [
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,15 @@ import PackageDescription
 let package = Package(
     name: "iQualize",
     platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-markdown.git", from: "0.4.0"),
+    ],
     targets: [
         .executableTarget(
             name: "iQualize",
+            dependencies: [
+                .product(name: "Markdown", package: "swift-markdown"),
+            ],
             path: "Sources/iQualize",
             exclude: ["Info.plist"],
             linkerSettings: [

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (octaves, 0.05
 - Presets submenu with checkmarks and active preset name in parent item — changes sync to the EQ window in real time
 - Bypass EQ toggle (Cmd+B) — pass audio through unprocessed; while bypassed, the Post-EQ spectrum line and its color/fill controls are hidden/disabled (post-EQ would otherwise just mirror pre-EQ)
 - Current output device display
+- Help… (Cmd+?) — opens an in-app Help window rendering the README's Features section, with a "View latest on GitHub" link
 - About iQualize — shows version and a "View on GitHub" button that opens the project page in your default browser
 
 ### Settings

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -11,6 +11,11 @@ final class EQWindow: NSWindow {
         if onKeyDown?(event) == true { return }
         super.keyDown(with: event)
     }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if HelpShortcut.handles(event) { return true }
+        return super.performKeyEquivalent(with: event)
+    }
 }
 
 @available(macOS 14.2, *)

--- a/Sources/iQualize/HelpRenderer.swift
+++ b/Sources/iQualize/HelpRenderer.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Markdown
+
+@MainActor
+enum HelpRenderer {
+    private static var cachedHTML: String?
+
+    static func featuresHTML() -> String {
+        if let cached = cachedHTML { return cached }
+        let html = renderHTML()
+        cachedHTML = html
+        return html
+    }
+
+    private static func renderHTML() -> String {
+        let body: String
+        if let url = Bundle.main.url(forResource: "README", withExtension: "md"),
+           let text = try? String(contentsOf: url, encoding: .utf8) {
+            let features = extractFeatures(from: text)
+            let document = Document(parsing: features)
+            var visitor = HTMLVisitor()
+            body = visitor.visit(document)
+        } else {
+            body = "<p><em>Could not load help content. View it on <a href=\"https://github.com/DariusCorvus/iqualize#features\">GitHub</a> instead.</em></p>"
+        }
+        return wrap(body: body)
+    }
+
+    /// Returns the slice of the README from `## Features` (inclusive) to the next `## ` heading (exclusive).
+    private static func extractFeatures(from markdown: String) -> String {
+        var lines: [String] = []
+        var inSection = false
+        for line in markdown.components(separatedBy: "\n") {
+            if line.trimmingCharacters(in: .whitespaces) == "## Features" {
+                inSection = true
+                lines.append(line)
+                continue
+            }
+            if inSection {
+                if line.hasPrefix("## ") { break }
+                lines.append(line)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func wrap(body: String) -> String {
+        let header = "<div class=\"help-header\"><a href=\"https://github.com/DariusCorvus/iqualize#features\">View latest on GitHub →</a></div>"
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>\(css)</style>
+        </head>
+        <body>
+        \(header)
+        \(body)
+        </body>
+        </html>
+        """
+    }
+
+    private static let css = """
+    :root { color-scheme: light dark; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        margin: 0;
+        padding: 24px 32px 40px 32px;
+        max-width: 760px;
+        color: light-dark(#1d1d1f, #f5f5f7);
+        background: light-dark(#ffffff, #1e1e1e);
+    }
+    h2 { font-size: 1.5em; margin-top: 1.4em; border-bottom: 1px solid light-dark(#e5e5e7, #38383a); padding-bottom: 0.2em; }
+    h3 { font-size: 1.15em; margin-top: 1.2em; }
+    h4 { font-size: 1em; margin-top: 1em; }
+    p { margin: 0.6em 0; }
+    ul, ol { padding-left: 1.4em; }
+    li { margin: 0.2em 0; }
+    code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.92em;
+        background: light-dark(#f4f4f6, #2a2a2c);
+        padding: 0.1em 0.35em;
+        border-radius: 4px;
+    }
+    pre {
+        background: light-dark(#f4f4f6, #2a2a2c);
+        padding: 12px 14px;
+        border-radius: 6px;
+        overflow-x: auto;
+    }
+    pre code { background: transparent; padding: 0; font-size: 0.85em; line-height: 1.4; }
+    a { color: light-dark(#0066cc, #4ea1ff); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    blockquote {
+        margin: 0.8em 0;
+        padding: 0 0 0 14px;
+        border-left: 3px solid light-dark(#d1d1d6, #48484a);
+        color: light-dark(#444, #c7c7cc);
+    }
+    .help-header {
+        font-size: 0.85em;
+        opacity: 0.75;
+        margin-bottom: 1.2em;
+        padding-bottom: 0.6em;
+        border-bottom: 1px dashed light-dark(#e5e5e7, #38383a);
+    }
+    """
+}
+
+private struct HTMLVisitor: MarkupVisitor {
+    typealias Result = String
+
+    mutating func defaultVisit(_ markup: any Markup) -> String {
+        var out = ""
+        for child in markup.children { out += visit(child) }
+        return out
+    }
+
+    mutating func visitDocument(_ document: Document) -> String {
+        defaultVisit(document)
+    }
+
+    mutating func visitHeading(_ heading: Heading) -> String {
+        let level = min(max(heading.level, 1), 6)
+        return "<h\(level)>\(visitChildren(of: heading))</h\(level)>\n"
+    }
+
+    mutating func visitParagraph(_ paragraph: Paragraph) -> String {
+        "<p>\(visitChildren(of: paragraph))</p>\n"
+    }
+
+    mutating func visitText(_ text: Text) -> String {
+        Self.escapeText(text.string)
+    }
+
+    mutating func visitStrong(_ strong: Strong) -> String {
+        "<strong>\(visitChildren(of: strong))</strong>"
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> String {
+        "<em>\(visitChildren(of: emphasis))</em>"
+    }
+
+    mutating func visitInlineCode(_ inlineCode: InlineCode) -> String {
+        "<code>\(Self.escapeText(inlineCode.code))</code>"
+    }
+
+    mutating func visitLink(_ link: Link) -> String {
+        let dest = link.destination ?? "#"
+        return "<a href=\"\(Self.escapeAttr(dest))\">\(visitChildren(of: link))</a>"
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> String {
+        let langAttr = codeBlock.language.map { " class=\"language-\(Self.escapeAttr($0))\"" } ?? ""
+        return "<pre><code\(langAttr)>\(Self.escapeText(codeBlock.code))</code></pre>\n"
+    }
+
+    mutating func visitUnorderedList(_ list: UnorderedList) -> String {
+        "<ul>\n\(visitChildren(of: list))</ul>\n"
+    }
+
+    mutating func visitOrderedList(_ list: OrderedList) -> String {
+        "<ol>\n\(visitChildren(of: list))</ol>\n"
+    }
+
+    mutating func visitListItem(_ listItem: ListItem) -> String {
+        "<li>\(visitChildren(of: listItem))</li>\n"
+    }
+
+    mutating func visitLineBreak(_ lineBreak: LineBreak) -> String { "<br>\n" }
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> String { " " }
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> String { "<hr>\n" }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> String {
+        "<blockquote>\(visitChildren(of: blockQuote))</blockquote>\n"
+    }
+
+    mutating func visitHTMLBlock(_ htmlBlock: HTMLBlock) -> String {
+        htmlBlock.rawHTML
+    }
+
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> String {
+        inlineHTML.rawHTML
+    }
+
+    mutating func visitImage(_ image: Image) -> String {
+        let src = image.source ?? ""
+        return "<img src=\"\(Self.escapeAttr(src))\" alt=\"\(visitChildren(of: image))\">"
+    }
+
+    private mutating func visitChildren(of markup: any Markup) -> String {
+        var out = ""
+        for child in markup.children { out += visit(child) }
+        return out
+    }
+
+    private static func escapeText(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "<", with: "&lt;")
+         .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func escapeAttr(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "\"", with: "&quot;")
+         .replacingOccurrences(of: "<", with: "&lt;")
+         .replacingOccurrences(of: ">", with: "&gt;")
+    }
+}

--- a/Sources/iQualize/HelpWindowController.swift
+++ b/Sources/iQualize/HelpWindowController.swift
@@ -1,0 +1,76 @@
+import AppKit
+import WebKit
+
+/// Routes Cmd+Shift+? to the in-app Help window. Each app window subclass calls
+/// this from `performKeyEquivalent` so the shortcut works regardless of activation
+/// policy (accessory mode has no OS menu bar to fire menu shortcuts).
+@available(macOS 14.2, *)
+@MainActor
+enum HelpShortcut {
+    static func handles(_ event: NSEvent) -> Bool {
+        guard event.modifierFlags.contains(.command),
+              event.charactersIgnoringModifiers == "?" else { return false }
+        (NSApp.delegate as? AppDelegate)?.openHelp(nil)
+        return true
+    }
+}
+
+/// NSWindow subclass that catches Cmd+? — used for the Settings window
+/// (and any other window where we want the help shortcut to fire).
+@available(macOS 14.2, *)
+@MainActor
+final class HelpAwareWindow: NSWindow {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if HelpShortcut.handles(event) { return true }
+        return super.performKeyEquivalent(with: event)
+    }
+}
+
+@available(macOS 14.2, *)
+@MainActor
+final class HelpWindowController: NSWindowController, NSWindowDelegate, WKNavigationDelegate {
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 600),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered, defer: true
+        )
+        window.title = "iQualize Help"
+        window.minSize = NSSize(width: 480, height: 400)
+        window.center()
+        window.isReleasedWhenClosed = false
+
+        super.init(window: window)
+        window.delegate = self
+
+        let webView = WKWebView()
+        webView.navigationDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: container.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        window.contentView = container
+
+        webView.loadHTMLString(HelpRenderer.featuresHTML(), baseURL: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
+        if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.28.0</string>
+	<string>0.29.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.28.0</string>
+	<string>0.29.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -8,6 +8,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     private let presetStore: PresetStore
     private var eqWindowController: EQWindowController?
     private var settingsWindowController: SettingsWindowController?
+    private var helpWindowController: HelpWindowController?
 
     init(audioEngine: AudioEngine, presetStore: PresetStore) {
         self.audioEngine = audioEngine
@@ -137,6 +138,13 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
 
         menu.addItem(.separator())
 
+        // Help
+        let helpItem = NSMenuItem(title: "Help…", action: #selector(openHelp(_:)),
+                                   keyEquivalent: "?")
+        helpItem.keyEquivalentModifierMask = [.command]
+        helpItem.target = self
+        menu.addItem(helpItem)
+
         // About
         let aboutItem = NSMenuItem(title: "About iQualize", action: #selector(showAbout(_:)),
                                     keyEquivalent: "")
@@ -235,6 +243,14 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         updateIcon()
         eqWindowController?.syncBypass(audioEngine.bypassed)
         settingsWindowController?.syncBypass(audioEngine.bypassed)
+    }
+
+    @objc func openHelp(_ sender: Any?) {
+        if helpWindowController == nil {
+            helpWindowController = HelpWindowController()
+        }
+        helpWindowController?.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc private func showAbout(_ sender: NSMenuItem) {

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -30,7 +30,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         self.audioEngine = audioEngine
         self.eqWindowController = eqWindowController
 
-        let window = NSWindow(
+        let window = HelpAwareWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 0),
             styleMask: [.titled, .closable],
             backing: .buffered, defer: true

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -101,6 +101,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         menuBarController?.toggleBypassFromMenu()
     }
 
+    @objc func openHelp(_ sender: Any?) {
+        menuBarController?.openHelp(sender)
+    }
+
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(toggleBypass(_:)) {
             menuItem.state = audioEngine?.bypassed == true ? .on : .off
@@ -147,6 +151,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         controlsMenu.addItem(bypassItem)
         controlsMenuItem.submenu = controlsMenu
         mainMenu.addItem(controlsMenuItem)
+
+        // Window menu — standard macOS pattern. NSApp.windowsMenu auto-appends
+        // the names of open titled windows below the standard items.
+        let windowMenuItem = NSMenuItem()
+        let windowMenu = NSMenu(title: "Window")
+        let minimizeItem = windowMenu.addItem(withTitle: "Minimize",
+                                               action: #selector(NSWindow.miniaturize(_:)),
+                                               keyEquivalent: "m")
+        minimizeItem.keyEquivalentModifierMask = [.command]
+        windowMenu.addItem(withTitle: "Zoom",
+                           action: #selector(NSWindow.performZoom(_:)),
+                           keyEquivalent: "")
+        windowMenu.addItem(.separator())
+        windowMenu.addItem(withTitle: "Bring All to Front",
+                           action: #selector(NSApplication.arrangeInFront(_:)),
+                           keyEquivalent: "")
+        windowMenuItem.submenu = windowMenu
+        mainMenu.addItem(windowMenuItem)
+        NSApp.windowsMenu = windowMenu
+
+        // Help menu — standard macOS pattern. Not registered as NSApp.helpMenu so
+        // macOS doesn't add the Help search popover (we ship our own help window).
+        // Cmd+? itself is handled by HelpAwareWindow.performKeyEquivalent so the
+        // shortcut works regardless of activation policy.
+        let helpMenuItem = NSMenuItem()
+        let helpMenu = NSMenu(title: "Help")
+        let helpEntry = NSMenuItem(title: "iQualize Help",
+                                    action: #selector(openHelp(_:)),
+                                    keyEquivalent: "?")
+        helpEntry.keyEquivalentModifierMask = [.command]
+        helpEntry.target = self
+        helpMenu.addItem(helpEntry)
+        helpMenuItem.submenu = helpMenu
+        mainMenu.addItem(helpMenuItem)
 
         NSApp.mainMenu = mainMenu
     }

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,9 @@ fi
 # Copy app icon
 cp -f Sources/iQualize/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
 
+# Copy README so the in-app Help window can render the Features section
+cp -f README.md "$APP/Contents/Resources/README.md"
+
 # Always update Info.plist — then re-sign if it changed (plist change invalidates signature)
 if ! cmp -s Sources/iQualize/Info.plist "$APP/Contents/Info.plist"; then
     cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"


### PR DESCRIPTION
Addresses suggestion #8 in #60: render the README's Features description as in-app help reachable from the menu bar.

## Summary
- New **Help…** item in the menu bar dropdown (above About) and a standard macOS **Help** menu with **Cmd+?** in the OS menu bar — both open the same window.
- The window uses `WKWebView` to render the README's `## Features` section as styled HTML with a system-aware CSS sheet (auto adapts to Light/Dark via `prefers-color-scheme`).
- Markdown is parsed at runtime via Apple's `swift-markdown` package (the project's first third-party dep) using a custom `MarkupVisitor` → HTML walker. Output is cached after first render.
- README.md is bundled into `Contents/Resources/` at install time (`install.sh`), so help is always in sync with the binary the user has. A **"View latest on GitHub →"** link in the window header gives the escape hatch for content newer than the installed build.
- External links inside the help content are routed through `NSWorkspace.shared.open` so they open in the user's default browser, never inside the help window.
- Bumps to **0.29.0** (new feature, minor bump).

## Files
- New: `HelpRenderer.swift`, `HelpWindowController.swift`
- Modified: `Package.swift` (swift-markdown dep), `MenuBarController.swift` (Help… item + handler), `iQualizeApp.swift` (OS Help menu, Cmd+?), `install.sh` (copies README into Resources/), `Info.plist`, `README.md`, `CLAUDE.md`, `CHANGELOG.md`

## Test plan
- [x] `swift build` succeeds
- [x] `bash install.sh` and app launches cleanly
- [x] Click menu bar → **Help…** → window renders the Features section
- [x] Dark mode renders correctly (verified via screenshot)
- [x] Light mode renders correctly
- [x] Cmd+? from anywhere in the app opens the Help window
- [x] Clicking "View latest on GitHub" opens in default browser, not inside the window
- [x] Clicking other links (Spotify reference link, etc.) also opens in default browser
- [x] Resize the window — content reflows
- [x] Bundle README is missing → graceful "Could not load help content" fallback message