### PR TITLE
Per-preset In/Out dB with global toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.33.0] - 2026-07-11
+
+### Added
+- Per-preset In/Out dB — input and output gain can now be stored on each preset individually, so switching presets restores that preset's gain
+- New "Share In/Out dB across all presets" toggle in Settings → General to keep the previous behavior of one shared gain value across all presets (on by default, preserving existing behavior)
+- Adjusting In/Out dB on a built-in preset while per-preset mode is on forks it into a "(Custom)" copy, matching how band edits already fork built-ins
+
 ## [0.32.1] - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ open /Applications/iQualize.app
 - Adjustable max gain range: ±6, ±12, ±18, or ±24 dB — or auto-scale to fit the current curve (up to ±24 dB)
 - Input gain (±24 dB) — pre-EQ level control for proper gain staging
 - Output gain (±24 dB) — post-EQ level control, applied before the peak limiter
+- In/Out dB can be shared globally across all presets, or set per-preset — toggle in Settings → General (see Presets and Settings below)
 - Dynamic peak limiter (AUPeakLimiter) — prevents digital clipping at 0 dBFS
 - Smooth, glitch-free parameter updates — only changed values are written to the audio unit
 
@@ -76,6 +77,7 @@ open /Applications/iQualize.app
 - Built-in presets: Flat, Bass Boost, Vocal Clarity, Loudness, Treble Boost, Podcast, Techno, Deep House, Hard Techno, Minimal, American Rap, German Rap
 - Create, rename, overwrite, and delete custom presets
 - Built-in presets auto-fork when edited (non-destructive)
+- In/Out dB gain can be stored per-preset (default) or shared globally across all presets — see Settings → General
 - Unsaved changes indicator (asterisk in title)
 - Import/export as `.iqpreset` JSON files with batch import and overwrite protection
 - Quick switching from the menu bar or EQ window picker
