### PR TITLE
fix: Dream UI footer layout, light-mode legibility, and canvas polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to iQualize will be documented in this file.
 ### Fixed
 - "Out:" gain label no longer wraps onto a second line; In/Out/Bal labels and values share a consistent width
 - Inline cell editing and the empty-checkbox fill are now legible in Light mode (previously white-on-light)
+- Re-selecting a band's current filter type no longer forks a built-in preset to "(Custom)" or pushes a redundant undo step
+- Undo now clears the "modified" dirty dot once the EQ curve is back to the saved values (a phantom dot previously lingered after undoing a built-in→Custom fork)
 
 ## [0.29.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.31.0] - 2026-06-29
+
+### Changed
+- Dream EQ footer reorganized into two purpose-based rows with subtle group dividers: row 1 is signal (Bypass, Peak Limiter, In/Out/Balance, Channel, Output), row 2 is display (Pre-EQ, Post-EQ, Q/Oct, max gain, Auto-scale)
+- Add-band "+" buttons inset from the canvas edges so they no longer crowd the frame
+
+### Fixed
+- "Out:" gain label no longer wraps onto a second line; In/Out/Bal labels and values share a consistent width
+- Inline cell editing and the empty-checkbox fill are now legible in Light mode (previously white-on-light)
+
 ## [0.29.0] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to iQualize will be documented in this file.
 ### Changed
 - Dream EQ footer reorganized into two purpose-based rows with subtle group dividers: row 1 is signal (Bypass, Peak Limiter, In/Out/Balance, Channel, Output), row 2 is display (Pre-EQ, Post-EQ, Q/Oct, max gain, Auto-scale)
 - Add-band "+" buttons inset from the canvas edges so they no longer crowd the frame
+- Theme (Auto/Light/Dark) moved out of the EQ toolbar into Settings → General — it's rarely changed, so the toolbar now carries just Snap and the gear
+- Snap toggle is now a magnet icon (icon-only, with a hover tooltip) instead of the "♪ Snap" label
 
 ### Fixed
 - "Out:" gain label no longer wraps onto a second line; In/Out/Bal labels and values share a consistent width

--- a/Sources/iQualize/DreamUI/DreamControls.swift
+++ b/Sources/iQualize/DreamUI/DreamControls.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - tb-btn (toolbar button)
@@ -203,36 +204,29 @@ struct DreamToolbarGroup<Content: View>: View {
     }
 }
 
-// MARK: - Magnet icon (SF Symbols has no `magnet` glyph on macOS 14–15, so draw a horseshoe)
+// MARK: - Magnet icon
 
+/// Tabler's `magnet` glyph (SF Symbols has no `magnet` on macOS), rendered straight from its SVG
+/// as a template image so it tints with the control's foreground/accent color — the Snap toggle
+/// shows it in the text color when off and white when on.
 struct MagnetIcon: View {
-    var size: CGFloat = 14
-    var lineWidth: CGFloat = 1.7
+    var size: CGFloat = 15
 
     var body: some View {
-        MagnetShape()
-            .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+        Image(nsImage: Self.image)
+            .renderingMode(.template)
+            .resizable()
+            .interpolation(.high)
+            .aspectRatio(contentMode: .fit)
             .frame(width: size, height: size)
     }
-}
 
-private struct MagnetShape: Shape {
-    func path(in rect: CGRect) -> Path {
-        // Reference geometry in a 24×24 box; horseshoe opening downward (tips at the bottom),
-        // matching the 🧲 orientation. Scaled to whatever frame we're given.
-        let s = min(rect.width, rect.height) / 24
-        func pt(_ x: CGFloat, _ y: CGFloat) -> CGPoint { CGPoint(x: rect.minX + x * s, y: rect.minY + y * s) }
-        var p = Path()
-        // Body: left prong up, arc over the top, right prong down.
-        p.move(to: pt(7, 20))
-        p.addLine(to: pt(7, 11))
-        p.addQuadCurve(to: pt(17, 11), control: pt(12, 2))
-        p.addLine(to: pt(17, 20))
-        // Pole caps at the two bottom tips.
-        p.move(to: pt(4.5, 20)); p.addLine(to: pt(9.5, 20))
-        p.move(to: pt(14.5, 20)); p.addLine(to: pt(19.5, 20))
-        return p
-    }
+    private static let image: NSImage = {
+        let svg = #"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 13V5a2 2 0 0 1 2-2h1a2 2 0 0 1 2 2v8a2 2 0 0 0 6 0V5a2 2 0 0 1 2-2h1a2 2 0 0 1 2 2v8a8 8 0 0 1-16 0m0-5h5m6 0h4"/></svg>"#
+        let img = NSImage(data: Data(svg.utf8)) ?? NSImage()
+        img.isTemplate = true
+        return img
+    }()
 }
 
 // MARK: - Filter type icon (mirrors FilterIcon paths in the JSX)

