### PR TITLE
Import presets from AutoEQ/OPRA, default per-preset In/Out dB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.35.0] - 2026-07-12
+
+### Added
+- Import Preset… now also accepts AutoEQ `ParametricEQ.txt`/`GraphicEQ.txt` and OPRA `eq_info.json` files alongside iQualize's own format, so community EQ profiles for headphones/IEMs can be dropped in directly. GraphicEQ curves are resampled onto the app's 31-band ceiling; each format's preamp/gain value is carried over as the preset's input gain
+
+### Changed
+- Per-preset In/Out dB is now the default for new installs, instead of sharing one gain value across all presets — matches the imported preamp/gain value from AutoEQ/OPRA presets landing on the preset itself rather than being silently ignored until "Share In/Out dB across all presets" was manually turned off in Settings
+
 ## [0.34.0] - 2026-07-11
 
 ### Added

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -119,7 +119,7 @@ final class AudioEngine {
 
     /// When true, `inputGainDB`/`outputGainDB` are shared across all presets and untouched
     /// by preset switches. When false, they're resolved from `activePreset` on every switch.
-    var gainIsGlobal: Bool = true
+    var gainIsGlobal: Bool = false
 
     var peakLimiter: Bool = true {
         didSet { applyBands() }

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -56,7 +56,7 @@ final class DreamViewModel {
     var postEqEnabled: Bool = false
     var inGainDB: Float = 0
     var outGainDB: Float = 0
-    var gainIsGlobal: Bool = true
+    var gainIsGlobal: Bool = false
     var balance: Float = 0
     var autoScale: Bool = true
     var maxGainDB: Float = 12
@@ -644,10 +644,12 @@ final class DreamViewModel {
     }
 
     /// Import one or more preset files via an osascript-driven open dialog (multi-select).
-    /// For each imported preset shows a rename/overwrite dialog matching the AppKit version.
+    /// Recognizes iQualize's native format as well as AutoEQ ParametricEQ.txt/GraphicEQ.txt
+    /// and OPRA eq_info.json (see `PresetImporter`). For each imported preset shows a
+    /// rename/overwrite dialog matching the AppKit version.
     func importPresets() {
         let script = """
-        set fileList to choose file of type {"json", "iqpreset"} with prompt "Import Presets" with multiple selections allowed
+        set fileList to choose file of type {"json", "iqpreset", "txt"} with prompt "Import Presets" with multiple selections allowed
         set output to ""
         repeat with f in fileList
             set output to output & POSIX path of f & linefeed
@@ -663,10 +665,8 @@ final class DreamViewModel {
             let url = URL(fileURLWithPath: path)
             do {
                 let data = try Data(contentsOf: url)
-                let decoded = try JSONDecoder().decode(EQPresetData.self, from: data)
-                var importName = decoded.name.isEmpty
-                    ? url.deletingPathExtension().lastPathComponent
-                    : decoded.name
+                let parsed = try PresetImporter.parse(data: data, filename: url.lastPathComponent)
+                var importName = parsed.name ?? Self.defaultImportName(for: url)
 
                 let customNames = Set(presetStore.customPresets.map(\.name))
                 let nameExists = customNames.contains(importName)
@@ -717,9 +717,11 @@ final class DreamViewModel {
                 let preset = EQPresetData(
                     id: UUID(),
                     name: importName,
-                    bands: decoded.bands,
-                    rightBands: decoded.rightBands,
-                    isBuiltIn: false
+                    bands: parsed.bands,
+                    rightBands: parsed.rightBands,
+                    isBuiltIn: false,
+                    inputGainDB: parsed.inputGainDB,
+                    outputGainDB: parsed.outputGainDB
                 )
                 presetStore.saveCustomPreset(preset)
                 lastImported = preset
@@ -738,6 +740,19 @@ final class DreamViewModel {
             syncFromAudioEngine()
             registerUndo(actionName: "Import Preset", oldPreset: old)
         }
+    }
+
+    /// Derives a default preset name from an imported file's name, stripping AutoEQ's
+    /// conventional " ParametricEQ"/" GraphicEQ" filename suffix if present so e.g.
+    /// "Sennheiser HD 600 ParametricEQ.txt" defaults to "Sennheiser HD 600".
+    private static func defaultImportName(for url: URL) -> String {
+        let base = url.deletingPathExtension().lastPathComponent
+        for suffix in [" ParametricEQ", " GraphicEQ"] {
+            if base.range(of: suffix, options: [.caseInsensitive, .anchored, .backwards]) != nil {
+                return String(base.dropLast(suffix.count))
+            }
+        }
+        return base
     }
 
     /// Runs an AppleScript snippet via /usr/bin/osascript, returns trimmed stdout or nil.

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -55,7 +55,7 @@ struct iQualizeState: Codable {
         activeChannel: nil,
         inputGainDB: 0.0,
         outputGainDB: 0.0,
-        linkGainGlobally: true,
+        linkGainGlobally: false,
         showBandwidthAsQ: true,
         preEqFillEnabled: false,
         postEqFillEnabled: true,
@@ -65,7 +65,7 @@ struct iQualizeState: Codable {
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = true, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = false, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -112,7 +112,7 @@ struct iQualizeState: Codable {
         activeChannel = try? container.decode(String.self, forKey: .activeChannel)
         inputGainDB = (try? container.decode(Float.self, forKey: .inputGainDB)) ?? 0.0
         outputGainDB = (try? container.decode(Float.self, forKey: .outputGainDB)) ?? 0.0
-        linkGainGlobally = (try? container.decode(Bool.self, forKey: .linkGainGlobally)) ?? true
+        linkGainGlobally = (try? container.decode(Bool.self, forKey: .linkGainGlobally)) ?? false
         showBandwidthAsQ = (try? container.decode(Bool.self, forKey: .showBandwidthAsQ)) ?? true
         preEqLineColorHex = try? container.decode(String.self, forKey: .preEqLineColorHex)
         postEqLineColorHex = try? container.decode(String.self, forKey: .postEqLineColorHex)

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.34.0</string>
+	<string>0.35.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.34.0</string>
+	<string>0.35.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/PresetImporter.swift
+++ b/Sources/iQualize/PresetImporter.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+// MARK: - Errors
+
+enum PresetImportError: LocalizedError {
+    case unrecognizedFormat
+    case noBandsFound
+
+    var errorDescription: String? {
+        switch self {
+        case .unrecognizedFormat:
+            return "This file isn't a recognized preset format (iQualize, AutoEQ ParametricEQ/GraphicEQ, or OPRA)."
+        case .noBandsFound:
+            return "No EQ bands could be parsed from this file."
+        }
+    }
+}
+
+// MARK: - Parsed Preset
+
+/// Format-agnostic result of importing a preset file, before it's assigned an id/name
+/// and turned into a full `EQPresetData` by the caller.
+struct ParsedPreset {
+    var name: String?
+    var bands: [EQBand]
+    var rightBands: [EQBand]?
+    var inputGainDB: Float?
+    var outputGainDB: Float?
+}
+
+// MARK: - Importer
+
+enum PresetImporter {
+
+    static func parse(data: Data, filename: String) throws -> ParsedPreset {
+        if let decoded = try? JSONDecoder().decode(EQPresetData.self, from: data), !decoded.bands.isEmpty {
+            return ParsedPreset(
+                name: decoded.name.isEmpty ? nil : decoded.name,
+                bands: decoded.bands,
+                rightBands: decoded.rightBands,
+                inputGainDB: decoded.inputGainDB,
+                outputGainDB: decoded.outputGainDB
+            )
+        }
+
+        if let opra = try? JSONDecoder().decode(OPRAEqInfo.self, from: data) {
+            return try parseOPRA(opra)
+        }
+
+        if let text = String(data: data, encoding: .utf8) {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("GraphicEQ:") {
+                return try parseGraphicEQ(trimmed)
+            }
+            if trimmed.hasPrefix("Preamp:") || trimmed.contains("Filter 1:") {
+                return try parseParametricEQ(trimmed)
+            }
+        }
+
+        throw PresetImportError.unrecognizedFormat
+    }
+
+    // MARK: AutoEQ ParametricEQ.txt
+
+    private static func parseParametricEQ(_ text: String) throws -> ParsedPreset {
+        var preamp: Float?
+        var bands: [EQBand] = []
+
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let tokens = rawLine.split(separator: " ").map(String.init)
+            guard let first = tokens.first else { continue }
+
+            if first == "Preamp:", tokens.count >= 2 {
+                preamp = Float(tokens[1])
+            } else if first.hasPrefix("Filter") {
+                guard let stateIndex = tokens.firstIndex(where: { $0 == "ON" || $0 == "OFF" }),
+                      tokens[stateIndex] == "ON",
+                      stateIndex + 1 < tokens.count else { continue }
+
+                guard let filterType = autoEQFilterType(tokens[stateIndex + 1]) else { continue }
+                guard let fc = number(after: "Fc", in: tokens),
+                      let gain = number(after: "Gain", in: tokens) else { continue }
+                let q = number(after: "Q", in: tokens) ?? 0.707
+
+                bands.append(EQBand(frequency: fc, gain: gain, bandwidth: EQBand.qToOctaves(q), filterType: filterType))
+            }
+        }
+
+        guard !bands.isEmpty else { throw PresetImportError.noBandsFound }
+        if bands.count > EQPresetData.maxBandCount {
+            bands = Array(bands.prefix(EQPresetData.maxBandCount))
+        }
+
+        return ParsedPreset(name: nil, bands: bands, rightBands: nil, inputGainDB: preamp, outputGainDB: nil)
+    }
+
+    private static func number(after keyword: String, in tokens: [String]) -> Float? {
+        guard let index = tokens.firstIndex(of: keyword), index + 1 < tokens.count else { return nil }
+        return Float(tokens[index + 1])
+    }
+
+    private static func autoEQFilterType(_ token: String) -> FilterType? {
+        switch token {
+        case "PK": return .parametric
+        case "LSC", "LS": return .lowShelf
+        case "HSC", "HS": return .highShelf
+        case "LP": return .lowPass
+        case "HP": return .highPass
+        case "BP": return .bandPass
+        case "NO", "BS": return .notch
+        default: return nil
+        }
+    }
+
+    // MARK: AutoEQ GraphicEQ.txt
+
+    /// Standard 31-band ISO 1/3-octave center frequencies (20 Hz - 20 kHz).
+    /// Conveniently exactly `EQPresetData.maxBandCount`.
+    private static let iso31BandFrequencies: [Float] = [
+        20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
+        1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000, 12500, 16000, 20000
+    ]
+
+    private static func parseGraphicEQ(_ text: String) throws -> ParsedPreset {
+        let body = String(text.dropFirst("GraphicEQ:".count))
+        let points: [(freq: Float, gain: Float)] = body.split(separator: ";").compactMap { entry in
+            let numbers = entry.split(separator: " ").compactMap { Float($0) }
+            guard numbers.count >= 2 else { return nil }
+            return (numbers[0], numbers[1])
+        }.sorted { $0.freq < $1.freq }
+
+        guard !points.isEmpty else { throw PresetImportError.noBandsFound }
+
+        let bands = iso31BandFrequencies.map { freq in
+            EQBand(frequency: freq, gain: interpolatedGain(points: points, atFrequency: freq), bandwidth: 0.5, filterType: .parametric)
+        }
+
+        return ParsedPreset(name: nil, bands: bands, rightBands: nil, inputGainDB: nil, outputGainDB: nil)
+    }
+
+    private static func interpolatedGain(points: [(freq: Float, gain: Float)], atFrequency freq: Float) -> Float {
+        if freq <= points.first!.freq { return points.first!.gain }
+        if freq >= points.last!.freq { return points.last!.gain }
+
+        for i in 1..<points.count {
+            guard points[i].freq >= freq else { continue }
+            let p0 = points[i - 1], p1 = points[i]
+            guard p1.freq > p0.freq else { return p0.gain }
+            let t = (log2(freq) - log2(p0.freq)) / (log2(p1.freq) - log2(p0.freq))
+            return p0.gain + t * (p1.gain - p0.gain)
+        }
+        return points.last!.gain
+    }
+
+    // MARK: OPRA eq_info.json
+
+    private static func parseOPRA(_ opra: OPRAEqInfo) throws -> ParsedPreset {
+        guard opra.type == "parametric_eq" else { throw PresetImportError.unrecognizedFormat }
+
+        var bands = opra.parameters.bands.compactMap { band -> EQBand? in
+            guard let filterType = opraFilterType(band.type) else { return nil }
+            let bandwidth = band.q.map { EQBand.qToOctaves($0) } ?? 1.0
+            return EQBand(frequency: band.frequency, gain: band.gain_db ?? 0, bandwidth: bandwidth, filterType: filterType)
+        }
+
+        guard !bands.isEmpty else { throw PresetImportError.noBandsFound }
+        // Schema states bands are "sorted by priority" and software with fewer bands should truncate.
+        if bands.count > EQPresetData.maxBandCount {
+            bands = Array(bands.prefix(EQPresetData.maxBandCount))
+        }
+
+        return ParsedPreset(name: nil, bands: bands, rightBands: nil, inputGainDB: opra.parameters.gain_db, outputGainDB: nil)
+    }
+
+    private static func opraFilterType(_ raw: String) -> FilterType? {
+        switch raw {
+        case "peak_dip": return .parametric
+        case "low_shelf": return .lowShelf
+        case "high_shelf": return .highShelf
+        case "low_pass": return .lowPass
+        case "high_pass": return .highPass
+        case "band_pass": return .bandPass
+        case "band_stop": return .notch
+        default: return nil
+        }
+    }
+}
+
+// MARK: - OPRA Schema
+
+private struct OPRAEqInfo: Decodable {
+    struct Parameters: Decodable {
+        struct Band: Decodable {
+            let type: String
+            let frequency: Float
+            let gain_db: Float?
+            let q: Float?
+        }
+        let gain_db: Float
+        let bands: [Band]
+    }
+
+    let type: String
+    let parameters: Parameters
+}


### PR DESCRIPTION
## Summary
- Import Preset… now recognizes AutoEQ `ParametricEQ.txt`/`GraphicEQ.txt` and OPRA `eq_info.json` alongside iQualize's own format, so community headphone/IEM EQ profiles can be dropped in directly. GraphicEQ curves are resampled onto the app's 31-band ceiling, and each format's preamp/gain value carries over as the preset's input gain.
- Per-preset In/Out dB is now the default for new installs, instead of one gain value shared across all presets — so an imported preamp/gain value isn't silently ignored until "Share In/Out dB across all presets" is turned off by hand in Settings.
- Bumps to 0.35.0, CHANGELOG updated.

## Test plan
- [x] `swift build` succeeds
- [x] Build/install/launch verified (`bash install.sh`, app launches)
- [x] Verified `PresetImporter.parse` against real AutoEQ `ParametricEQ.txt`/`GraphicEQ.txt` and OPRA `eq_info.json` samples pulled from the upstream repos — bands/gains/Q/filter types match source data exactly
- [x] Drove the actual app UI: imported all sample files through Import Preset…, confirmed name-collision/overwrite dialog, confirmed unsupported-file error alert, confirmed native `.iqpreset` round-trip (including `inputGainDB`/`outputGainDB`) still works