### PR TITLE
Pin favorite presets to the top of the menu bar dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to iQualize will be documented in this file.
 ## [0.33.0] - 2026-07-11
 
 ### Added
-- Pin/favorite presets so they show at the top level of the menu bar dropdown for one-click switching, instead of always having to dig into the Presets submenu (#80). ⌥-click any preset (in the top-level Favorites list or the Presets submenu) to pin/unpin it; a star marks favorited presets in the submenu
+- Pin/favorite presets so they show at the top of both the menu bar dropdown and the in-app preset picker for one-click switching, instead of always having to dig into the full preset list (#80). ⌥-click any preset to pin/unpin it; a star marks favorited presets in the full list
 
 ## [0.32.2] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.33.0] - 2026-07-11
+
+### Added
+- Pin/favorite presets so they show at the top level of the menu bar dropdown for one-click switching, instead of always having to dig into the Presets submenu (#80). ⌥-click any preset (in the top-level Favorites list or the Presets submenu) to pin/unpin it; a star marks favorited presets in the submenu
+
 ## [0.32.2] - 2026-07-11
 
 ### Fixed

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @available(macOS 14.2, *)
@@ -44,15 +45,18 @@ struct DreamToolbar: View {
     @ViewBuilder
     private var presetGroup: some View {
         Menu {
-            ForEach(vm.presetStore.allPresets, id: \.id) { preset in
-                Button(action: { vm.loadPreset(id: preset.id) }) {
-                    if preset.id == vm.activePresetID {
-                        Label(preset.name, systemImage: "checkmark")
-                    } else {
-                        Text(preset.name)
-                    }
+            let favorites = vm.presetStore.favoritePresets
+            if !favorites.isEmpty {
+                ForEach(favorites, id: \.id) { preset in
+                    presetButton(for: preset)
                 }
+                Divider()
             }
+            ForEach(vm.presetStore.allPresets, id: \.id) { preset in
+                presetButton(for: preset)
+            }
+            Divider()
+            Text("⌥-click a preset to pin/unpin")
         } label: {
             HStack(spacing: 4) {
                 Text(presetButtonLabel)
@@ -114,5 +118,24 @@ struct DreamToolbar: View {
     private var presetButtonLabel: String {
         let suffix = vm.isBuiltIn ? " (Built-in)" : ""
         return "\(vm.presetName)\(suffix)"
+    }
+
+    @ViewBuilder
+    private func presetButton(for preset: EQPresetData) -> some View {
+        Button(action: {
+            if NSEvent.modifierFlags.contains(.option) {
+                vm.presetStore.toggleFavorite(preset.id)
+            } else {
+                vm.loadPreset(id: preset.id)
+            }
+        }) {
+            let isFavorite = vm.presetStore.isFavorite(preset.id)
+            let name = isFavorite ? "★ \(preset.name)" : preset.name
+            if preset.id == vm.activePresetID {
+                Label(name, systemImage: "checkmark")
+            } else {
+                Text(name)
+            }
+        }
     }
 }

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -129,12 +129,12 @@ struct DreamToolbar: View {
                 vm.loadPreset(id: preset.id)
             }
         }) {
-            let isFavorite = vm.presetStore.isFavorite(preset.id)
-            let name = isFavorite ? "★ \(preset.name)" : preset.name
             if preset.id == vm.activePresetID {
-                Label(name, systemImage: "checkmark")
+                Label(preset.name, systemImage: "checkmark")
+            } else if vm.presetStore.isFavorite(preset.id) {
+                Label(preset.name, systemImage: "pin.fill")
             } else {
-                Text(name)
+                Text(preset.name)
             }
         }
     }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.32.2</string>
+	<string>0.33.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.32.2</string>
+	<string>0.33.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -76,6 +76,21 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
 
         menu.addItem(.separator())
 
+        // Favorites — pinned presets for one-click switching
+        let favorites = presetStore.favoritePresets
+        if !favorites.isEmpty {
+            for preset in favorites {
+                let item = NSMenuItem(title: preset.name,
+                                      action: #selector(selectPreset(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = preset.id.uuidString
+                item.state = audioEngine.activePreset.id == preset.id ? .on : .off
+                item.image = Self.starImage
+                menu.addItem(item)
+            }
+            menu.addItem(.separator())
+        }
+
         // Presets submenu
         let presetMenuItem = NSMenuItem(title: "Presets (\(audioEngine.activePreset.name))",
                                          action: nil, keyEquivalent: "")
@@ -85,13 +100,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         builtInHeader.isEnabled = false
         presetSubmenu.addItem(builtInHeader)
         for preset in EQPresetData.builtInPresets {
-            let item = NSMenuItem(title: preset.name,
-                                  action: #selector(selectPreset(_:)), keyEquivalent: "")
-            item.target = self
-            item.representedObject = preset.id.uuidString
-            item.state = audioEngine.activePreset.id == preset.id ? .on : .off
-            item.indentationLevel = 1
-            presetSubmenu.addItem(item)
+            presetSubmenu.addItem(presetItem(for: preset))
         }
 
         if !presetStore.customPresets.isEmpty {
@@ -100,15 +109,14 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
             customHeader.isEnabled = false
             presetSubmenu.addItem(customHeader)
             for preset in presetStore.customPresets {
-                let item = NSMenuItem(title: preset.name,
-                                      action: #selector(selectPreset(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = preset.id.uuidString
-                item.state = audioEngine.activePreset.id == preset.id ? .on : .off
-                item.indentationLevel = 1
-                presetSubmenu.addItem(item)
+                presetSubmenu.addItem(presetItem(for: preset))
             }
         }
+
+        presetSubmenu.addItem(.separator())
+        let pinHint = NSMenuItem(title: "⌥-click a preset to pin/unpin", action: nil, keyEquivalent: "")
+        pinHint.isEnabled = false
+        presetSubmenu.addItem(pinHint)
 
         presetMenuItem.submenu = presetSubmenu
         menu.addItem(presetMenuItem)
@@ -159,12 +167,39 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         menu.addItem(quitItem)
     }
 
+    // MARK: - Presets
+
+    private static let starImage: NSImage = {
+        let image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: "Favorite")!
+        image.isTemplate = true
+        return image
+    }()
+
+    private func presetItem(for preset: EQPresetData) -> NSMenuItem {
+        let item = NSMenuItem(title: preset.name,
+                              action: #selector(selectPreset(_:)), keyEquivalent: "")
+        item.target = self
+        item.representedObject = preset.id.uuidString
+        item.state = audioEngine.activePreset.id == preset.id ? .on : .off
+        item.indentationLevel = 1
+        if presetStore.isFavorite(preset.id) {
+            item.image = Self.starImage
+        }
+        return item
+    }
+
     // MARK: - Actions
 
     @objc private func selectPreset(_ sender: NSMenuItem) {
         guard let uuidString = sender.representedObject as? String,
-              let id = UUID(uuidString: uuidString),
-              let preset = presetStore.preset(for: id) else { return }
+              let id = UUID(uuidString: uuidString) else { return }
+
+        if NSEvent.modifierFlags.contains(.option) {
+            presetStore.toggleFavorite(id)
+            return
+        }
+
+        guard let preset = presetStore.preset(for: id) else { return }
         audioEngine.activePreset = preset
         var s = iQualizeState.load()
         s.selectedPresetID = preset.id

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -85,7 +85,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
                 item.target = self
                 item.representedObject = preset.id.uuidString
                 item.state = audioEngine.activePreset.id == preset.id ? .on : .off
-                item.image = Self.starImage
+                item.image = Self.pinImage
                 menu.addItem(item)
             }
             menu.addItem(.separator())
@@ -169,8 +169,8 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
 
     // MARK: - Presets
 
-    private static let starImage: NSImage = {
-        let image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: "Favorite")!
+    private static let pinImage: NSImage = {
+        let image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: "Pinned")!
         image.isTemplate = true
         return image
     }()
@@ -183,7 +183,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         item.state = audioEngine.activePreset.id == preset.id ? .on : .off
         item.indentationLevel = 1
         if presetStore.isFavorite(preset.id) {
-            item.image = Self.starImage
+            item.image = Self.pinImage
         }
         return item
     }

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -6,12 +6,20 @@ import Observation
 @MainActor
 final class PresetStore {
     private(set) var customPresets: [EQPresetData] = []
+    /// Pinned/favorited preset IDs, in the order they were favorited.
+    private(set) var favoritePresetIDs: [UUID] = []
 
     var allPresets: [EQPresetData] {
         EQPresetData.builtInPresets + customPresets
     }
 
+    /// Favorited presets, in favorite order. Skips IDs that no longer resolve to a preset.
+    var favoritePresets: [EQPresetData] {
+        favoritePresetIDs.compactMap { preset(for: $0) }
+    }
+
     private static let key = "com.iqualize.customPresets"
+    private static let favoritesKey = "com.iqualize.favoritePresetIDs"
 
     init() {
         load()
@@ -19,6 +27,19 @@ final class PresetStore {
 
     func preset(for id: UUID) -> EQPresetData? {
         allPresets.first { $0.id == id }
+    }
+
+    func isFavorite(_ id: UUID) -> Bool {
+        favoritePresetIDs.contains(id)
+    }
+
+    func toggleFavorite(_ id: UUID) {
+        if let index = favoritePresetIDs.firstIndex(of: id) {
+            favoritePresetIDs.remove(at: index)
+        } else {
+            favoritePresetIDs.append(id)
+        }
+        persistFavorites()
     }
 
     func saveCustomPreset(_ preset: EQPresetData) {
@@ -33,19 +54,32 @@ final class PresetStore {
     func deleteCustomPreset(id: UUID) {
         customPresets.removeAll { $0.id == id }
         persist()
+        if favoritePresetIDs.contains(id) {
+            favoritePresetIDs.removeAll { $0 == id }
+            persistFavorites()
+        }
     }
 
     private func load() {
-        guard let data = UserDefaults.standard.data(forKey: Self.key),
-              let presets = try? JSONDecoder().decode([EQPresetData].self, from: data) else {
-            return
+        if let data = UserDefaults.standard.data(forKey: Self.key),
+           let presets = try? JSONDecoder().decode([EQPresetData].self, from: data) {
+            customPresets = presets
         }
-        customPresets = presets
+        if let data = UserDefaults.standard.data(forKey: Self.favoritesKey),
+           let ids = try? JSONDecoder().decode([UUID].self, from: data) {
+            favoritePresetIDs = ids
+        }
     }
 
     private func persist() {
         if let data = try? JSONEncoder().encode(customPresets) {
             UserDefaults.standard.set(data, forKey: Self.key)
+        }
+    }
+
+    private func persistFavorites() {
+        if let data = try? JSONEncoder().encode(favoritePresetIDs) {
+            UserDefaults.standard.set(data, forKey: Self.favoritesKey)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a pinned/favorite flag per preset, persisted independently of custom/built-in preset storage
- Favorited presets now render as a dedicated section at the top of **both** the menu bar dropdown and the in-app EQ window's preset picker (`Sources/iQualize/DreamUI/DreamToolbar.swift`), for one-click switching — no more digging into the full preset list for a headphone EQ / Flat toggle
- ⌥-click any preset (in the top favorites list or the full list) to pin/unpin it; a pin icon marks favorited presets in the full list (shares the checkmark's icon column, so titles stay aligned), and a hint ("⌥-click a preset to pin/unpin") is shown at the bottom of both menus
- Deleting a custom preset also removes it from favorites
- Bumped to **0.34.0** (minor — new feature; 0.33.0 was already claimed by #85, merged after this branch was cut) and updated CHANGELOG

Fixes #80

## Test plan
- [x] `swift build` succeeds
- [x] Installed and launched the app (`bash install.sh && open /Applications/iQualize.app`), verified it starts
- [x] Verified via UI automation: menu bar Favorites section is hidden when empty, appears once a preset is favorited, shows the correct checkmark/pin state as the active preset changes, and one-click switches presets from the top level
- [x] Verified the same behavior in the in-app preset dropdown (EQ window toolbar): favorites section at top, pin markers in the full list, one-click switching works, and preset titles stay column-aligned
- [x] Verified the pin/unpin hint text renders in both menus
- [x] Merged latest `main` (which picked up #85's per-preset In/Out dB) and re-verified the app still launches