### PR TITLE
Add preset gain and output device profiles

### DIFF
--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -86,6 +86,7 @@ private func renderCallback(
 final class AudioEngine {
     private(set) var isRunning = false
     private(set) var outputDeviceName = "Unknown"
+    private(set) var outputDeviceUID = ""
     private(set) var error: String?
 
     private var tapID = AudioObjectID(kAudioObjectUnknown)
@@ -101,6 +102,7 @@ final class AudioEngine {
     @ObservationIgnored
     nonisolated(unsafe) private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
     var onStateChange: (() -> Void)?
+    var shouldRunForOutputDevice: ((String) -> Bool)?
 
     // Spectrum analyzers — one per tap point
     let preEqAnalyzer = SpectrumAnalyzer()
@@ -151,8 +153,10 @@ final class AudioEngine {
     init() {
         do {
             let deviceID = try getDefaultOutputDeviceID()
+            outputDeviceUID = try getDeviceUID(deviceID)
             outputDeviceName = try getDeviceName(deviceID)
         } catch {
+            outputDeviceUID = ""
             outputDeviceName = "Unknown"
         }
         installDeviceChangeListener()
@@ -180,6 +184,7 @@ final class AudioEngine {
 
         let outputDeviceID = try getDefaultOutputDeviceID()
         let outputUID = try getDeviceUID(outputDeviceID)
+        outputDeviceUID = outputUID
         outputDeviceName = try getDeviceName(outputDeviceID)
 
         // 1. Translate our PID → AudioObjectID so we can exclude ourselves from the tap.
@@ -468,6 +473,12 @@ final class AudioEngine {
         }
     }
 
+    func applyPreset(_ preset: EQPresetData) {
+        activePreset = preset
+        inputGainDB = preset.inputGainDB
+        splitChannelActive = preset.isSplitChannel
+    }
+
     private func applyBands(from old: EQPresetData? = nil) {
         guard let eq else { return }
 
@@ -564,17 +575,21 @@ final class AudioEngine {
         guard !isRestarting else { return }
 
         if let deviceID = try? getDefaultOutputDeviceID(),
+           let uid = try? getDeviceUID(deviceID),
            let name = try? getDeviceName(deviceID) {
+            outputDeviceUID = uid
             outputDeviceName = name
         }
 
         if isRunning {
             isRestarting = true
             stop()
-            do {
-                try start()
-            } catch {
-                self.error = error.localizedDescription
+            if shouldRunForOutputDevice?(outputDeviceUID) ?? true {
+                do {
+                    try start()
+                } catch {
+                    self.error = error.localizedDescription
+                }
             }
             isRestarting = false
         }

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -153,6 +153,16 @@ final class DreamViewModel {
         presetName = preset.name
         activePresetID = preset.id
         isBuiltIn = preset.isBuiltIn
+        bypass = audioEngine.bypassed
+        peakLimiter = audioEngine.peakLimiter
+        inGainDB = audioEngine.inputGainDB
+        outGainDB = audioEngine.outputGainDB
+        balance = audioEngine.balance
+        if preset.isSplitChannel {
+            if channel == .linked { channel = .l }
+        } else {
+            channel = .linked
+        }
         if initial {
             savedSnapshot = preset
             isModified = false
@@ -351,6 +361,7 @@ final class DreamViewModel {
             name: forkName,
             bands: custom.bands,
             rightBands: custom.rightBands,
+            inputGainDB: custom.inputGainDB,
             isBuiltIn: false
         )
         audioEngine.activePreset = newPreset
@@ -366,7 +377,7 @@ final class DreamViewModel {
         undoManager.registerUndo(withTarget: self) { [weak self] target in
             guard let self else { return }
             let redoPreset = self.audioEngine.activePreset
-            self.audioEngine.activePreset = oldPreset
+            self.audioEngine.applyPreset(oldPreset)
             self.syncFromAudioEngine()
             if oldPreset == self.savedSnapshot {
                 self.isModified = false
@@ -503,7 +514,7 @@ final class DreamViewModel {
     func loadPreset(id: UUID) {
         guard let preset = presetStore.preset(for: id) else { return }
         let oldPreset = audioEngine.activePreset
-        audioEngine.activePreset = preset
+        audioEngine.applyPreset(preset)
         // Sync split channel state to match the loaded preset
         if preset.isSplitChannel {
             audioEngine.splitChannelActive = true
@@ -518,13 +529,15 @@ final class DreamViewModel {
         registerUndo(actionName: "Load Preset", oldPreset: oldPreset)
         var s = iQualizeState.load()
         s.selectedPresetID = preset.id
+        s.inputGainDB = audioEngine.inputGainDB
+        s.splitChannelEnabled = preset.isSplitChannel
         s.save()
     }
 
     func resetToSnapshot() {
         guard let snap = savedSnapshot else { return }
         let old = audioEngine.activePreset
-        audioEngine.activePreset = snap
+        audioEngine.applyPreset(snap)
         syncFromAudioEngine()
         isModified = false
         registerUndo(actionName: "Reset Preset", oldPreset: old)
@@ -538,11 +551,12 @@ final class DreamViewModel {
             id: UUID(),
             name: "Custom EQ \(n)",
             bands: EQPresetData.flat.bands,
+            inputGainDB: 0.0,
             isBuiltIn: false
         )
         presetStore.saveCustomPreset(preset)
         let old = audioEngine.activePreset
-        audioEngine.activePreset = preset
+        audioEngine.applyPreset(preset)
         savedSnapshot = preset
         isModified = false
         syncFromAudioEngine()
@@ -558,7 +572,9 @@ final class DreamViewModel {
         var preset = audioEngine.activePreset
         preset.bands = bands
         preset.rightBands = rightBands
+        preset.inputGainDB = inGainDB
         presetStore.saveCustomPreset(preset)
+        audioEngine.activePreset = preset
         savedSnapshot = preset
         isModified = false
     }
@@ -579,11 +595,12 @@ final class DreamViewModel {
             name: resolvedName,
             bands: bands,
             rightBands: rightBands,
+            inputGainDB: inGainDB,
             isBuiltIn: false
         )
         presetStore.saveCustomPreset(newPreset)
         let old = audioEngine.activePreset
-        audioEngine.activePreset = newPreset
+        audioEngine.applyPreset(newPreset)
         savedSnapshot = newPreset
         isModified = false
         syncFromAudioEngine()
@@ -594,7 +611,7 @@ final class DreamViewModel {
         guard !isBuiltIn else { return }
         presetStore.deleteCustomPreset(id: activePresetID)
         let old = audioEngine.activePreset
-        audioEngine.activePreset = .flat
+        audioEngine.applyPreset(.flat)
         savedSnapshot = .flat
         isModified = false
         syncFromAudioEngine()
@@ -728,6 +745,7 @@ final class DreamViewModel {
                     name: importName,
                     bands: decoded.bands,
                     rightBands: decoded.rightBands,
+                    inputGainDB: decoded.inputGainDB,
                     isBuiltIn: false
                 )
                 presetStore.saveCustomPreset(preset)
@@ -741,7 +759,7 @@ final class DreamViewModel {
 
         if let preset = lastImported {
             let old = audioEngine.activePreset
-            audioEngine.activePreset = preset
+            audioEngine.applyPreset(preset)
             savedSnapshot = preset
             isModified = false
             syncFromAudioEngine()
@@ -783,6 +801,12 @@ final class DreamViewModel {
 
     func applyInputGain() {
         audioEngine.inputGainDB = inGainDB
+        var preset = audioEngine.activePreset
+        preset.inputGainDB = inGainDB
+        audioEngine.activePreset = preset
+        let wasModified = isModified
+        isModified = preset != savedSnapshot
+        if wasModified != isModified { onTitleShouldUpdate?() }
         persistFooterToggles()
     }
 

--- a/Sources/iQualize/EQModels.swift
+++ b/Sources/iQualize/EQModels.swift
@@ -96,7 +96,40 @@ struct EQPresetData: Codable, Equatable, Sendable, Identifiable {
     /// Right channel bands. When nil, the preset is in linked (stereo) mode.
     /// When non-nil, `bands` represents the left channel and `rightBands` the right.
     var rightBands: [EQBand]?
+    var inputGainDB: Float
     let isBuiltIn: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, bands, rightBands, inputGainDB, isBuiltIn
+    }
+
+    init(id: UUID,
+         name: String,
+         bands: [EQBand],
+         rightBands: [EQBand]? = nil,
+         inputGainDB: Float = 0.0,
+         isBuiltIn: Bool) {
+        self.id = id
+        self.name = name
+        self.bands = bands
+        self.rightBands = rightBands
+        self.inputGainDB = Self.clampInputGain(inputGainDB)
+        self.isBuiltIn = isBuiltIn
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        bands = try container.decode([EQBand].self, forKey: .bands)
+        rightBands = try container.decodeIfPresent([EQBand].self, forKey: .rightBands)
+        inputGainDB = Self.clampInputGain((try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0.0)
+        isBuiltIn = try container.decode(Bool.self, forKey: .isBuiltIn)
+    }
+
+    private static func clampInputGain(_ value: Float) -> Float {
+        max(-24, min(24, value))
+    }
 
     var isFlat: Bool {
         let bandsFlat = bands.allSatisfy { $0.gain == 0 && $0.filterType == .parametric }

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -56,7 +56,7 @@ final class EQWindowController: NSWindowController {
         // Restore active preset.
         let state = iQualizeState.load()
         if let preset = presetStore.preset(for: state.selectedPresetID) {
-            audioEngine.activePreset = preset
+            audioEngine.applyPreset(preset)
             viewModel.syncFromAudioEngine(initial: true)
         }
 

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -22,20 +22,27 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         statusItem.menu = menu
         updateIcon()
 
+        audioEngine.shouldRunForOutputDevice = { uid in
+            OutputDeviceProfileStore.profile(for: uid)?.isEnabled ?? !OutputDeviceProfileStore.hasProfiles
+        }
+
         // Rebuild menu on device changes
         audioEngine.onStateChange = { [weak self] in
+            self?.applyOutputDeviceProfileIfAvailable()
             self?.updateIcon()
         }
 
         // Restore saved state and always start EQ
         if let preset = presetStore.preset(for: state.selectedPresetID) {
-            audioEngine.activePreset = preset
+            audioEngine.applyPreset(preset)
         }
         audioEngine.peakLimiter = state.peakLimiter
         audioEngine.maxGainDB = state.maxGainDB
         audioEngine.bypassed = state.bypassed
         audioEngine.balance = state.balance
-        audioEngine.setEnabled(true)
+        audioEngine.inputGainDB = state.inputGainDB
+        audioEngine.outputGainDB = state.outputGainDB
+        applyOutputDeviceProfileIfAvailable()
         updateIcon()
 
         // Restore EQ window if it was open when the app last quit
@@ -163,9 +170,11 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         guard let uuidString = sender.representedObject as? String,
               let id = UUID(uuidString: uuidString),
               let preset = presetStore.preset(for: id) else { return }
-        audioEngine.activePreset = preset
+        audioEngine.applyPreset(preset)
         var s = iQualizeState.load()
         s.selectedPresetID = preset.id
+        s.inputGainDB = audioEngine.inputGainDB
+        s.splitChannelEnabled = preset.isSplitChannel
         s.save()
         eqWindowController?.syncUIToPreset()
     }
@@ -178,6 +187,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         if settingsWindowController == nil {
             settingsWindowController = SettingsWindowController(
                 audioEngine: audioEngine, eqWindowController: eqWindowController)
+            settingsWindowController?.onOutputEnabledChanged = { [weak self] in self?.updateIcon() }
         }
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)
@@ -229,6 +239,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         if settingsWindowController == nil {
             settingsWindowController = SettingsWindowController(
                 audioEngine: audioEngine, eqWindowController: eqWindowController)
+            settingsWindowController?.onOutputEnabledChanged = { [weak self] in self?.updateIcon() }
         }
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)
@@ -243,6 +254,64 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         updateIcon()
         eqWindowController?.syncBypass(audioEngine.bypassed)
         settingsWindowController?.syncBypass(audioEngine.bypassed)
+    }
+
+    private func applyOutputDeviceProfileIfAvailable() {
+        guard let profile = OutputDeviceProfileStore.profile(for: audioEngine.outputDeviceUID) else {
+            if OutputDeviceProfileStore.hasProfiles {
+                applyUnprofiledOutputDefaults()
+            } else {
+                applyLegacyOutputDefaults()
+            }
+            settingsWindowController?.syncDeviceProfile()
+            return
+        }
+
+        var state = iQualizeState.load()
+        if let presetID = profile.presetID,
+           let preset = presetStore.preset(for: presetID) {
+            audioEngine.applyPreset(preset)
+            state.selectedPresetID = preset.id
+            state.splitChannelEnabled = preset.isSplitChannel
+        }
+
+        audioEngine.bypassed = profile.bypassed
+        audioEngine.inputGainDB = profile.inputGainDB
+        audioEngine.setEnabled(profile.isEnabled)
+        state.isEnabled = profile.isEnabled
+        state.bypassed = profile.bypassed
+        state.inputGainDB = profile.inputGainDB
+        state.save()
+
+        eqWindowController?.syncUIToPreset()
+        settingsWindowController?.syncBypass(audioEngine.bypassed)
+        settingsWindowController?.syncDeviceProfile()
+    }
+
+    private func applyUnprofiledOutputDefaults() {
+        audioEngine.applyPreset(.flat)
+        audioEngine.bypassed = true
+        audioEngine.inputGainDB = 0
+        audioEngine.setEnabled(false)
+
+        var state = iQualizeState.load()
+        state.isEnabled = false
+        state.selectedPresetID = EQPresetData.flat.id
+        state.splitChannelEnabled = false
+        state.bypassed = true
+        state.inputGainDB = 0
+        state.save()
+
+        eqWindowController?.syncUIToPreset()
+        settingsWindowController?.syncBypass(audioEngine.bypassed)
+    }
+
+    private func applyLegacyOutputDefaults() {
+        audioEngine.setEnabled(true)
+
+        var state = iQualizeState.load()
+        state.isEnabled = audioEngine.isRunning
+        state.save()
     }
 
     @objc func openHelp(_ sender: Any?) {

--- a/Sources/iQualize/OutputDeviceProfile.swift
+++ b/Sources/iQualize/OutputDeviceProfile.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+struct OutputDeviceProfile: Codable, Equatable, Sendable {
+    var deviceUID: String
+    var deviceName: String
+    var isEnabled: Bool
+    var presetID: UUID?
+    var presetName: String
+    var bypassed: Bool
+    var inputGainDB: Float
+
+    enum CodingKeys: String, CodingKey {
+        case deviceUID, deviceName, isEnabled, presetID, presetName, bypassed, inputGainDB
+    }
+
+    init(deviceUID: String,
+         deviceName: String,
+         isEnabled: Bool,
+         presetID: UUID?,
+         presetName: String,
+         bypassed: Bool,
+         inputGainDB: Float) {
+        self.deviceUID = deviceUID
+        self.deviceName = deviceName
+        self.isEnabled = isEnabled
+        self.presetID = presetID
+        self.presetName = presetName
+        self.bypassed = bypassed
+        self.inputGainDB = inputGainDB
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceUID = try container.decode(String.self, forKey: .deviceUID)
+        deviceName = try container.decode(String.self, forKey: .deviceName)
+        isEnabled = (try? container.decode(Bool.self, forKey: .isEnabled)) ?? true
+        presetID = try? container.decode(UUID.self, forKey: .presetID)
+        presetName = try container.decode(String.self, forKey: .presetName)
+        bypassed = (try? container.decode(Bool.self, forKey: .bypassed)) ?? false
+        inputGainDB = (try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0
+    }
+}
+
+enum OutputDeviceProfileStore {
+    private static let key = "com.iqualize.outputDeviceProfiles"
+
+    static var hasProfiles: Bool {
+        !loadAll().isEmpty
+    }
+
+    static func profile(for deviceUID: String) -> OutputDeviceProfile? {
+        guard !deviceUID.isEmpty else { return nil }
+        return loadAll()[deviceUID]
+    }
+
+    static func save(_ profile: OutputDeviceProfile) {
+        guard !profile.deviceUID.isEmpty else { return }
+        var profiles = loadAll()
+        profiles[profile.deviceUID] = profile
+        persist(profiles)
+    }
+
+    static func delete(deviceUID: String) {
+        guard !deviceUID.isEmpty else { return }
+        var profiles = loadAll()
+        profiles.removeValue(forKey: deviceUID)
+        persist(profiles)
+    }
+
+    private static func loadAll() -> [String: OutputDeviceProfile] {
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let profiles = try? JSONDecoder().decode([String: OutputDeviceProfile].self, from: data) else {
+            return [:]
+        }
+        return profiles
+    }
+
+    private static func persist(_ profiles: [String: OutputDeviceProfile]) {
+        if let data = try? JSONEncoder().encode(profiles) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+}

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -6,6 +6,7 @@ import ServiceManagement
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let audioEngine: AudioEngine
     private weak var eqWindowController: EQWindowController?
+    var onOutputEnabledChanged: (() -> Void)?
 
     private var peakLimiterCheckbox: NSButton!
     private var maxGainPicker: NSPopUpButton!
@@ -23,6 +24,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private var preEqFillResetButton: NSButton!
     private var postEqFillResetButton: NSButton!
     private var bandwidthModeSegment: NSSegmentedControl!
+    private var deviceProfileLabel: NSTextField!
+    private var deviceProfileEnabledCheckbox: NSButton!
+    private var saveDeviceProfileButton: NSButton!
+    private var removeDeviceProfileButton: NSButton!
     private var hideFromDockCheckbox: NSButton!
     private var startAtLoginCheckbox: NSButton!
 
@@ -71,10 +76,15 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         postEqFillColorWell.color = (state.postEqFillColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
         applyPostEqEnabled(!audioEngine.bypassed)
         bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
+        updateDeviceProfileControls()
     }
 
     func syncBypass(_ on: Bool) {
         applyPostEqEnabled(!on)
+    }
+
+    func syncDeviceProfile() {
+        updateDeviceProfileControls()
     }
 
     private func applyPostEqEnabled(_ enabled: Bool) {
@@ -192,6 +202,38 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
         mainStack.addArrangedSubview(bwRow)
 
+        // ── Output Profile ──
+        let profileHeader = makeSectionHeader("Output Profile")
+        mainStack.addArrangedSubview(profileHeader)
+
+        deviceProfileLabel = NSTextField(labelWithString: "")
+        deviceProfileLabel.font = .systemFont(ofSize: 12)
+        deviceProfileLabel.textColor = .secondaryLabelColor
+        deviceProfileLabel.maximumNumberOfLines = 2
+        deviceProfileLabel.lineBreakMode = .byWordWrapping
+        deviceProfileLabel.preferredMaxLayoutWidth = 300
+        mainStack.addArrangedSubview(deviceProfileLabel)
+
+        deviceProfileEnabledCheckbox = NSButton(checkboxWithTitle: "Run iQualize on This Output",
+                                                target: self, action: #selector(toggleCurrentOutputEnabled(_:)))
+        deviceProfileEnabledCheckbox.state = audioEngine.isRunning ? .on : .off
+        mainStack.addArrangedSubview(deviceProfileEnabledCheckbox)
+
+        let deviceProfileRow = NSStackView()
+        deviceProfileRow.orientation = .horizontal
+        deviceProfileRow.spacing = 8
+
+        saveDeviceProfileButton = NSButton(title: "Save Current Output Profile",
+                                           target: self, action: #selector(saveCurrentOutputProfile(_:)))
+        deviceProfileRow.addArrangedSubview(saveDeviceProfileButton)
+
+        removeDeviceProfileButton = NSButton(title: "Remove",
+                                             target: self, action: #selector(removeCurrentOutputProfile(_:)))
+        deviceProfileRow.addArrangedSubview(removeDeviceProfileButton)
+
+        mainStack.addArrangedSubview(deviceProfileRow)
+        updateDeviceProfileControls()
+
         // ── General ──
         let generalHeader = makeSectionHeader("General")
         mainStack.addArrangedSubview(generalHeader)
@@ -266,6 +308,36 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         fillRow.edgeInsets = NSEdgeInsets(top: 0, left: 18, bottom: 0, right: 0)
         group.addArrangedSubview(fillRow)
         return group
+    }
+
+    private func updateDeviceProfileControls() {
+        guard deviceProfileLabel != nil else { return }
+        let uid = audioEngine.outputDeviceUID
+        let deviceName = audioEngine.outputDeviceName
+        let hasDevice = !uid.isEmpty
+
+        deviceProfileEnabledCheckbox.isEnabled = hasDevice
+        deviceProfileEnabledCheckbox.state = audioEngine.isRunning ? .on : .off
+        saveDeviceProfileButton.isEnabled = hasDevice
+        removeDeviceProfileButton.isEnabled = hasDevice && OutputDeviceProfileStore.profile(for: uid) != nil
+
+        guard hasDevice else {
+            deviceProfileLabel.stringValue = "No output device profile is available."
+            return
+        }
+
+        if let profile = OutputDeviceProfileStore.profile(for: uid) {
+            let enabled = profile.isEnabled ? "On" : "Off"
+            let bypass = profile.bypassed ? "Bypass on" : "Bypass off"
+            deviceProfileLabel.stringValue = "\(deviceName): \(enabled), \(profile.presetName), \(bypass), In \(formatSigned(profile.inputGainDB))"
+        } else {
+            let running = audioEngine.isRunning ? "iQualize is currently running" : "iQualize audio is off"
+            deviceProfileLabel.stringValue = "\(deviceName): no saved profile. \(running) for this output."
+        }
+    }
+
+    private func formatSigned(_ value: Float) -> String {
+        String(format: "%@%.1f dB", value >= 0 ? "+" : "", value)
     }
 
     // MARK: - Actions
@@ -398,6 +470,45 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         state.showBandwidthAsQ = asQ
         state.save()
         eqWindowController?.syncBandwidthMode(asQ: asQ)
+    }
+
+    @objc private func toggleCurrentOutputEnabled(_ sender: NSButton) {
+        audioEngine.setEnabled(sender.state == .on)
+
+        var state = iQualizeState.load()
+        state.isEnabled = audioEngine.isRunning
+        state.save()
+
+        if var profile = OutputDeviceProfileStore.profile(for: audioEngine.outputDeviceUID) {
+            profile.isEnabled = audioEngine.isRunning
+            profile.presetID = audioEngine.activePreset.id
+            profile.presetName = audioEngine.activePreset.name
+            profile.bypassed = audioEngine.bypassed
+            profile.inputGainDB = audioEngine.inputGainDB
+            OutputDeviceProfileStore.save(profile)
+        }
+
+        updateDeviceProfileControls()
+        onOutputEnabledChanged?()
+    }
+
+    @objc private func saveCurrentOutputProfile(_ sender: NSButton) {
+        let profile = OutputDeviceProfile(
+            deviceUID: audioEngine.outputDeviceUID,
+            deviceName: audioEngine.outputDeviceName,
+            isEnabled: audioEngine.isRunning,
+            presetID: audioEngine.activePreset.id,
+            presetName: audioEngine.activePreset.name,
+            bypassed: audioEngine.bypassed,
+            inputGainDB: audioEngine.inputGainDB
+        )
+        OutputDeviceProfileStore.save(profile)
+        updateDeviceProfileControls()
+    }
+
+    @objc private func removeCurrentOutputProfile(_ sender: NSButton) {
+        OutputDeviceProfileStore.delete(deviceUID: audioEngine.outputDeviceUID)
+        updateDeviceProfileControls()
     }
 
     @objc private func toggleHideFromDock(_ sender: NSButton) {


### PR DESCRIPTION
Hi, I added output-device profiles and per-preset input gain.

I needed this for a headphone EQ setup where my wired headphones need a specific preset and input gain, but I also want AirPods/speakers to use a different state or stay off. Since I already got it working locally, I figured I would send it over in case it is useful. No pressure if you would rather rework it in your own style.

Changes:
- Presets can now store `inputGainDB`, so switching presets restores the matching input gain.
- Output profiles are saved per CoreAudio output device UID.
- Settings has an Output Profile section for saving/removing the current output profile.
- Device changes automatically apply the matching profile.
- Once output profiles are in use, unprofiled outputs fall back to Flat, bypassed, input gain 0, and iQualize stopped, so a headphone EQ/tap path does not leak onto other devices.
- Before any output profiles exist, the app keeps the previous default behavior and runs normally.

Built with Codex and checked locally with `swift build -c release` on Xcode 26.5 / Swift 6.3.2.

All the best.