### PR TITLE
fix: persist selectedPresetID when gain-forking a preset in the EQ window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.37.1] - 2026-07-12
+
+### Fixed
+- Gain-slider edits in the EQ window while per-preset In/Out dB is active now correctly persist the forked "(Custom)" preset as the selected preset, so it's still active after quitting and relaunching instead of silently reverting to the original built-in preset
+
 ## [0.37.0] - 2026-07-12
 
 ### Added

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -848,6 +848,9 @@ final class DreamViewModel {
             audioEngine.activePreset = preset
             presetStore.saveCustomPreset(preset)
             savedSnapshot = preset
+            var s = iQualizeState.load()
+            s.selectedPresetID = preset.id
+            s.save()
         }
     }
 
@@ -862,6 +865,9 @@ final class DreamViewModel {
             audioEngine.activePreset = preset
             presetStore.saveCustomPreset(preset)
             savedSnapshot = preset
+            var s = iQualizeState.load()
+            s.selectedPresetID = preset.id
+            s.save()
         }
     }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.37.0</string>
+	<string>0.37.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.37.0</string>
+	<string>0.37.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- `applyInputGain()`/`applyOutputGain()` in `DreamViewModel` fork a built-in preset into a "(Custom)" copy when per-preset gain mode is active, but never persisted `iQualizeState.selectedPresetID` to the new fork's id — same class of bug already fixed in `MenuBarController.setInputGain`/`setOutputGain`, now mirrored here.
- Without the fix, adjusting the Input/Output dB slider on a built-in preset (with "Share In/Out dB across all presets" off) forks it fine in the moment, but the fork is silently forgotten on quit/relaunch — the app reverts to the original built-in preset even though the fork still exists in the presets list.
- Bumped 0.37.0 → 0.37.1 (patch) and added a CHANGELOG entry per repo convention.

## Test plan
- [x] `swift build` succeeds
- [x] Reproduced manually: selected built-in "Treble Boost", per-preset gain mode on, dragged Input dB slider → forked to "Treble Boost (Custom)" (+14.5 dB)
- [x] Quit via Cmd+Q, relaunched — "Treble Boost (Custom)" was restored as active (menu bar + EQ window), gain intact