--- a/Sources/iQualize/DreamUI/DreamControls.swift
+++ b/Sources/iQualize/DreamUI/DreamControls.swift
@@ -203,6 +203,38 @@ struct DreamToolbarGroup<Content: View>: View {
     }
 }
 
+// MARK: - Magnet icon (SF Symbols has no `magnet` glyph on macOS 14–15, so draw a horseshoe)
+
+struct MagnetIcon: View {
+    var size: CGFloat = 14
+    var lineWidth: CGFloat = 1.7
+
+    var body: some View {
+        MagnetShape()
+            .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+            .frame(width: size, height: size)
+    }
+}
+
+private struct MagnetShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        // Reference geometry in a 24×24 box; horseshoe opening downward (tips at the bottom),
+        // matching the 🧲 orientation. Scaled to whatever frame we're given.
+        let s = min(rect.width, rect.height) / 24
+        func pt(_ x: CGFloat, _ y: CGFloat) -> CGPoint { CGPoint(x: rect.minX + x * s, y: rect.minY + y * s) }
+        var p = Path()
+        // Body: left prong up, arc over the top, right prong down.
+        p.move(to: pt(7, 20))
+        p.addLine(to: pt(7, 11))
+        p.addQuadCurve(to: pt(17, 11), control: pt(12, 2))
+        p.addLine(to: pt(17, 20))
+        // Pole caps at the two bottom tips.
+        p.move(to: pt(4.5, 20)); p.addLine(to: pt(9.5, 20))
+        p.move(to: pt(14.5, 20)); p.addLine(to: pt(19.5, 20))
+        return p
+    }
+}
+
 // MARK: - Filter type icon (mirrors FilterIcon paths in the JSX)
 
 struct FilterTypeIcon: View {

--- a/Sources/iQualize/DreamUI/DreamControls.swift
+++ b/Sources/iQualize/DreamUI/DreamControls.swift
@@ -87,7 +87,7 @@ struct DreamCheckbox: View {
             HStack(spacing: 5) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(isOn && !disabled ? theme.accent : Color.white.opacity(0.04))
+                        .fill(isOn && !disabled ? theme.accent : (theme.scheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.04)))
                         .overlay(
                             RoundedRectangle(cornerRadius: 3)
                                 .strokeBorder(isOn && !disabled ? theme.accent : theme.line2, lineWidth: 1)
@@ -106,6 +106,8 @@ struct DreamCheckbox: View {
                 Text(title)
                     .font(.system(size: 11))
                     .foregroundStyle(disabled ? theme.textMute : theme.textDim)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
             }
             .opacity(disabled ? 0.4 : 1.0)
             .contentShape(Rectangle())
@@ -128,6 +130,8 @@ struct DreamSegment<Value: Hashable>: View {
                 Button(action: { selection = opt.value }) {
                     Text(opt.label)
                         .font(.system(size: 10.5))
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                         .padding(.horizontal, 7)
                         .padding(.vertical, 1.5)
                         .foregroundStyle(selection == opt.value ? .white : theme.textDim)

--- a/Sources/iQualize/DreamUI/DreamFooter.swift
+++ b/Sources/iQualize/DreamUI/DreamFooter.swift
@@ -7,32 +7,45 @@ struct DreamFooter: View {
     @Environment(\.dreamTheme) private var theme
 
     var body: some View {
-        VStack(spacing: 4) {
-            // Row 1: Bypass · In · Out · Balance · Channel
-            HStack(spacing: 12) {
+        VStack(spacing: 6) {
+            // Row 1 — levels & routing.
+            HStack(spacing: 10) {
                 bypassToggle
+                divider
                 gainSlider(label: "In", value: $vm.inGainDB, onChange: vm.applyInputGain)
                 gainSlider(label: "Out", value: $vm.outGainDB, onChange: vm.applyOutputGain)
                 balanceSlider
+                divider
                 channelSegment
-                Spacer()
+                Spacer(minLength: 8)
                 outputLabel
             }
 
-            // Row 2: Pre-EQ · Post-EQ · Q/Oct · Peak Limiter · Auto-scale · Max gain
-            HStack(spacing: 12) {
+            // Row 2 — spectrum, scale, and processing.
+            HStack(spacing: 10) {
                 preEqToggle
                 postEqToggle
-                bandwidthDisplaySegment
-                peakLimiterToggle
+                divider
                 autoScaleToggle
+                bandwidthDisplaySegment
                 maxGainSegment
+                divider
+                peakLimiterToggle
                 Spacer()
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
         .background(theme.bgToolbar)
+    }
+
+    /// Thin vertical separator between footer groups, matching the toolbar's
+    /// `DreamToolbarGroup` divider language.
+    @ViewBuilder
+    private var divider: some View {
+        theme.line
+            .frame(width: 1, height: 16)
+            .padding(.horizontal, 2)
     }
 
     // MARK: - Toggles
@@ -85,7 +98,9 @@ struct DreamFooter: View {
             Text("\(label):")
                 .font(.system(size: 11))
                 .foregroundStyle(theme.textMute)
-                .frame(minWidth: 22, alignment: .trailing)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 28, alignment: .trailing)
             DreamSlider(
                 value: Binding(
                     get: { Double(value.wrappedValue) },
@@ -97,7 +112,9 @@ struct DreamFooter: View {
             Text(formatSigned(value.wrappedValue))
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundStyle(theme.textDim)
-                .frame(minWidth: 50, alignment: .leading)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 52, alignment: .leading)
         }
     }
 
@@ -107,7 +124,9 @@ struct DreamFooter: View {
             Text("Bal:")
                 .font(.system(size: 11))
                 .foregroundStyle(theme.textMute)
-                .frame(minWidth: 22, alignment: .trailing)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 28, alignment: .trailing)
             DreamSlider(
                 value: Binding(
                     get: { Double(vm.balance) },
@@ -120,7 +139,9 @@ struct DreamFooter: View {
             Text(formatBalance(vm.balance))
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundStyle(theme.textDim)
-                .frame(minWidth: 30, alignment: .leading)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 34, alignment: .leading)
         }
     }
 
@@ -168,8 +189,11 @@ struct DreamFooter: View {
         HStack(spacing: 4) {
             Text("Output:")
                 .foregroundStyle(theme.textMute)
+                .fixedSize()
             Text(vm.outputDeviceName)
                 .foregroundStyle(theme.textDim)
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
         .font(.system(size: 12))
     }

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -98,7 +98,7 @@ struct DreamToolbar: View {
             get: { vm.snapToSemitone },
             set: { vm.snapToSemitone = $0; vm.persistSnap() }
         )) {
-            MagnetIcon(size: 14)
+            MagnetIcon(size: 15)
         }
         .toggleStyle(.button)
         .controlSize(.regular)

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -98,35 +98,17 @@ struct DreamToolbar: View {
             get: { vm.snapToSemitone },
             set: { vm.snapToSemitone = $0; vm.persistSnap() }
         )) {
-            HStack(spacing: 4) {
-                Image(systemName: "music.note").font(.system(size: 11))
-                Text("Snap")
-            }
+            MagnetIcon(size: 14)
         }
         .toggleStyle(.button)
         .controlSize(.regular)
-
-        Menu {
-            Picker("Theme", selection: Binding(
-                get: { vm.theme },
-                set: { vm.theme = $0; vm.persistTheme() }
-            )) {
-                Text("Auto").tag(DreamThemePreference.auto)
-                Text("Light").tag(DreamThemePreference.light)
-                Text("Dark").tag(DreamThemePreference.dark)
-            }
-        } label: {
-            Image(systemName: vm.theme.systemImage).font(.system(size: 12, weight: .medium))
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .controlSize(.regular)
-        .fixedSize()
+        .help("Snap band frequencies to semitones")
 
         Button(action: { vm.onOpenSettings?() }) {
             Image(systemName: "gearshape").font(.system(size: 12, weight: .medium))
         }
         .controlSize(.regular)
+        .help("Settings")
     }
 
     private var presetButtonLabel: String {

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -184,12 +184,17 @@ final class DreamViewModel {
         }
         audioEngine.activePreset = preset
         let wasModified = isModified
-        if savedSnapshot != preset {
-            isModified = true
-        } else {
-            isModified = false
-        }
+        isModified = !contentMatchesSaved(preset)
         if wasModified != isModified { onTitleShouldUpdate?() }
+    }
+
+    /// The dirty flag tracks whether the EQ *content* (band curves) differs from the saved
+    /// baseline — not the preset's identity (id / name / built-in flag). Comparing identity is
+    /// wrong across a built-in→"(Custom)" fork: undoing the fork restores the same curve under a
+    /// different identity and would otherwise leave a phantom dirty dot.
+    private func contentMatchesSaved(_ preset: EQPresetData) -> Bool {
+        guard let saved = savedSnapshot else { return false }
+        return preset.bands == saved.bands && preset.rightBands == saved.rightBands
     }
 
     // MARK: - Mutation helpers
@@ -363,17 +368,16 @@ final class DreamViewModel {
             guard let self else { return }
             let redoPreset = self.audioEngine.activePreset
             self.audioEngine.activePreset = oldPreset
+            // Set the dirty flag *before* syncing: syncFromAudioEngine() fires the title-update
+            // callback, which must see the corrected isModified value (otherwise the title keeps a
+            // stale dirty dot even though Reset is correctly disabled).
+            self.isModified = !self.contentMatchesSaved(oldPreset)
             self.syncFromAudioEngine()
-            if oldPreset == self.savedSnapshot {
-                self.isModified = false
-            } else {
-                self.isModified = true
-            }
             self.registerUndo(actionName: actionName, oldPreset: redoPreset)
         }
         undoManager.setActionName(actionName)
         // Ensure modified flag is correct after redo path.
-        isModified = (currentPreset != savedSnapshot)
+        isModified = !contentMatchesSaved(currentPreset)
     }
 
     // MARK: - Band lookups
@@ -390,10 +394,25 @@ final class DreamViewModel {
 
     func updateBand(id: UUID, frequency: Float? = nil, gain: Float? = nil, bandwidth: Float? = nil, filterType: FilterType? = nil, registerUndo: Bool = false) {
         guard let i = indexOfBand(id: id) else { return }
+        let cur = bands[i]
+        // Clamp the requested values the same way the mutation will, so the no-op check below
+        // compares apples to apples.
+        let newFreq = frequency.map { max(20, min(20000, $0)) }
+        let newGain = gain.map      { max(-gainClamp, min(gainClamp, $0)) }
+        let newBW   = bandwidth.map { max(0.05, min(8.0, $0)) }
+        // No-op guard: if nothing actually changes, don't mutate. This keeps re-selecting a band's
+        // current filter type (or nudging a value that's already at its clamp) from forking a
+        // built-in preset to "(Custom)" or pushing a redundant undo step.
+        let changes =
+            (newFreq.map     { $0 != cur.frequency }  ?? false) ||
+            (newGain.map     { $0 != cur.gain }       ?? false) ||
+            (newBW.map       { $0 != cur.bandwidth }  ?? false) ||
+            (filterType.map  { $0 != cur.filterType } ?? false)
+        guard changes else { return }
         let body = {
-            if let f = frequency { self.bands[i].frequency = max(20, min(20000, f)) }
-            if let g = gain      { self.bands[i].gain      = max(-self.gainClamp, min(self.gainClamp, g)) }
-            if let b = bandwidth { self.bands[i].bandwidth = max(0.05, min(8.0, b)) }
+            if let f = newFreq { self.bands[i].frequency = f }
+            if let g = newGain { self.bands[i].gain      = g }
+            if let b = newBW   { self.bands[i].bandwidth = b }
             if let t = filterType { self.bands[i].filterType = t }
         }
         if registerUndo {

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -106,12 +106,6 @@ final class DreamViewModel {
         }
     }
 
-    func persistTheme() {
-        var s = iQualizeState.load()
-        s.dreamTheme = theme.rawValue
-        s.save()
-    }
-
     func persistSnap() {
         var s = iQualizeState.load()
         s.snapToSemitone = snapToSemitone

--- a/Sources/iQualize/DreamUI/EQCanvasView.swift
+++ b/Sources/iQualize/DreamUI/EQCanvasView.swift
@@ -45,7 +45,7 @@ struct EQCanvasView: View {
     private func addButton(_ side: AddSide) -> some View {
         AddBandButton(side: side) { vm.addBand(side == .left ? .left : .right) }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: side == .left ? .leading : .trailing)
-            .padding(.horizontal, 4)
+            .padding(.horizontal, 8)
     }
 
     // MARK: - Pointer overlay

--- a/Sources/iQualize/DreamUI/EQReadoutGrid.swift
+++ b/Sources/iQualize/DreamUI/EQReadoutGrid.swift
@@ -61,7 +61,7 @@ struct ReadoutCell: View {
                 TextField("", text: $editingText, onCommit: commitEdit)
                     .textFieldStyle(.plain)
                     .multilineTextAlignment(.center)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(theme.scheme == .light ? theme.text : .white)
                     .font(.system(size: 11, design: .monospaced))
                     .focused($focused)
                     .onAppear {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -113,6 +113,10 @@ final class EQWindowController: NSWindowController {
         viewModel.bandwidthDisplay = asQ ? .q : .oct
     }
 
+    func syncTheme(_ preference: DreamThemePreference) {
+        viewModel.theme = preference
+    }
+
     // The color/fill settings are wired through Settings → UserDefaults; the canvas re-reads
     // them on the next draw. Setters left as no-ops to preserve the public surface.
     func syncPreEqLineColor(_ color: NSColor) {}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.30.2</string>
+	<string>0.31.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.30.2</string>
+	<string>0.31.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -23,6 +23,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private var preEqFillResetButton: NSButton!
     private var postEqFillResetButton: NSButton!
     private var bandwidthModeSegment: NSSegmentedControl!
+    private var themeSegment: NSSegmentedControl!
     private var hideFromDockCheckbox: NSButton!
     private var startAtLoginCheckbox: NSButton!
 
@@ -71,6 +72,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         postEqFillColorWell.color = (state.postEqFillColorHex.flatMap(NSColor.init(srgbHexRGB:))) ?? .systemOrange
         applyPostEqEnabled(!audioEngine.bypassed)
         bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
+        themeSegment.selectedSegment = Self.themeIndex(for: state.dreamTheme)
     }
 
     func syncBypass(_ on: Bool) {
@@ -195,6 +197,21 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         // ── General ──
         let generalHeader = makeSectionHeader("General")
         mainStack.addArrangedSubview(generalHeader)
+
+        let themeRow = NSStackView()
+        themeRow.orientation = .horizontal
+        themeRow.spacing = 6
+
+        let themeLabel = NSTextField(labelWithString: "Theme:")
+        themeLabel.font = .systemFont(ofSize: 13)
+        themeRow.addArrangedSubview(themeLabel)
+
+        themeSegment = NSSegmentedControl(labels: ["Auto", "Light", "Dark"], trackingMode: .selectOne,
+                                          target: self, action: #selector(themeChanged(_:)))
+        themeSegment.selectedSegment = Self.themeIndex(for: state.dreamTheme)
+        themeRow.addArrangedSubview(themeSegment)
+
+        mainStack.addArrangedSubview(themeRow)
 
         hideFromDockCheckbox = NSButton(checkboxWithTitle: "Hide from Dock",
                                           target: self, action: #selector(toggleHideFromDock(_:)))
@@ -398,6 +415,31 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         state.showBandwidthAsQ = asQ
         state.save()
         eqWindowController?.syncBandwidthMode(asQ: asQ)
+    }
+
+    @objc private func themeChanged(_ sender: NSSegmentedControl) {
+        let preference = Self.themePreference(for: sender.selectedSegment)
+        var state = iQualizeState.load()
+        state.dreamTheme = preference.rawValue
+        state.save()
+        eqWindowController?.syncTheme(preference)
+    }
+
+    /// Map a persisted `dreamTheme` raw value to a segment index (0 = Auto, 1 = Light, 2 = Dark).
+    private static func themeIndex(for raw: String?) -> Int {
+        switch DreamThemePreference(rawValue: raw ?? "") {
+        case .light: return 1
+        case .dark:  return 2
+        default:     return 0
+        }
+    }
+
+    private static func themePreference(for index: Int) -> DreamThemePreference {
+        switch index {
+        case 1:  return .light
+        case 2:  return .dark
+        default: return .auto
+        }
     }
 
     @objc private func toggleHideFromDock(_ sender: NSButton) {


### PR DESCRIPTION
A fine-tuning / love-for-detail pass over the new SwiftUI Dream EQ window, built up over a few commits while iterating interactively.

## Changed — layout & appearance (commit 1)

**Footer** (`DreamFooter.swift`)
- **Fix the "Out:" label wrapping** onto a second line. The `In:`/`Out:`/`Bal:` labels shared a 22pt frame too narrow for "Out:". Labels and values now use `lineLimit(1)`/`fixedSize` with consistent widths and align on one line.
- **Regroup the two rows by purpose**, with subtle vertical dividers matching the toolbar's group language:
  - Row 1 — levels & routing: `Bypass │ In · Out · Bal │ Linked/L/R ⟶ Output`
  - Row 2 — display & processing: `Pre-EQ · Post-EQ │ Auto-scale · Q/Oct · ±max │ Peak Limiter`
- Output label truncates gracefully instead of wrapping at narrow widths.

**Components** (`DreamControls.swift`) — harden `DreamCheckbox` / `DreamSegment` labels (`lineLimit(1)`/`fixedSize`) so they never collapse into vertical text; scheme-aware empty-checkbox fill.

**Canvas** (`EQCanvasView.swift`) — inset the add-band "+" buttons (4→8pt) so they no longer crowd the frame edges.

**Light mode** (`EQReadoutGrid.swift`) — inline cell-editing text was hardcoded `.white` (invisible on the light field); now theme-aware.

## Fixed — behavior (commit 2, `DreamViewModel.swift`)

- **Re-selecting a band's current filter type forked a built-in to "(Custom)".** `updateBand()` now no-ops when the requested value(s) already match the band — no fork, no redundant undo step.
- **Undo left a phantom "modified" dirty dot.** The flag compared whole-`EQPresetData` identity, so undoing a built-in→Custom fork (same curve, different identity) still read as modified. It now compares EQ *content* (bands + rightBands), and the undo path sets `isModified` before the title-update callback fires.

## Changed — toolbar & Settings (commit 3)

- **Moved the theme control (Auto/Light/Dark) out of the EQ toolbar into Settings → General.** It's rarely changed, so it doesn't need to sit in the window chrome. Changing it there updates the EQ window live via a new `EQWindowController.syncTheme()`, mirroring the existing Settings→EQ sync pattern.
- **Snap toggle is now an icon-only magnet + hover tooltip** instead of "♪ Snap". SF Symbols has no `magnet` glyph on this OS, so it's a small custom horseshoe `Shape` (`MagnetIcon`), matching the existing `FilterTypeIcon` approach.

## Verification

Built, installed, exercised the live window hands-on (dark + light):
- Footer reads cleanly on two rows; "Out:" on one line; dividers group each row; inline editing legible in light mode.
- Filter quirk: re-selecting the same type no longer forks; a real change forks + marks dirty; **undo clears the dot and restores the built-in; redo restores the dirty state.**
- **Theme menu gone from the toolbar; Settings → General flips the EQ window Light/Dark live; the magnet renders in both on/off states and still toggles snapping.**

## Notes for reviewer

- Peak Limiter stays in footer row 2 (row 1 can't fit it at the window's width), isolated by a divider.
- The theme's scope is unchanged: it controls the Dream EQ window's appearance (the Settings window itself follows system appearance).
- **Left intentionally unaddressed:** right-edge knob-label crowding (8k/16k labels can overlap) — needs collision-avoidance, too risky for this PR.

Version bumped to **0.31.0** (minor) + CHANGELOG entry.

Stay Tuned
Darius