@@ -97,6 +99,8 @@ Presets are `.iqpreset` files — plain JSON:
 ```
 
 Each band: `frequency` (Hz, 20–20000), `gain` (dB), `bandwidth` (octaves, 0.05–10 — 1.0 = one octave ≈ Q 1.41), `filterType` (one of `parametric`, `lowShelf`, `highShelf`, `lowPass`, `highPass`, `bandPass`, `notch` — defaults to `parametric` if omitted).
+
+Presets may also carry `inputGainDB` and `outputGainDB` (dB, optional — omitted or absent means 0 dB, and they're only applied when In/Out dB is in per-preset mode; see Settings → General).
 
 ### Undo/Redo
 
@@ -132,7 +136,7 @@ Accessible via the gear icon in the EQ window, the Settings item in the menu bar
 
 - **Audio**: Peak Limiter toggle, Max Gain range (±6/12/18/24 dB), Auto Scale toggle
 - **Display**: Pre-EQ / Post-EQ spectrum toggles, per-spectrum line color picker, per-spectrum Fill toggle with its own color picker, reset buttons to return to the dynamic system colors, Q / Octave bandwidth display toggle
-- **General**: Theme (Auto / Light / Dark), Hide from Dock toggle, Start at Login toggle
+- **General**: Theme (Auto / Light / Dark), Hide from Dock toggle, Start at Login toggle, Share In/Out dB across all presets toggle
 
 ### Spectrum Analyzer
 

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -110,8 +110,16 @@ final class AudioEngine {
     var activePreset: EQPresetData = .flat {
         didSet {
             applyBands(from: oldValue)
+            if !gainIsGlobal {
+                inputGainDB = activePreset.inputGainDB ?? 0
+                outputGainDB = activePreset.outputGainDB ?? 0
+            }
         }
     }
+
+    /// When true, `inputGainDB`/`outputGainDB` are shared across all presets and untouched
+    /// by preset switches. When false, they're resolved from `activePreset` on every switch.
+    var gainIsGlobal: Bool = true
 
     var peakLimiter: Bool = true {
         didSet { applyBands() }

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -56,6 +56,7 @@ final class DreamViewModel {
     var postEqEnabled: Bool = false
     var inGainDB: Float = 0
     var outGainDB: Float = 0
+    var gainIsGlobal: Bool = true
     var balance: Float = 0
     var autoScale: Bool = true
     var maxGainDB: Float = 12
@@ -104,6 +105,7 @@ final class DreamViewModel {
         balance = s.balance
         inGainDB = s.inputGainDB
         outGainDB = s.outputGainDB
+        gainIsGlobal = s.linkGainGlobally
         maxGainDB = s.maxGainDB
         preEqLineColor = s.preEqLineColorHex.flatMap(NSColor.init(srgbHexRGB:)).map(Color.init(nsColor:)) ?? Color(nsColor: .systemCyan)
         postEqLineColor = s.postEqLineColorHex.flatMap(NSColor.init(srgbHexRGB:)).map(Color.init(nsColor:)) ?? Color(nsColor: .systemOrange)
@@ -155,6 +157,8 @@ final class DreamViewModel {
         presetName = preset.name
         activePresetID = preset.id
         isBuiltIn = preset.isBuiltIn
+        inGainDB = audioEngine.inputGainDB
+        outGainDB = audioEngine.outputGainDB
         if initial {
             savedSnapshot = preset
             isModified = false
@@ -344,22 +348,7 @@ final class DreamViewModel {
 
     private func forkIfBuiltIn() {
         guard audioEngine.activePreset.isBuiltIn else { return }
-        let baseName = "\(audioEngine.activePreset.name) (Custom)"
-        let existing = presetStore.allPresets.map { $0.name }
-        var forkName = baseName
-        if existing.contains(forkName) {
-            var n = 2
-            while existing.contains("\(baseName) \(n)") { n += 1 }
-            forkName = "\(baseName) \(n)"
-        }
-        let custom = audioEngine.activePreset
-        let newPreset = EQPresetData(
-            id: UUID(),
-            name: forkName,
-            bands: custom.bands,
-            rightBands: custom.rightBands,
-            isBuiltIn: false
-        )
+        let newPreset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
         audioEngine.activePreset = newPreset
         savedSnapshot = newPreset
         presetName = newPreset.name
@@ -784,13 +773,31 @@ final class DreamViewModel {
     }
 
     func applyInputGain() {
-        audioEngine.inputGainDB = inGainDB
-        persistFooterToggles()
+        if audioEngine.gainIsGlobal {
+            audioEngine.inputGainDB = inGainDB
+            persistFooterToggles()
+        } else {
+            forkIfBuiltIn()
+            var preset = audioEngine.activePreset
+            preset.inputGainDB = inGainDB
+            audioEngine.activePreset = preset
+            presetStore.saveCustomPreset(preset)
+            savedSnapshot = preset
+        }
     }
 
     func applyOutputGain() {
-        audioEngine.outputGainDB = outGainDB
-        persistFooterToggles()
+        if audioEngine.gainIsGlobal {
+            audioEngine.outputGainDB = outGainDB
+            persistFooterToggles()
+        } else {
+            forkIfBuiltIn()
+            var preset = audioEngine.activePreset
+            preset.outputGainDB = outGainDB
+            audioEngine.activePreset = preset
+            presetStore.saveCustomPreset(preset)
+            savedSnapshot = preset
+        }
     }
 
     func applyBalance() {

--- a/Sources/iQualize/EQModels.swift
+++ b/Sources/iQualize/EQModels.swift
@@ -97,6 +97,11 @@ struct EQPresetData: Codable, Equatable, Sendable, Identifiable {
     /// When non-nil, `bands` represents the left channel and `rightBands` the right.
     var rightBands: [EQBand]?
     let isBuiltIn: Bool
+    /// Per-preset input gain override, in dB. Nil = 0 dB / not customized.
+    /// Only applied when In/Out dB is in per-preset mode (see AudioEngine.gainIsGlobal).
+    var inputGainDB: Float?
+    /// Per-preset output gain override, in dB. Nil = 0 dB / not customized.
+    var outputGainDB: Float?
 
     var isFlat: Bool {
         let bandsFlat = bands.allSatisfy { $0.gain == 0 && $0.filterType == .parametric }

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -19,6 +19,9 @@ struct iQualizeState: Codable {
     var activeChannel: String?
     var inputGainDB: Float
     var outputGainDB: Float
+    /// When true, `inputGainDB`/`outputGainDB` above are shared across all presets.
+    /// When false, gain is read from/written to the active EQPresetData instead.
+    var linkGainGlobally: Bool
     var showBandwidthAsQ: Bool
     /// User-picked Pre-EQ line color as `#RRGGBB` (sRGB). nil = use the dynamic system color.
     var preEqLineColorHex: String?
