### PR TITLE
fix: request audio-only permission instead of screen recording

### DIFF
--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.32.1</string>
+	<string>0.32.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.32.1</string>
+	<string>0.32.2</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -1,5 +1,4 @@
 import AppKit
-import CoreGraphics
 import Foundation
 import ServiceManagement
 
@@ -13,12 +12,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     var isRealQuit = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Check screen/audio capture permission — CATap requires it
-        let hasAccess = CGPreflightScreenCaptureAccess()
-        if !hasAccess {
-            CGRequestScreenCaptureAccess()
-        }
-
+        // No explicit permission preflight here — AudioHardwareCreateProcessTap
+        // (in AudioEngine.start()) triggers its own audio-only TCC prompt via
+        // NSAudioCaptureUsageDescription, scoped to system audio capture rather
+        // than the combined Screen & System Audio Recording permission.
         setupMainMenu()
 
         audioEngine = AudioEngine()


### PR DESCRIPTION
## Summary
- `AudioHardwareCreateProcessTap` (Core Audio Process Tap) already triggers its own TCC prompt scoped to `NSAudioCaptureUsageDescription` (already declared in Info.plist) — no need for the app to separately request Screen Recording access.
- Removed the eager `CGPreflightScreenCaptureAccess`/`CGRequestScreenCaptureAccess` call at launch, which was forcing the broader combined "Screen & System Audio Recording" permission instead of the narrower audio-only one.
- Bumped version 0.32.1 → 0.32.2 (patch, bug fix).

Fixes the permission-scope issue: users no longer need to grant screen recording access for an app that only processes system audio.

## Verification
- `swift build` succeeds.
- App builds, installs, and launches successfully (`pgrep -x iQualize` confirms running).
- Reset TCC permissions (`tccutil reset ScreenCapture com.iqualize.app`) and relaunched — confirmed visually in System Settings → Privacy & Security → Screen & System Audio Recording that iQualize now appears under the separate **"System Audio Recording Only"** section, not the combined **"Screen & System Audio Recording"** section.
- EQ window opens and processes live audio normally under the narrower permission — no regression.

## Test plan
- [x] `swift build`
- [x] Install + launch verification per CLAUDE.md
- [x] Visual confirmation in System Settings that permission scope narrowed correctly
- [x] Live audio processing still works