### PR TITLE
Preset Browser: search and import OPRA community EQ profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.36.0] - 2026-07-12
+
+### Added
+- Preset Browser: search and import community headphone/IEM EQ profiles directly from the OPRA database (opra.roon.app) without hunting down and downloading a file first. Browse by vendor/product, pick from the available community-contributed curves for that model, and import in one click — reuses the existing AutoEQ/OPRA import path under the hood
+
 ## [0.35.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ open /Applications/iQualize.app
 - Built-in presets auto-fork when edited (non-destructive)
 - In/Out dB gain can be stored per-preset (default) or shared globally across all presets — see Settings → General
 - Unsaved changes indicator (asterisk in title)
-- Import/export as `.iqpreset` JSON files with batch import and overwrite protection
+- Import/export as `.iqpreset` JSON files with batch import and overwrite protection — also accepts AutoEQ `ParametricEQ.txt`/`GraphicEQ.txt` and OPRA `eq_info.json` files
+- Preset Browser: search and import community headphone/IEM EQ profiles directly from the [OPRA](https://opra.roon.app/) database, no manual file download needed
 - Quick switching from the menu bar or EQ window picker
 
 #### Preset Format

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -80,6 +80,7 @@ struct DreamToolbar: View {
                 .keyboardShortcut("s", modifiers: [.command, .shift])
             Divider()
             Button("Import Preset…") { vm.importPresets() }
+            Button("Browse OPRA Presets…") { vm.showPresetBrowser() }
             Button("Export Preset…") { vm.exportActivePreset() }
         } label: {
             Text("Save")

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -666,65 +666,10 @@ final class DreamViewModel {
             do {
                 let data = try Data(contentsOf: url)
                 let parsed = try PresetImporter.parse(data: data, filename: url.lastPathComponent)
-                var importName = parsed.name ?? Self.defaultImportName(for: url)
-
-                let customNames = Set(presetStore.customPresets.map(\.name))
-                let nameExists = customNames.contains(importName)
-
-                let alert = NSAlert()
-                alert.messageText = nameExists
-                    ? "A preset named \"\(importName)\" already exists."
-                    : "Import \"\(importName)\""
-                alert.informativeText = "You can change the preset name before importing."
-                alert.addButton(withTitle: nameExists ? "Overwrite" : "Import")
-                alert.addButton(withTitle: "Skip")
-
-                let nameField = NSTextField(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
-                nameField.stringValue = importName
-                alert.accessoryView = nameField
-                alert.window.initialFirstResponder = nameField
-
-                // Live-update the action button label as the user types so it always reflects
-                // whether saving will overwrite an existing preset.
-                let actionButton = alert.buttons[0]
-                let observer = NotificationCenter.default.addObserver(
-                    forName: NSControl.textDidChangeNotification,
-                    object: nameField, queue: .main
-                ) { _ in
-                    let current = nameField.stringValue.trimmingCharacters(in: .whitespaces)
-                    actionButton.title = customNames.contains(current) ? "Overwrite" : "Import"
+                let suggestedName = parsed.name ?? Self.defaultImportName(for: url)
+                if let saved = saveImportedPreset(parsed, suggestedName: suggestedName) {
+                    lastImported = saved
                 }
-
-                let response = alert.runModal()
-                NotificationCenter.default.removeObserver(observer)
-                if response == .alertSecondButtonReturn { continue }
-
-                let finalName = nameField.stringValue.trimmingCharacters(in: .whitespaces)
-                if finalName.isEmpty { continue }
-                importName = finalName
-
-                if let existing = presetStore.customPresets.first(where: { $0.name == importName }) {
-                    let confirm = NSAlert()
-                    confirm.messageText = "Overwrite \"\(importName)\"?"
-                    confirm.informativeText = "This will replace the existing preset with the imported one."
-                    confirm.addButton(withTitle: "Overwrite")
-                    confirm.addButton(withTitle: "Cancel")
-                    confirm.alertStyle = .warning
-                    if confirm.runModal() != .alertFirstButtonReturn { continue }
-                    presetStore.deleteCustomPreset(id: existing.id)
-                }
-
-                let preset = EQPresetData(
-                    id: UUID(),
-                    name: importName,
-                    bands: parsed.bands,
-                    rightBands: parsed.rightBands,
-                    isBuiltIn: false,
-                    inputGainDB: parsed.inputGainDB,
-                    outputGainDB: parsed.outputGainDB
-                )
-                presetStore.saveCustomPreset(preset)
-                lastImported = preset
             } catch {
                 let alert = NSAlert(error: error)
                 alert.informativeText = "Failed to import \(url.lastPathComponent): \(error.localizedDescription)"
@@ -739,6 +684,104 @@ final class DreamViewModel {
             isModified = false
             syncFromAudioEngine()
             registerUndo(actionName: "Import Preset", oldPreset: old)
+        }
+    }
+
+    /// Shows the rename/overwrite dialog for a parsed preset and, if confirmed, saves it as a
+    /// custom preset. Returns the saved preset, or `nil` if the user skipped/cancelled/cleared
+    /// the name. Shared by the file-based import flow and the OPRA Preset Browser.
+    private func saveImportedPreset(_ parsed: ParsedPreset, suggestedName: String) -> EQPresetData? {
+        var importName = suggestedName
+
+        let customNames = Set(presetStore.customPresets.map(\.name))
+        let nameExists = customNames.contains(importName)
+
+        let alert = NSAlert()
+        alert.messageText = nameExists
+            ? "A preset named \"\(importName)\" already exists."
+            : "Import \"\(importName)\""
+        alert.informativeText = "You can change the preset name before importing."
+        alert.addButton(withTitle: nameExists ? "Overwrite" : "Import")
+        alert.addButton(withTitle: "Skip")
+
+        let nameField = NSTextField(frame: NSRect(x: 0, y: 0, width: 250, height: 24))
+        nameField.stringValue = importName
+        alert.accessoryView = nameField
+        alert.window.initialFirstResponder = nameField
+
+        // Live-update the action button label as the user types so it always reflects
+        // whether saving will overwrite an existing preset.
+        let actionButton = alert.buttons[0]
+        let observer = NotificationCenter.default.addObserver(
+            forName: NSControl.textDidChangeNotification,
+            object: nameField, queue: .main
+        ) { _ in
+            let current = nameField.stringValue.trimmingCharacters(in: .whitespaces)
+            actionButton.title = customNames.contains(current) ? "Overwrite" : "Import"
+        }
+
+        let response = alert.runModal()
+        NotificationCenter.default.removeObserver(observer)
+        if response == .alertSecondButtonReturn { return nil }
+
+        let finalName = nameField.stringValue.trimmingCharacters(in: .whitespaces)
+        if finalName.isEmpty { return nil }
+        importName = finalName
+
+        if let existing = presetStore.customPresets.first(where: { $0.name == importName }) {
+            let confirm = NSAlert()
+            confirm.messageText = "Overwrite \"\(importName)\"?"
+            confirm.informativeText = "This will replace the existing preset with the imported one."
+            confirm.addButton(withTitle: "Overwrite")
+            confirm.addButton(withTitle: "Cancel")
+            confirm.alertStyle = .warning
+            if confirm.runModal() != .alertFirstButtonReturn { return nil }
+            presetStore.deleteCustomPreset(id: existing.id)
+        }
+
+        let preset = EQPresetData(
+            id: UUID(),
+            name: importName,
+            bands: parsed.bands,
+            rightBands: parsed.rightBands,
+            isBuiltIn: false,
+            inputGainDB: parsed.inputGainDB,
+            outputGainDB: parsed.outputGainDB
+        )
+        presetStore.saveCustomPreset(preset)
+        return preset
+    }
+
+    // MARK: - OPRA Preset Browser
+
+    private var presetBrowserWindowController: PresetBrowserWindowController?
+
+    /// Opens (or refocuses) the OPRA Preset Browser window.
+    func showPresetBrowser() {
+        if presetBrowserWindowController == nil {
+            presetBrowserWindowController = PresetBrowserWindowController { [weak self] product, curve in
+                self?.importOPRACurve(product: product, curve: curve)
+            }
+        }
+        presetBrowserWindowController?.showWindow(nil)
+        presetBrowserWindowController?.window?.makeKeyAndOrderFront(nil)
+    }
+
+    private func importOPRACurve(product: OPRAProductEntry, curve: OPRACurveEntry) {
+        do {
+            let parsed = try PresetImporter.parse(data: curve.data, filename: product.productName)
+            let suggestedName = "\(product.vendorName) \(product.productName)"
+            guard let saved = saveImportedPreset(parsed, suggestedName: suggestedName) else { return }
+            let old = audioEngine.activePreset
+            audioEngine.activePreset = saved
+            savedSnapshot = saved
+            isModified = false
+            syncFromAudioEngine()
+            registerUndo(actionName: "Import Preset", oldPreset: old)
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.informativeText = "Failed to import \(product.vendorName) \(product.productName): \(error.localizedDescription)"
+            alert.runModal()
         }
     }
 

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Search-and-import UI for OPRA's community headphone EQ database. Sidebar lists matching
+/// products; selecting one shows its available community EQ curves in the detail pane.
+@available(macOS 14.2, *)
+struct PresetBrowserView: View {
+    let onImport: (OPRAProductEntry, OPRACurveEntry) -> Void
+
+    @State private var products: [OPRAProductEntry] = []
+    @State private var searchText = ""
+    @State private var selectedProductID: String?
+    @State private var loadState: LoadState = .loading
+
+    private enum LoadState { case loading, loaded, failed(String) }
+
+    private var filteredProducts: [OPRAProductEntry] {
+        guard !searchText.isEmpty else { return products }
+        return products.filter {
+            "\($0.vendorName) \($0.productName)".localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 240, ideal: 280)
+        } detail: {
+            detail
+        }
+        .task { await load() }
+    }
+
+    @ViewBuilder
+    private var sidebar: some View {
+        switch loadState {
+        case .loading:
+            ProgressView("Loading OPRA database…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .failed(let message):
+            VStack(spacing: 12) {
+                Text(message)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                Button("Retry") { Task { await load() } }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .loaded:
+            List(filteredProducts, selection: $selectedProductID) { product in
+                productRow(product).tag(product.id)
+            }
+            .listStyle(.sidebar)
+            .searchable(text: $searchText, placement: .sidebar, prompt: "Search headphones…")
+        }
+    }
+
+    private func productRow(_ product: OPRAProductEntry) -> some View {
+        HStack(spacing: 10) {
+            thumbnail(for: product)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(product.vendorName) \(product.productName)")
+                    .font(.body)
+                if let subtype = product.subtype {
+                    Text(subtype.replacingOccurrences(of: "_", with: " ").capitalized)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func thumbnail(for product: OPRAProductEntry) -> some View {
+        Group {
+            if let url = product.thumbnailURL {
+                AsyncImage(url: url) { image in
+                    image.resizable().scaledToFit()
+                } placeholder: {
+                    Color.clear
+                }
+            } else {
+                Image(systemName: "headphones")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: 32, height: 24)
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if let selectedProductID, let product = products.first(where: { $0.id == selectedProductID }) {
+            List(product.curves) { curve in
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(curve.author).font(.body)
+                        if let details = curve.details {
+                            Text(details).font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    Button("Import") { onImport(product, curve) }
+                }
+            }
+            .navigationTitle("\(product.vendorName) \(product.productName)")
+        } else {
+            Text("Select a headphone to see available EQ profiles")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func load() async {
+        loadState = .loading
+        do {
+            products = try await OPRACatalog.shared.loadIfNeeded()
+            loadState = .loaded
+        } catch {
+            loadState = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/OPRACatalog.swift
+++ b/Sources/iQualize/OPRACatalog.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// A single community EQ curve for a product, from the OPRA database.
+/// `data` is the raw JSON of the entry's `data` object — already in the exact shape
+/// `PresetImporter.parse(data:filename:)` expects (see `OPRAEqInfo` in PresetImporter.swift).
+struct OPRACurveEntry: Identifiable, Sendable {
+    let id: String
+    let author: String
+    let details: String?
+    let data: Data
+}
+
+/// A product (headphone/IEM) from the OPRA database, joined with its vendor name and
+/// every community EQ curve available for it. Products with no curves are never produced —
+/// they aren't importable.
+struct OPRAProductEntry: Identifiable, Sendable {
+    let id: String
+    let vendorName: String
+    let productName: String
+    let subtype: String?
+    let thumbnailURL: URL?
+    let curves: [OPRACurveEntry]
+}
+
+enum OPRACatalogError: LocalizedError {
+    case noData
+
+    var errorDescription: String? {
+        switch self {
+        case .noData:
+            return "Couldn't load the OPRA preset database. Check your internet connection and try again."
+        }
+    }
+}
+
+/// Fetches, caches, and parses OPRA's community-maintained headphone EQ database
+/// (https://github.com/opra-project/OPRA) for the Preset Browser.
+@available(macOS 14.2, *)
+@MainActor
+final class OPRACatalog {
+    static let shared = OPRACatalog()
+
+    private static let sourceURL = URL(string: "https://opra.roonlabs.net/database_v1.jsonl")!
+    private nonisolated static let assetBaseURL = URL(string: "https://opra.roonlabs.net/")!
+    private static let cacheMaxAge: TimeInterval = 24 * 60 * 60
+    private static let lastFetchedKey = "com.iqualize.opraCatalogFetchedAt"
+
+    private var cached: [OPRAProductEntry]?
+
+    private init() {}
+
+    /// Returns the parsed product catalog, using a same-day disk cache when available and
+    /// falling back to any existing (even stale) cache if a fresh network fetch fails.
+    func loadIfNeeded() async throws -> [OPRAProductEntry] {
+        if let cached { return cached }
+
+        let cacheURL = Self.cacheFileURL()
+        let lastFetched = UserDefaults.standard.object(forKey: Self.lastFetchedKey) as? Date
+        let isFresh = lastFetched.map { Date().timeIntervalSince($0) < Self.cacheMaxAge } ?? false
+
+        if isFresh, let data = try? Data(contentsOf: cacheURL) {
+            let products = try await Self.parse(data)
+            cached = products
+            return products
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: Self.sourceURL)
+            try? Self.writeCache(data, to: cacheURL)
+            UserDefaults.standard.set(Date(), forKey: Self.lastFetchedKey)
+            let products = try await Self.parse(data)
+            cached = products
+            return products
+        } catch {
+            guard let data = try? Data(contentsOf: cacheURL) else { throw error }
+            let products = try await Self.parse(data)
+            cached = products
+            return products
+        }
+    }
+
+    private static func cacheFileURL() -> URL {
+        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let dir = base.appendingPathComponent(Bundle.main.bundleIdentifier ?? "com.iqualize.app", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("opra_database_v1.jsonl")
+    }
+
+    private static func writeCache(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Parses the JSONL database (one JSON object per line: vendor / product / eq) into
+    /// joined `OPRAProductEntry` values. Done off the main actor since this walks tens of
+    /// thousands of lines.
+    nonisolated private static func parse(_ data: Data) async throws -> [OPRAProductEntry] {
+        try await Task.detached(priority: .userInitiated) {
+            var vendorNames: [String: String] = [:]
+            struct PendingProduct {
+                var name: String
+                var subtype: String?
+                var vendorID: String?
+                var thumbnailPath: String?
+            }
+            var products: [String: PendingProduct] = [:]
+            var curvesByProduct: [String: [OPRACurveEntry]] = [:]
+
+            guard let text = String(data: data, encoding: .utf8) else { throw OPRACatalogError.noData }
+
+            for line in text.split(whereSeparator: \.isNewline) {
+                guard let lineData = line.data(using: .utf8),
+                      let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                      let type = object["type"] as? String,
+                      let payload = object["data"] as? [String: Any] else { continue }
+
+                switch type {
+                case "vendor":
+                    guard let id = object["id"] as? String, let name = payload["name"] as? String else { continue }
+                    vendorNames[id] = name
+
+                case "product":
+                    guard let id = object["id"] as? String, let name = payload["name"] as? String else { continue }
+                    products[id] = PendingProduct(
+                        name: name,
+                        subtype: payload["subtype"] as? String,
+                        vendorID: payload["vendor_id"] as? String,
+                        thumbnailPath: payload["line_art_96x64_png"] as? String
+                    )
+
+                case "eq":
+                    guard let id = object["id"] as? String,
+                          let author = payload["author"] as? String,
+                          let productID = payload["product_id"] as? String,
+                          let curveData = try? JSONSerialization.data(withJSONObject: payload) else { continue }
+                    let curve = OPRACurveEntry(id: id, author: author, details: payload["details"] as? String, data: curveData)
+                    curvesByProduct[productID, default: []].append(curve)
+
+                default:
+                    continue
+                }
+            }
+
+            var entries: [OPRAProductEntry] = []
+            entries.reserveCapacity(products.count)
+            for (productID, product) in products {
+                guard let curves = curvesByProduct[productID], !curves.isEmpty else { continue }
+                let vendorName = product.vendorID.flatMap { vendorNames[$0] } ?? "Unknown"
+                let thumbnailURL = product.thumbnailPath.flatMap { URL(string: $0, relativeTo: assetBaseURL) }
+                entries.append(OPRAProductEntry(
+                    id: productID,
+                    vendorName: vendorName,
+                    productName: product.name,
+                    subtype: product.subtype,
+                    thumbnailURL: thumbnailURL?.absoluteURL,
+                    curves: curves
+                ))
+            }
+
+            return entries.sorted {
+                ($0.vendorName, $0.productName) < ($1.vendorName, $1.productName)
+            }
+        }.value
+    }
+}

--- a/Sources/iQualize/PresetBrowserWindowController.swift
+++ b/Sources/iQualize/PresetBrowserWindowController.swift
@@ -1,0 +1,40 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the OPRA Preset Browser (see `PresetBrowserView`) in its own resizable window,
+/// following the same plain-`NSWindowController` + `NSHostingView` bridging pattern as
+/// `HelpWindowController` / `DreamHostingView`.
+@available(macOS 14.2, *)
+@MainActor
+final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate {
+    init(onImport: @escaping (OPRAProductEntry, OPRACurveEntry) -> Void) {
+        let window = HelpAwareWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered, defer: true
+        )
+        window.title = "Browse OPRA Presets"
+        window.minSize = NSSize(width: 480, height: 360)
+        window.center()
+        window.isReleasedWhenClosed = false
+
+        super.init(window: window)
+        window.delegate = self
+
+        let host = NSHostingView(rootView: PresetBrowserView(onImport: onImport))
+        host.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(host)
+        NSLayoutConstraint.activate([
+            host.topAnchor.constraint(equalTo: container.topAnchor),
+            host.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            host.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        window.contentView = container
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+}


### PR DESCRIPTION
## Summary
- Adds a Preset Browser window (Save/Import menu → "Browse OPRA Presets…") that searches and imports community headphone/IEM EQ profiles directly from the [OPRA](https://opra.roon.app/) database, instead of requiring users to manually find and download an `eq_info.json` first
- `OPRACatalog` fetches/caches `database_v1.jsonl` (~12.6MB, ~714 vendors / ~6,230 products / ~12,600 curves) and joins vendor/product/eq entries; `PresetBrowserView` is a `NavigationSplitView` — search/select a product in the sidebar, pick one of its available community curves in the detail pane
- Reuses the existing AutoEQ/OPRA import path end-to-end: the browser hands the selected curve's raw JSON straight to `PresetImporter.parseOPRA` (added in #86), no duplicated parsing logic
- Refactored `DreamViewModel.importPresets()`'s per-file rename/overwrite/save logic into a shared `saveImportedPreset` helper, used by both the file-import flow and the new browser import
- Version bump 0.35.0 → 0.36.0 (new feature), CHANGELOG + README updated

## Test plan
- [x] `swift build` succeeds
- [x] App builds, installs, and launches (`install.sh` + `pgrep` check)
- [x] Validated the OPRA jsonl parse/join logic against the live database (6,229/6,230 products joined correctly, zero missing vendors/thumbnails)
- [x] Clicked through the full flow in the running app: opened the browser, searched "HD 650", selected a product, saw its 13 available community curves, imported the oratory1990 Harman Target curve, confirmed the rename dialog, confirmed it became the active preset with correct bands/gain, confirmed it persisted across app restart as a custom preset
- [x] Fixed a sidebar-too-narrow default (`.navigationSplitViewColumnWidth`) found during that manual pass