### PR TITLE
Deletable built-in presets + iQualize catalog tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.37.0] - 2026-07-12
+
+### Added
+- Built-in presets can now be deleted (except Flat, which stays as a safe fallback) — useful if you don't want the app's more opinionated presets (Hard Techno, German Rap, DEADBEEF, etc.) cluttering your picker. Deleted ones aren't gone for good: the Preset Browser (Save/Import menu → "Preset Browser…") now has an **iQualize** tab alongside OPRA, listing anything you've deleted with a one-click Restore
+
 ## [0.36.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,11 +76,12 @@ open /Applications/iQualize.app
 
 - Built-in presets: Flat, Bass Boost, Vocal Clarity, Loudness, Treble Boost, Podcast, Techno, Deep House, Hard Techno, Minimal, American Rap, German Rap
 - Create, rename, overwrite, and delete custom presets
+- Built-in presets can be deleted too (except Flat) if you don't want them cluttering your picker — bring a deleted one back anytime from the Preset Browser's iQualize tab
 - Built-in presets auto-fork when edited (non-destructive)
 - In/Out dB gain can be stored per-preset (default) or shared globally across all presets — see Settings → General
 - Unsaved changes indicator (asterisk in title)
 - Import/export as `.iqpreset` JSON files with batch import and overwrite protection — also accepts AutoEQ `ParametricEQ.txt`/`GraphicEQ.txt` and OPRA `eq_info.json` files