@@ -52,6 +55,7 @@ struct iQualizeState: Codable {
         activeChannel: nil,
         inputGainDB: 0.0,
         outputGainDB: 0.0,
+        linkGainGlobally: true,
         showBandwidthAsQ: true,
         preEqFillEnabled: false,
         postEqFillEnabled: true,
@@ -61,7 +65,7 @@ struct iQualizeState: Codable {
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = true, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -78,6 +82,7 @@ struct iQualizeState: Codable {
         self.activeChannel = activeChannel
         self.inputGainDB = inputGainDB
         self.outputGainDB = outputGainDB
+        self.linkGainGlobally = linkGainGlobally
         self.showBandwidthAsQ = showBandwidthAsQ
         self.preEqLineColorHex = preEqLineColorHex
         self.postEqLineColorHex = postEqLineColorHex
@@ -107,6 +112,7 @@ struct iQualizeState: Codable {
         activeChannel = try? container.decode(String.self, forKey: .activeChannel)
         inputGainDB = (try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0.0
         outputGainDB = (try? container.decode(Float.self, forKey: .outputGainDB)) ?? 0.0
+        linkGainGlobally = (try? container.decode(Bool.self, forKey: .linkGainGlobally)) ?? true
         showBandwidthAsQ = (try? container.decode(Bool.self, forKey: .showBandwidthAsQ)) ?? true
         preEqLineColorHex = try? container.decode(String.self, forKey: .preEqLineColorHex)
         postEqLineColorHex = try? container.decode(String.self, forKey: .postEqLineColorHex)

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -93,6 +93,10 @@ final class EQWindowController: NSWindowController {
         viewModel.peakLimiter = on
     }
 
+    func syncGainIsGlobal(_ on: Bool) {
+        viewModel.gainIsGlobal = on
+    }
+
     func syncMaxGain(_ db: Float) {
         viewModel.maxGainDB = db
     }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.32.1</string>
+	<string>0.33.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.32.1</string>
+	<string>0.33.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -28,6 +28,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         }
 
         // Restore saved state and always start EQ
+        audioEngine.gainIsGlobal = state.linkGainGlobally
         if let preset = presetStore.preset(for: state.selectedPresetID) {
             audioEngine.activePreset = preset
         }
@@ -35,8 +36,10 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         audioEngine.maxGainDB = state.maxGainDB
         audioEngine.bypassed = state.bypassed
         audioEngine.balance = state.balance
-        audioEngine.inputGainDB = state.inputGainDB
-        audioEngine.outputGainDB = state.outputGainDB
+        if state.linkGainGlobally {
+            audioEngine.inputGainDB = state.inputGainDB
+            audioEngine.outputGainDB = state.outputGainDB
+        }
         audioEngine.setEnabled(true)
         updateIcon()
 
@@ -179,7 +182,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     @objc private func openSettings(_ sender: NSMenuItem) {
         if settingsWindowController == nil {
             settingsWindowController = SettingsWindowController(
-                audioEngine: audioEngine, eqWindowController: eqWindowController)
+                audioEngine: audioEngine, presetStore: presetStore, eqWindowController: eqWindowController)
         }
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)
@@ -230,7 +233,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
     func showSettings() {
         if settingsWindowController == nil {
             settingsWindowController = SettingsWindowController(
-                audioEngine: audioEngine, eqWindowController: eqWindowController)
+                audioEngine: audioEngine, presetStore: presetStore, eqWindowController: eqWindowController)
         }
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -35,6 +35,30 @@ final class PresetStore {
         persist()
     }
 
+    /// Returns a "(Custom)" fork of `preset` (deduped name against `allPresets`) if it's
+    /// built-in; returns `preset` unchanged otherwise. Pure — does not persist and does not
+    /// touch AudioEngine; callers decide whether/when to call `saveCustomPreset`.
+    func forkIfBuiltIn(_ preset: EQPresetData) -> EQPresetData {
+        guard preset.isBuiltIn else { return preset }
+        let baseName = "\(preset.name) (Custom)"
+        let existing = allPresets.map { $0.name }
+        var forkName = baseName
+        if existing.contains(forkName) {
+            var n = 2
+            while existing.contains("\(baseName) \(n)") { n += 1 }
+            forkName = "\(baseName) \(n)"
+        }
+        return EQPresetData(
+            id: UUID(),
+            name: forkName,
+            bands: preset.bands,
+            rightBands: preset.rightBands,
+            isBuiltIn: false,
+            inputGainDB: preset.inputGainDB,
+            outputGainDB: preset.outputGainDB
+        )
+    }
+
     private func load() {
         guard let data = UserDefaults.standard.data(forKey: Self.key),
               let presets = try? JSONDecoder().decode([EQPresetData].self, from: data) else {

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -5,6 +5,7 @@ import ServiceManagement
 @MainActor
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let audioEngine: AudioEngine
+    private let presetStore: PresetStore
     private weak var eqWindowController: EQWindowController?
 
     private var peakLimiterCheckbox: NSButton!
@@ -26,9 +27,11 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private var themeSegment: NSSegmentedControl!
     private var hideFromDockCheckbox: NSButton!
     private var startAtLoginCheckbox: NSButton!
+    private var linkGainCheckbox: NSButton!
 
-    init(audioEngine: AudioEngine, eqWindowController: EQWindowController?) {
+    init(audioEngine: AudioEngine, presetStore: PresetStore, eqWindowController: EQWindowController?) {
         self.audioEngine = audioEngine
+        self.presetStore = presetStore
         self.eqWindowController = eqWindowController
 
         let window = HelpAwareWindow(
@@ -73,6 +76,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         applyPostEqEnabled(!audioEngine.bypassed)
         bandwidthModeSegment.selectedSegment = state.showBandwidthAsQ ? 0 : 1
         themeSegment.selectedSegment = Self.themeIndex(for: state.dreamTheme)
+        linkGainCheckbox.state = state.linkGainGlobally ? .on : .off
     }
 
     func syncBypass(_ on: Bool) {
@@ -223,6 +227,11 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         startAtLoginCheckbox.state = SMAppService.mainApp.status == .enabled ? .on : .off
         mainStack.addArrangedSubview(startAtLoginCheckbox)
 
+        linkGainCheckbox = NSButton(checkboxWithTitle: "Share In/Out dB across all presets",
+                                      target: self, action: #selector(toggleLinkGainGlobally(_:)))
+        linkGainCheckbox.state = state.linkGainGlobally ? .on : .off
+        mainStack.addArrangedSubview(linkGainCheckbox)
+
         return mainStack
     }
 
@@ -293,6 +302,32 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         state.peakLimiter = audioEngine.peakLimiter
         state.save()
         eqWindowController?.syncPeakLimiter(audioEngine.peakLimiter)
+    }
+
+    @objc private func toggleLinkGainGlobally(_ sender: NSButton) {
+        let makeGlobal = sender.state == .on
+        var state = iQualizeState.load()
+        if makeGlobal {
+            // Per-preset -> Global: current per-preset gain becomes the new shared baseline.
+            state.inputGainDB = audioEngine.inputGainDB
+            state.outputGainDB = audioEngine.outputGainDB
+            state.linkGainGlobally = true
+            state.save()
+            audioEngine.gainIsGlobal = true
+        } else {
+            // Global -> Per-preset: seed the active preset with the current global gain,
+            // forking it out of a built-in first if needed.
+            audioEngine.gainIsGlobal = false
+            var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+            preset.inputGainDB = audioEngine.inputGainDB
+            preset.outputGainDB = audioEngine.outputGainDB
+            presetStore.saveCustomPreset(preset)
+            audioEngine.activePreset = preset
+            state.linkGainGlobally = false
+            state.save()
+        }
+        eqWindowController?.syncGainIsGlobal(audioEngine.gainIsGlobal)
+        eqWindowController?.syncUIToPreset()
     }
 
     @objc private func maxGainChanged(_ sender: NSPopUpButton) {


### PR DESCRIPTION
## Summary
- Input/output gain (In dB / Out dB) can now be stored per-preset instead of being one shared value across the whole app.
- New "Share In/Out dB across all presets" toggle in Settings → General restores the previous global behavior (on by default, preserving existing behavior for existing users).
- Adjusting gain on a built-in preset while per-preset mode is on forks it into a "(Custom)" copy, matching how band edits already fork built-ins.
- Gain resolution is centralized in `AudioEngine.activePreset`'s `didSet` so every preset-switch path (Dream window, menu bar, undo/redo, startup restore) gets correct gain automatically.
- README (Features / Preset Format / Settings sections) updated to match, since it feeds the in-app Help window.
- Version bumped 0.32.1 → 0.33.0 with a CHANGELOG entry (new feature).

## Test plan
- [x] `swift build` clean
- [x] Mandatory launch verification (`pgrep -x iQualize` after install)
- [x] Manually verified in the running app: global mode behaves as before; toggling to per-preset seeds the active preset's gain with no jump and forks built-ins; editing gain on a built-in preset forks it live; toggle state and per-preset gains persist correctly across a full app relaunch; toggling back to global re-seeds the shared baseline with no jump and applies uniformly across presets again