### PR TITLE
docs: make the CLI's install step harder to miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.39.0] - 2026-07-12
+
+### Changed
+- Made the CLI's install step harder to miss: Settings → General now shows a caption under "Install Command Line Tool" explaining what it does and that you need a new Terminal window afterward, and the README's Command Line section leads with setup instead of burying it in a usage example
+
 ## [0.38.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -170,8 +170,13 @@ Accessible via the gear icon in the EQ window, the Settings item in the menu bar
 
 Control a running iQualize instance without touching the menu bar — handy if you don't
 use it at all, and makes iQualize scriptable (Shortcuts, launchd jobs, keyboard-shortcut
-launchers, etc). Install it from Settings → General → "Install Command Line Tool" (or,
-for dev builds, `install.sh` symlinks it automatically).
+launchers, etc).
+
+**Setup (one-time):** open iQualize → Settings (Cmd+,) → General → **"Install Command
+Line Tool"**. This prompts for your admin password once and adds `iqualize` to your
+PATH. Open a **new** Terminal window afterward — a window that was already open won't
+pick it up. (Building from source instead? `install.sh` symlinks it automatically, no
+button needed.)
 
 ```
 iqualize                      # same as `iqualize status`
@@ -184,7 +189,8 @@ iqualize gain output [<dB>]
 ```
 
 If iQualize isn't running, the CLI launches it and retries for a few seconds before
-giving up.
+giving up. If Terminal still says `command not found` after installing, double-check
+you opened a new window/tab, and that `/usr/local/bin` is on your `PATH` (`echo $PATH`).
 
 ## Architecture
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.38.0</string>
+	<string>0.39.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.38.0</string>
+	<string>0.39.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -239,6 +239,12 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         installCLIButton.isEnabled = !Self.cliAlreadyInstalled
         mainStack.addArrangedSubview(installCLIButton)
 
+        let cliHint = NSTextField(wrappingLabelWithString:
+            "Adds the `iqualize` command to Terminal — control iQualize without the menu bar. Open a new Terminal window after installing.")
+        cliHint.font = .systemFont(ofSize: 11)
+        cliHint.textColor = .secondaryLabelColor
+        mainStack.addArrangedSubview(cliHint)
+
         return mainStack
     }
 

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -240,9 +240,14 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         mainStack.addArrangedSubview(installCLIButton)
 
         let cliHint = NSTextField(wrappingLabelWithString:
-            "Adds the `iqualize` command to Terminal — control iQualize without the menu bar. Open a new Terminal window after installing.")
+            "Adds the `iqualize` command to Terminal. Open a new Terminal window after installing.")
         cliHint.font = .systemFont(ofSize: 11)
         cliHint.textColor = .secondaryLabelColor
+        // Without a capped layout width, a wrapping label reports its unwrapped single-line
+        // width as its intrinsic size — which would make it the widest row and blow out the
+        // window instead of wrapping. Cap it to the window's base content width so it wraps
+        // in place and never becomes the width driver.
+        cliHint.preferredMaxLayoutWidth = 280
         mainStack.addArrangedSubview(cliHint)
 
         return mainStack


### PR DESCRIPTION
## Summary
- Running `iqualize` in Terminal before clicking Settings → General → "Install Command Line Tool" fails with a plain `command not found`, with nothing pointing the user at the button that fixes it.
- Adds a caption under the button in Settings explaining what it does and that a new Terminal window is needed afterward.
- Reorders the README's Command Line section to lead with the one-time setup step instead of mentioning it mid-sentence before the usage examples, and adds a troubleshooting line for the "command not found" case.
- Version bump to 0.39.0 (UI change) per this repo's version-bump rule; CHANGELOG updated.

## Test plan
- [x] `swift build` — compiles clean
- [x] `bash install.sh && open /Applications/iQualize.app` — launches successfully
- [x] Visual: Settings → General shows the new caption under "Install Command Line Tool"