### PR TITLE
release: v0.32.0 — new SwiftUI Dream UI + startup gain fix

### DIFF
--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.31.0</string>
+	<string>0.31.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.31.0</string>
+	<string>0.31.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -35,6 +35,8 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         audioEngine.maxGainDB = state.maxGainDB
         audioEngine.bypassed = state.bypassed
         audioEngine.balance = state.balance
+        audioEngine.inputGainDB = state.inputGainDB
+        audioEngine.outputGainDB = state.outputGainDB
         audioEngine.setEnabled(true)
         updateIcon()
 


### PR DESCRIPTION
The v0.32.0 release. Bundles the headline new UI (which shipped in code as 0.30.0–0.31.0 but was never cut as a GitHub release) with the startup gain fix.

## Included

### New SwiftUI "Dream" EQ window (0.30.x)
The EQ surface was rebuilt from scratch on a SwiftUI `Canvas` — dB/Hz axes, real pre/post-EQ spectrum, smoothed Catmull-Rom traces, per-band ghost responses, draggable knobs + bandwidth handles, a five-row readout grid with inline editing, native menus, and a tighter 880×600 window. Same audio engine, presets, and persisted state underneath.

### Startup gain fix — Fixes #74
`MenuBarController.init` restored every persisted audio property except In/Out gain before starting the engine, so on relaunch audio played at unadjusted levels until the EQ window was opened. Now both gains are restored alongside `balance`, before `setEnabled(true)`.

## Docs
- CHANGELOG: retroactively documents the Dream UI rewrite (0.30.0–0.30.2) and adds the 0.32.0 gain fix
- README: removes the stale drag-and-drop reorder note (now right-click only); adds the Theme control to Settings → General
- New hero screenshot (preview.webp) updated for the new UI

## Version
`0.31.0 → 0.32.0`

## Verification
- Builds, signs, installs, and launches (`OK: app running`)
- Gain repro: set non-zero In/Out gain, quit, relaunch without opening the EQ window — audio reflects the saved gain immediately

Stay Tuned
Darius