### PR TITLE
chore: ignore release DMGs, remove .claude/skills from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.xcodeproj/
 xcuserdata/
 DerivedData/
+*.dmg


### PR DESCRIPTION
Two cleanup items bundled:

- Adds `*.dmg` to `.gitignore` so the DMG built by `create-dmg.sh` doesn't show up as untracked after every release.
- Adds `.claude/skills/` to `.gitignore` and removes 324 previously-committed skill files (gstack and related) from the repo — they're auto-installed locally and don't belong in version control.