### PR TITLE
fix: remove unused band reorder grab-handle row from Dream EQ

### DIFF
--- a/Sources/iQualize/DreamUI/DreamRootView.swift
+++ b/Sources/iQualize/DreamUI/DreamRootView.swift
@@ -16,7 +16,6 @@ struct DreamRootView: View {
             VStack(spacing: 0) {
                 EQCanvasView(vm: vm)
                 EQReadoutGrid(vm: vm)
-                    .coordinateSpace(name: "readouts")
             }
             .overlay(alignment: .top)    { theme.line.frame(height: 1) }
             .overlay(alignment: .bottom) { theme.line.frame(height: 1) }

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -39,10 +39,6 @@ final class DreamViewModel {
     var theme: DreamThemePreference = .auto
     var editing: EditingTarget?
 
-    // MARK: - Reorder drag state (handle row)
-
-    var reorderDrag: ReorderDrag?
-
     // MARK: - Audio mirror (rebuilt from audioEngine on change)
 
     var bands: [EQBand] = []
@@ -479,25 +475,6 @@ final class DreamViewModel {
         }
     }
 
-    func reorderBands(fromID: UUID, toIndex: Int) {
-        let sorted = displayBands
-        guard let fromIdx = sorted.firstIndex(where: { $0.id == fromID }) else { return }
-        let clamped = max(0, min(sorted.count - 1, toIndex))
-        guard clamped != fromIdx else { return }
-        mutate("Reorder Bands") {
-            var reord = sorted
-            let moved = reord.remove(at: fromIdx)
-            reord.insert(moved, at: clamped)
-            // Reassign frequencies to the new positions, preserving the original ascending sequence.
-            let originalFreqs = sorted.map(\.frequency).sorted()
-            for (newPos, b) in reord.enumerated() {
-                if let i = self.bands.firstIndex(where: { $0.id == b.id }) {
-                    self.bands[i].frequency = originalFreqs[newPos]
-                }
-            }
-        }
-    }
-
     // MARK: - Mutations: preset
 
     func loadPreset(id: UUID) {
@@ -842,9 +819,4 @@ struct EditingTarget: Equatable {
 
 enum ReadoutField: Equatable {
     case gain, frequency, bandwidth
-}
-
-struct ReorderDrag: Equatable {
-    let bandID: UUID
-    var dropIndex: Int?
 }

--- a/Sources/iQualize/DreamUI/EQReadoutGrid.swift
+++ b/Sources/iQualize/DreamUI/EQReadoutGrid.swift
@@ -14,7 +14,6 @@ struct EQReadoutGrid: View {
             row(for: .frequency, bands: bands)
             row(for: .bandwidth, bands: bands)
             typeRow(bands: bands)
-            handleRow(bands: bands)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
@@ -37,18 +36,6 @@ struct EQReadoutGrid: View {
                 TypeCell(vm: vm, band: b)
             }
         }
-    }
-
-    @ViewBuilder
-    private func handleRow(bands: [EQBand]) -> some View {
-        GeometryReader { proxy in
-            HStack(spacing: 4) {
-                ForEach(bands, id: \.id) { b in
-                    HandleCell(vm: vm, band: b, rowWidth: proxy.size.width, totalCount: bands.count)
-                }
-            }
-        }
-        .frame(height: 14)
     }
 }
 
@@ -297,67 +284,6 @@ struct TypeCell: View {
         case .bandPass:   return "Band Pass"
         case .notch:      return "Notch"
         }
-    }
-}
-
-// MARK: - Reorder handle
-
-@available(macOS 14.2, *)
-struct HandleCell: View {
-    let vm: DreamViewModel
-    let band: EQBand
-    let rowWidth: CGFloat
-    let totalCount: Int
-
-    @Environment(\.dreamTheme) private var theme
-    @State private var hover = false
-    @State private var dragX: CGFloat? = nil
-
-    var body: some View {
-        let dragging = vm.reorderDrag?.bandID == band.id
-        ZStack {
-            // 6-dot grip
-            VStack(spacing: 2) {
-                ForEach(0..<2, id: \.self) { _ in
-                    HStack(spacing: 2) {
-                        ForEach(0..<3, id: \.self) { _ in
-                            Circle()
-                                .fill(dragging ? .white : theme.textMute)
-                                .frame(width: 2, height: 2)
-                        }
-                    }
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: 5)
-                .fill(dragging ? theme.accent : (hover ? theme.bgReadoutHover : theme.bgReadout))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 5)
-                .strokeBorder(dragging ? theme.accent : theme.line, lineWidth: 1)
-        )
-        .onHover { hover = $0 }
-        .gesture(
-            DragGesture(coordinateSpace: .named("readouts"))
-                .onChanged { v in
-                    if vm.reorderDrag?.bandID != band.id {
-                        vm.reorderDrag = ReorderDrag(bandID: band.id, dropIndex: nil)
-                    }
-                    let cellW = rowWidth / CGFloat(max(1, totalCount))
-                    let idx = max(0, min(totalCount - 1, Int(v.location.x / cellW)))
-                    if vm.reorderDrag?.dropIndex != idx {
-                        vm.reorderDrag = ReorderDrag(bandID: band.id, dropIndex: idx)
-                    }
-                }
-                .onEnded { _ in
-                    if let drag = vm.reorderDrag, let idx = drag.dropIndex {
-                        vm.reorderBands(fromID: drag.bandID, toIndex: idx)
-                    }
-                    vm.reorderDrag = nil
-                }
-        )
     }
 }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.30.1</string>
+	<string>0.30.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.30.1</string>
+	<string>0.30.2</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Removes the 6-dot drag-handle row that sat beneath each band's filter-type dropdown in the Dream EQ window — the gesture (drag-to-swap-band-frequencies) was visually noisy and not an obvious affordance.
- Cleans up the now-orphaned `HandleCell` view, `DreamViewModel.reorderBands`, `ReorderDrag` state, and the `"readouts"` coordinate space.
- Patch version bump 0.30.1 → 0.30.2.

## Test plan
- [x] `swift build` clean (no new warnings introduced)
- [x] `bash install.sh` + launch verification: app starts
- [x] Open EQ window — confirm each band column ends at the Bell type dropdown (no handle row)
- [x] Click-to-edit gain/Hz/Q cells still works
- [x] Scroll-wheel adjust on readouts still works
- [x] Type dropdown selection still works