-- Preset Browser: search and import community headphone/IEM EQ profiles directly from the [OPRA](https://opra.roon.app/) database, no manual file download needed
+- Preset Browser: an OPRA tab to search and import community headphone/IEM EQ profiles directly from the [OPRA](https://opra.roon.app/) database, and an iQualize tab to restore any built-in presets you've deleted
 - Quick switching from the menu bar or EQ window picker
 
 #### Preset Format

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -80,7 +80,7 @@ struct DreamToolbar: View {
                 .keyboardShortcut("s", modifiers: [.command, .shift])
             Divider()
             Button("Import Preset…") { vm.importPresets() }
-            Button("Browse OPRA Presets…") { vm.showPresetBrowser() }
+            Button("Preset Browser…") { vm.showPresetBrowser() }
             Button("Export Preset…") { vm.exportActivePreset() }
         } label: {
             Text("Save")
@@ -94,7 +94,7 @@ struct DreamToolbar: View {
         Button("Reset") { vm.resetToSnapshot() }
             .disabled(!vm.isModified)
         Button("Delete") { vm.deleteCurrentPreset() }
-            .disabled(vm.isBuiltIn)
+            .disabled(vm.activePresetID == EQPresetData.flat.id)
     }
 
     @ViewBuilder

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -582,14 +582,21 @@ final class DreamViewModel {
     }
 
     func deleteCurrentPreset() {
-        guard !isBuiltIn else { return }
-        presetStore.deleteCustomPreset(id: activePresetID)
+        guard activePresetID != EQPresetData.flat.id else { return }
+        if isBuiltIn {
+            presetStore.hideBuiltInPreset(id: activePresetID)
+        } else {
+            presetStore.deleteCustomPreset(id: activePresetID)
+        }
         let old = audioEngine.activePreset
         audioEngine.activePreset = .flat
         savedSnapshot = .flat
         isModified = false
         syncFromAudioEngine()
         registerUndo(actionName: "Delete Preset", oldPreset: old)
+        var s = iQualizeState.load()
+        s.selectedPresetID = EQPresetData.flat.id
+        s.save()
     }
 
     // MARK: - Undo / Redo
@@ -752,14 +759,14 @@ final class DreamViewModel {
         return preset
     }
 
-    // MARK: - OPRA Preset Browser
+    // MARK: - Preset Browser
 
     private var presetBrowserWindowController: PresetBrowserWindowController?
 
-    /// Opens (or refocuses) the OPRA Preset Browser window.
+    /// Opens (or refocuses) the Preset Browser window (OPRA tab + iQualize tab).
     func showPresetBrowser() {
         if presetBrowserWindowController == nil {
-            presetBrowserWindowController = PresetBrowserWindowController { [weak self] product, curve in
+            presetBrowserWindowController = PresetBrowserWindowController(presetStore: presetStore) { [weak self] product, curve in
                 self?.importOPRACurve(product: product, curve: curve)
             }
         }

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -1,9 +1,42 @@
 import SwiftUI
 
+/// Top-level Preset Browser container: a catalog picker switching between OPRA's community
+/// database and iQualize's own built-in presets the user has hidden from their picker.
+@available(macOS 14.2, *)
+struct PresetBrowserView: View {
+    let presetStore: PresetStore
+    let onImportOPRA: (OPRAProductEntry, OPRACurveEntry) -> Void
+
+    private enum Catalog: String, CaseIterable {
+        case opra = "OPRA"
+        case iqualize = "iQualize"
+    }
+
+    @State private var catalog: Catalog = .opra
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Catalog", selection: $catalog) {
+                ForEach(Catalog.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(8)
+            Divider()
+            switch catalog {
+            case .opra:
+                OPRACatalogBrowserView(onImport: onImportOPRA)
+            case .iqualize:
+                IQualizeCatalogView(presetStore: presetStore)
+            }
+        }
+    }
+}
+
 /// Search-and-import UI for OPRA's community headphone EQ database. Sidebar lists matching
 /// products; selecting one shows its available community EQ curves in the detail pane.
 @available(macOS 14.2, *)
-struct PresetBrowserView: View {
+struct OPRACatalogBrowserView: View {
     let onImport: (OPRAProductEntry, OPRACurveEntry) -> Void
 
     @State private var products: [OPRAProductEntry] = []
@@ -116,6 +149,31 @@ struct PresetBrowserView: View {
             loadState = .loaded
         } catch {
             loadState = .failed(error.localizedDescription)
+        }
+    }
+}
+
+/// Lists built-in presets the user has deleted from their picker, with a one-click way to
+/// bring each back. Unlike an OPRA import, restoring doesn't switch the active EQ curve —
+/// it just makes the preset selectable again from the normal preset picker.
+@available(macOS 14.2, *)
+struct IQualizeCatalogView: View {
+    let presetStore: PresetStore
+
+    var body: some View {
+        let hidden = presetStore.hiddenBuiltInPresets
+        if hidden.isEmpty {
+            Text("All built-in presets are already in your list")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(hidden) { preset in
+                HStack {
+                    Text(preset.name)
+                    Spacer()
+                    Button("Restore") { presetStore.restoreBuiltInPreset(id: preset.id) }
+                }
+            }
         }
     }
 }

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -53,12 +53,18 @@ final class EQWindowController: NSWindowController {
             self?.refreshWindowTitle()
         }
 
-        // Restore active preset.
-        let state = iQualizeState.load()
+        // Restore active preset. Falls back to Flat if the persisted ID no longer resolves
+        // (e.g. it pointed at a built-in that's since been hidden), correcting persisted state
+        // so this doesn't repeat on next launch.
+        var state = iQualizeState.load()
         if let preset = presetStore.preset(for: state.selectedPresetID) {
             audioEngine.activePreset = preset
-            viewModel.syncFromAudioEngine(initial: true)
+        } else {
+            audioEngine.activePreset = .flat
+            state.selectedPresetID = EQPresetData.flat.id
+            state.save()
         }
+        viewModel.syncFromAudioEngine(initial: true)
 
         viewModel.onTitleShouldUpdate = { [weak self] in self?.refreshWindowTitle() }
         refreshWindowTitle()

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.36.0</string>
+	<string>0.37.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.36.0</string>
+	<string>0.37.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -14,7 +14,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         self.audioEngine = audioEngine
         self.presetStore = presetStore
         super.init()
-        let state = iQualizeState.load()
+        var state = iQualizeState.load()
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         let menu = NSMenu()
@@ -31,6 +31,10 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         audioEngine.gainIsGlobal = state.linkGainGlobally
         if let preset = presetStore.preset(for: state.selectedPresetID) {
             audioEngine.activePreset = preset
+        } else {
+            audioEngine.activePreset = .flat
+            state.selectedPresetID = EQPresetData.flat.id
+            state.save()
         }
         audioEngine.peakLimiter = state.peakLimiter
         audioEngine.maxGainDB = state.maxGainDB
@@ -102,7 +106,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate {
         let builtInHeader = NSMenuItem(title: "Built-in", action: nil, keyEquivalent: "")
         builtInHeader.isEnabled = false
         presetSubmenu.addItem(builtInHeader)
-        for preset in EQPresetData.builtInPresets {
+        for preset in presetStore.allPresets.filter(\.isBuiltIn) {
             presetSubmenu.addItem(presetItem(for: preset))
         }
 

--- a/Sources/iQualize/PresetBrowserWindowController.swift
+++ b/Sources/iQualize/PresetBrowserWindowController.swift
@@ -1,19 +1,20 @@
 import AppKit
 import SwiftUI
 
-/// Hosts the OPRA Preset Browser (see `PresetBrowserView`) in its own resizable window,
-/// following the same plain-`NSWindowController` + `NSHostingView` bridging pattern as
-/// `HelpWindowController` / `DreamHostingView`.
+/// Hosts the Preset Browser (see `PresetBrowserView`) in its own resizable window — an OPRA
+/// tab plus an iQualize tab for built-in presets the user has hidden — following the same
+/// plain-`NSWindowController` + `NSHostingView` bridging pattern as `HelpWindowController` /
+/// `DreamHostingView`.
 @available(macOS 14.2, *)
 @MainActor
 final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate {
-    init(onImport: @escaping (OPRAProductEntry, OPRACurveEntry) -> Void) {
+    init(presetStore: PresetStore, onImportOPRA: @escaping (OPRAProductEntry, OPRACurveEntry) -> Void) {
         let window = HelpAwareWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered, defer: true
         )
-        window.title = "Browse OPRA Presets"
+        window.title = "Preset Browser"
         window.minSize = NSSize(width: 480, height: 360)
         window.center()
         window.isReleasedWhenClosed = false
@@ -21,7 +22,7 @@ final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate 
         super.init(window: window)
         window.delegate = self
 
-        let host = NSHostingView(rootView: PresetBrowserView(onImport: onImport))
+        let host = NSHostingView(rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA))
         host.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -8,9 +8,11 @@ final class PresetStore {
     private(set) var customPresets: [EQPresetData] = []
     /// Pinned/favorited preset IDs, in the order they were favorited.
     private(set) var favoritePresetIDs: [UUID] = []
+    /// Built-in presets the user has deleted from their picker. Flat can never appear here.
+    private(set) var hiddenBuiltInPresetIDs: [UUID] = []
 
     var allPresets: [EQPresetData] {
-        EQPresetData.builtInPresets + customPresets
+        EQPresetData.builtInPresets.filter { !hiddenBuiltInPresetIDs.contains($0.id) } + customPresets
     }
 
     /// Favorited presets, in favorite order. Skips IDs that no longer resolve to a preset.
@@ -18,8 +20,15 @@ final class PresetStore {
         favoritePresetIDs.compactMap { preset(for: $0) }
     }
 
+    /// Built-in presets currently hidden from the picker — shown in the Preset Browser's
+    /// iQualize tab so they can be brought back.
+    var hiddenBuiltInPresets: [EQPresetData] {
+        EQPresetData.builtInPresets.filter { hiddenBuiltInPresetIDs.contains($0.id) }
+    }
+
     private static let key = "com.iqualize.customPresets"
     private static let favoritesKey = "com.iqualize.favoritePresetIDs"
+    private static let hiddenBuiltInsKey = "com.iqualize.hiddenBuiltInPresetIDs"
 
     init() {
         load()
@@ -60,6 +69,24 @@ final class PresetStore {
         }
     }
 
+    /// Hides a built-in preset from the picker. Flat is protected — several places in the app
+    /// assume it always exists as a safe fallback, so it can never be hidden.
+    func hideBuiltInPreset(id: UUID) {
+        guard id != EQPresetData.flat.id, !hiddenBuiltInPresetIDs.contains(id) else { return }
+        hiddenBuiltInPresetIDs.append(id)
+        persistHiddenBuiltIns()
+        if favoritePresetIDs.contains(id) {
+            favoritePresetIDs.removeAll { $0 == id }
+            persistFavorites()
+        }
+    }
+
+    /// Brings a hidden built-in preset back into the picker.
+    func restoreBuiltInPreset(id: UUID) {
+        hiddenBuiltInPresetIDs.removeAll { $0 == id }
+        persistHiddenBuiltIns()
+    }
+
     /// Returns a "(Custom)" fork of `preset` (deduped name against `allPresets`) if it's
     /// built-in; returns `preset` unchanged otherwise. Pure — does not persist and does not
     /// touch AudioEngine; callers decide whether/when to call `saveCustomPreset`.
@@ -93,6 +120,10 @@ final class PresetStore {
            let ids = try? JSONDecoder().decode([UUID].self, from: data) {
             favoritePresetIDs = ids
         }
+        if let data = UserDefaults.standard.data(forKey: Self.hiddenBuiltInsKey),
+           let ids = try? JSONDecoder().decode([UUID].self, from: data) {
+            hiddenBuiltInPresetIDs = ids
+        }
     }
 
     private func persist() {
@@ -104,6 +135,12 @@ final class PresetStore {
     private func persistFavorites() {
         if let data = try? JSONEncoder().encode(favoritePresetIDs) {
             UserDefaults.standard.set(data, forKey: Self.favoritesKey)
+        }
+    }
+
+    private func persistHiddenBuiltIns() {
+        if let data = try? JSONEncoder().encode(hiddenBuiltInPresetIDs) {
+            UserDefaults.standard.set(data, forKey: Self.hiddenBuiltInsKey)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Built-in presets can now be deleted from the picker (Toolbar Delete button is no longer hard-disabled for them) — except **Flat**, which stays protected since several places in the code assume it always exists as a safe fallback (app defaults, decode-failure fallbacks, the delete-preset fallback target)
- Deleting a built-in just hides it (`PresetStore.hiddenBuiltInPresetIDs`, persisted like `favoritePresetIDs`) — the underlying preset data/UUID/`isBuiltIn` flag is untouched, so it's fully recoverable
- The Preset Browser (Save/Import menu → "Preset Browser…") now has two tabs: the existing **OPRA** tab, and a new **iQualize** tab listing any built-ins you've deleted with a one-click Restore. Restoring doesn't switch your active preset — it just makes it selectable again
- Bundled fix found while investigating: `EQWindowController` and `MenuBarController` silently no-op'd on launch if the persisted `selectedPresetID` stopped resolving (now reachable via this feature), leaving `audioEngine.activePreset` at its default without ever correcting the stale persisted ID. Both now explicitly fall back to Flat and persist the correction
- Version bump 0.36.0 → 0.37.0, CHANGELOG + README updated

## Test plan
- [x] `swift build` succeeds, no new warnings
- [x] App builds, installs, and launches (`install.sh` + `pgrep` check), including a quit/relaunch cycle to cover the launch-restore fallback fix
- [x] Clicked through the full flow: switched to "German Rap" (built-in), confirmed Delete is now enabled, deleted it — confirmed it disappeared from the toolbar preset picker and the app fell back to Flat with Delete disabled again
- [x] Opened Preset Browser → iQualize tab, confirmed "German Rap" listed with a Restore button, clicked Restore — confirmed it reappeared in the main picker in its original order, disappeared from the iQualize tab (live `@Observable` update, no refresh needed), and the active preset stayed on Flat (didn't auto-activate)
- [x] Confirmed the OPRA tab still works unchanged (regression check on the picker-container refactor)
- [x] Confirmed Flat's Delete button stays disabled at all times