### PR TITLE
feat: per-device EQ memory with a shared native preset picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.40.0] - 2026-07-12
+
+### Added
+- Per-device EQ memory — pin a preset to an output device (from the EQ window toolbar or the menu bar) and it's recalled automatically whenever that device becomes the active output, including at app launch (#79)
+
+### Changed
+- Renamed "pin" to "favorite" for the existing favorite-preset feature (star icon instead of a pin icon) to avoid confusion with the new device pin
+- The in-app EQ window's preset picker is now the same native menu as the menu bar dropdown — Favorites/Built-in/Custom sections, consistent star/checkmark layout, and ⌥-click-to-favorite that doesn't close the menu, on both surfaces
+- Toggling a device pin or a favorite is now a plain click/⌥-click instead of requiring extra modifiers to distinguish pin from unpin
+- The EQ window's output-device label now shows the device's pinned preset name, if any
+
 ## [0.39.0] - 2026-07-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ open /Applications/iQualize.app
 - Unsaved changes indicator (asterisk in title)
 - Import/export as `.iqpreset` JSON files with batch import and overwrite protection — also accepts AutoEQ `ParametricEQ.txt`/`GraphicEQ.txt` and OPRA `eq_info.json` files
 - Preset Browser: an OPRA tab to search and import community headphone/IEM EQ profiles directly from the [OPRA](https://opra.roon.app/) database, and an iQualize tab to restore any built-in presets you've deleted
-- Quick switching from the menu bar or EQ window picker
+- Quick switching from the menu bar or EQ window picker — both use the same native preset picker, with Favorites, Built-in, and Custom sections
+- Favorite presets (star icon, or ⌥-click a preset) to pin them to the top of the picker for one-click switching
+- Pin a preset to an output device (pin button in the EQ window toolbar, or from the menu bar) — it's recalled automatically whenever that device becomes the active audio output, including at launch
 
 #### Preset Format
 
@@ -128,7 +130,7 @@ Presets may also carry `inputGainDB` and `outputGainDB` (dB, optional — omitte
 - Option+click the menu bar icon to open the EQ window directly (skips the menu)
 - Presets submenu with checkmarks and active preset name in parent item — changes sync to the EQ window in real time
 - Bypass EQ toggle (Cmd+B) — pass audio through unprocessed; while bypassed, the Post-EQ spectrum line and its color/fill controls are hidden/disabled (post-EQ would otherwise just mirror pre-EQ)
-- Current output device display
+- Current output device display, with a pin/unpin item to remember a preset for that specific device
 - Help… (Cmd+?) — opens an in-app Help window rendering the README's Features section, with a "View latest on GitHub" link
 - About iQualize — shows version and a "View on GitHub" button that opens the project page in your default browser
 

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -86,6 +86,7 @@ private func renderCallback(
 final class AudioEngine {
     private(set) var isRunning = false
     private(set) var outputDeviceName = "Unknown"
+    private(set) var outputDeviceUID: String?
     private(set) var error: String?
 
     private var tapID = AudioObjectID(kAudioObjectUnknown)
@@ -101,6 +102,10 @@ final class AudioEngine {
     @ObservationIgnored
     nonisolated(unsafe) private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
     var onStateChange: (() -> Void)?
+    /// Resolves a pinned preset for a device UID, if any. Wired by the caller that owns
+    /// both AudioEngine and PresetStore — kept as a closure so AudioEngine stays decoupled
+    /// from the store type, same pattern as `onStateChange`.
+    var pinnedPresetProvider: ((String) -> EQPresetData?)?
 
     // Spectrum analyzers — one per tap point
     let preEqAnalyzer = SpectrumAnalyzer()
@@ -160,6 +165,7 @@ final class AudioEngine {
         do {
             let deviceID = try getDefaultOutputDeviceID()
             outputDeviceName = try getDeviceName(deviceID)
+            outputDeviceUID = try? getDeviceUID(deviceID)
         } catch {
             outputDeviceName = "Unknown"
         }
@@ -189,6 +195,7 @@ final class AudioEngine {
         let outputDeviceID = try getDefaultOutputDeviceID()
         let outputUID = try getDeviceUID(outputDeviceID)
         outputDeviceName = try getDeviceName(outputDeviceID)
+        outputDeviceUID = outputUID
 
         // 1. Translate our PID → AudioObjectID so we can exclude ourselves from the tap.
         //    Without this, the muted tap silences iQualize's own AVAudioEngine output.
@@ -571,9 +578,18 @@ final class AudioEngine {
     private func handleDeviceChange() {
         guard !isRestarting else { return }
 
-        if let deviceID = try? getDefaultOutputDeviceID(),
-           let name = try? getDeviceName(deviceID) {
-            outputDeviceName = name
+        if let deviceID = try? getDefaultOutputDeviceID() {
+            if let name = try? getDeviceName(deviceID) {
+                outputDeviceName = name
+            }
+            let uid = try? getDeviceUID(deviceID)
+            outputDeviceUID = uid
+            if let uid, let pinned = pinnedPresetProvider?(uid) {
+                activePreset = pinned
+                var s = iQualizeState.load()
+                s.selectedPresetID = pinned.id
+                s.save()
+            }
         }
 
         if isRunning {

--- a/Sources/iQualize/DreamUI/DreamFooter.swift
+++ b/Sources/iQualize/DreamUI/DreamFooter.swift
@@ -191,15 +191,22 @@ struct DreamFooter: View {
 
     // MARK: - Output label
 
+    private var outputLabelText: String {
+        if let pinned = vm.pinnedPresetNameForCurrentDevice {
+            return "\(vm.outputDeviceName) · Pinned: \(pinned)"
+        }
+        return vm.outputDeviceName
+    }
+
     @ViewBuilder
     private var outputLabel: some View {
-        Text(vm.outputDeviceName)
+        Text(outputLabelText)
             .font(.system(size: 11))
             .foregroundStyle(theme.textMute)
             .lineLimit(1)
             .truncationMode(.tail)
             .frame(maxWidth: 320)
-            .help(vm.outputDeviceName)
+            .help(outputLabelText)
     }
 
     // MARK: - Format

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -44,30 +44,13 @@ struct DreamToolbar: View {
 
     @ViewBuilder
     private var presetGroup: some View {
-        Menu {
-            let favorites = vm.presetStore.favoritePresets
-            if !favorites.isEmpty {
-                ForEach(favorites, id: \.id) { preset in
-                    presetButton(for: preset)
-                }
-                Divider()
-            }
-            ForEach(vm.presetStore.allPresets, id: \.id) { preset in
-                presetButton(for: preset)
-            }
-            Divider()
-            Text("⌥-click a preset to pin/unpin")
-        } label: {
-            HStack(spacing: 4) {
-                Text(presetButtonLabel)
+        PresetPickerButton(vm: vm, label: presetButtonLabel)
+            .fixedSize()
+            .overlay(alignment: .trailing) {
                 if vm.isModified {
-                    Circle().fill(theme.accent).frame(width: 5, height: 5)
+                    Circle().fill(theme.accent).frame(width: 5, height: 5).offset(x: 8)
                 }
             }
-        }
-        .menuStyle(.button)
-        .controlSize(.regular)
-        .fixedSize()
 
         Button("New") { vm.newPreset() }
 
@@ -109,6 +92,15 @@ struct DreamToolbar: View {
         .controlSize(.regular)
         .help("Snap band frequencies to semitones")
 
+        Button(action: { vm.toggleDevicePin() }) {
+            Image(systemName: vm.isCurrentDevicePinnedToActivePreset ? "pin.fill" : "pin")
+                .font(.system(size: 12, weight: .medium))
+        }
+        .controlSize(.regular)
+        .help(vm.isCurrentDevicePinnedToActivePreset
+              ? "Unpin from \(vm.outputDeviceName)"
+              : "Pin to \(vm.outputDeviceName)")
+
         Button(action: { vm.onOpenSettings?() }) {
             Image(systemName: "gearshape").font(.system(size: 12, weight: .medium))
         }
@@ -119,24 +111,5 @@ struct DreamToolbar: View {
     private var presetButtonLabel: String {
         let suffix = vm.isBuiltIn ? " (Built-in)" : ""
         return "\(vm.presetName)\(suffix)"
-    }
-
-    @ViewBuilder
-    private func presetButton(for preset: EQPresetData) -> some View {
-        Button(action: {
-            if NSEvent.modifierFlags.contains(.option) {
-                vm.presetStore.toggleFavorite(preset.id)
-            } else {
-                vm.loadPreset(id: preset.id)
-            }
-        }) {
-            if preset.id == vm.activePresetID {
-                Label(preset.name, systemImage: "checkmark")
-            } else if vm.presetStore.isFavorite(preset.id) {
-                Label(preset.name, systemImage: "pin.fill")
-            } else {
-                Text(preset.name)
-            }
-        }
     }
 }

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -69,6 +69,28 @@ final class DreamViewModel {
 
     var outputDeviceName: String { audioEngine.outputDeviceName }
 
+    /// Whether the active preset is the one pinned to the current output device.
+    var isCurrentDevicePinnedToActivePreset: Bool {
+        guard let uid = audioEngine.outputDeviceUID else { return false }
+        return presetStore.pinnedPresetID(forDeviceUID: uid) == activePresetID
+    }
+
+    /// Name of the preset pinned to the current output device, if any.
+    var pinnedPresetNameForCurrentDevice: String? {
+        guard let uid = audioEngine.outputDeviceUID else { return nil }
+        return presetStore.pinnedPreset(forDeviceUID: uid)?.name
+    }
+
+    /// Unpins if the active preset is already the one pinned here, otherwise pins it.
+    func toggleDevicePin() {
+        guard let uid = audioEngine.outputDeviceUID else { return }
+        if isCurrentDevicePinnedToActivePreset {
+            presetStore.unpinPreset(fromDeviceUID: uid)
+        } else {
+            presetStore.pinPreset(audioEngine.activePreset.id, toDeviceUID: uid)
+        }
+    }
+
     // Computed
     var canUndo: Bool { undoManager?.canUndo ?? false }
     var canRedo: Bool { undoManager?.canRedo ?? false }

--- a/Sources/iQualize/DreamUI/PresetPickerButton.swift
+++ b/Sources/iQualize/DreamUI/PresetPickerButton.swift
@@ -1,0 +1,67 @@
+import AppKit
+import SwiftUI
+
+/// Native NSButton + manually-popped NSMenu wrapper for the in-app preset picker, sharing
+/// PresetMenuBuilder with the menu bar dropdown so both surfaces render/behave identically.
+/// SwiftUI's `Menu` always closes on any item click, with no way to keep it open for
+/// ⌥-click-to-favorite — an `NSPopUpButton`'s automatic pull-down has the same limitation,
+/// so the menu here is built fresh and shown via `NSMenu.popUp` instead.
+@available(macOS 14.2, *)
+struct PresetPickerButton: NSViewRepresentable {
+    var vm: DreamViewModel
+    var label: String
+
+    func makeCoordinator() -> Coordinator { Coordinator(vm: vm) }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton()
+        button.bezelStyle = .rounded
+        button.controlSize = .regular
+        button.font = .systemFont(ofSize: NSFont.systemFontSize)
+        button.title = label
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.showMenu(_:))
+        button.lineBreakMode = .byTruncatingTail
+        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return button
+    }
+
+    func updateNSView(_ nsView: NSButton, context: Context) {
+        context.coordinator.vm = vm
+        nsView.title = label
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var vm: DreamViewModel
+        init(vm: DreamViewModel) { self.vm = vm }
+
+        @objc func showMenu(_ sender: NSButton) {
+            let menu = NSMenu()
+            menu.autoenablesItems = false
+
+            PresetMenuBuilder.addFavorites(
+                to: menu, presets: vm.presetStore.favoritePresets, activePresetID: vm.activePresetID,
+                onSelect: { [weak self] id in self?.select(id); menu.cancelTracking() },
+                onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }
+            )
+            PresetMenuBuilder.addPresetSections(
+                to: menu, builtIn: EQPresetData.builtInPresets, custom: vm.presetStore.customPresets,
+                favoriteIDs: Set(vm.presetStore.favoritePresetIDs), activePresetID: vm.activePresetID,
+                onSelect: { [weak self] id in self?.select(id); menu.cancelTracking() },
+                onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }
+            )
+
+            menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.height + 4), in: sender)
+        }
+
+        private func select(_ id: UUID) {
+            vm.loadPreset(id: id)
+        }
+
+        private func toggleFavorite(_ id: UUID) -> Bool {
+            vm.presetStore.toggleFavorite(id)
+            return vm.presetStore.isFavorite(id)
+        }
+    }
+}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.39.0</string>
+	<string>0.40.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.39.0</string>
+	<string>0.40.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -28,10 +28,21 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             self?.updateIcon()
         }
 
-        // Restore saved state and always start EQ
+        // Recall the preset pinned to a device the moment we switch to it.
+        audioEngine.pinnedPresetProvider = { [weak presetStore] uid in
+            presetStore?.pinnedPreset(forDeviceUID: uid)
+        }
+
+        // Restore saved state and always start EQ — a device pin for the current output
+        // takes priority over the last-selected preset, since it's an explicit user choice.
         audioEngine.gainIsGlobal = state.linkGainGlobally
-        if let preset = presetStore.preset(for: state.selectedPresetID) {
+        let startupPreset = audioEngine.outputDeviceUID
+            .flatMap { presetStore.pinnedPreset(forDeviceUID: $0) }
+            ?? presetStore.preset(for: state.selectedPresetID)
+        if let preset = startupPreset {
             audioEngine.activePreset = preset
+            state.selectedPresetID = preset.id
+            state.save()
         } else {
             audioEngine.activePreset = .flat
             state.selectedPresetID = EQPresetData.flat.id
@@ -84,48 +95,26 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
 
         menu.addItem(.separator())
 
-        // Favorites — pinned presets for one-click switching
-        let favorites = presetStore.favoritePresets
-        if !favorites.isEmpty {
-            for preset in favorites {
-                let item = NSMenuItem(title: preset.name,
-                                      action: #selector(selectPreset(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = preset.id.uuidString
-                item.state = audioEngine.activePreset.id == preset.id ? .on : .off
-                item.image = Self.pinImage
-                menu.addItem(item)
-            }
-            menu.addItem(.separator())
-        }
+        let activePresetID = audioEngine.activePreset.id
+        PresetMenuBuilder.addFavorites(
+            to: menu, presets: presetStore.favoritePresets, activePresetID: activePresetID,
+            onSelect: { [weak self] id in self?.selectPresetAndClose(id: id) },
+            onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }
+        )
 
         // Presets submenu
         let presetMenuItem = NSMenuItem(title: "Presets (\(audioEngine.activePreset.name))",
                                          action: nil, keyEquivalent: "")
         let presetSubmenu = NSMenu()
-
-        let builtInHeader = NSMenuItem(title: "Built-in", action: nil, keyEquivalent: "")
-        builtInHeader.isEnabled = false
-        presetSubmenu.addItem(builtInHeader)
-        for preset in presetStore.allPresets.filter(\.isBuiltIn) {
-            presetSubmenu.addItem(presetItem(for: preset))
-        }
-
-        if !presetStore.customPresets.isEmpty {
-            presetSubmenu.addItem(.separator())
-            let customHeader = NSMenuItem(title: "Custom", action: nil, keyEquivalent: "")
-            customHeader.isEnabled = false
-            presetSubmenu.addItem(customHeader)
-            for preset in presetStore.customPresets {
-                presetSubmenu.addItem(presetItem(for: preset))
-            }
-        }
-
-        presetSubmenu.addItem(.separator())
-        let pinHint = NSMenuItem(title: "⌥-click a preset to pin/unpin", action: nil, keyEquivalent: "")
-        pinHint.isEnabled = false
-        presetSubmenu.addItem(pinHint)
-
+        PresetMenuBuilder.addPresetSections(
+            to: presetSubmenu,
+            builtIn: presetStore.allPresets.filter(\.isBuiltIn),
+            custom: presetStore.customPresets,
+            favoriteIDs: Set(presetStore.favoritePresetIDs),
+            activePresetID: activePresetID,
+            onSelect: { [weak self] id in self?.selectPresetAndClose(id: id) },
+            onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }
+        )
         presetMenuItem.submenu = presetSubmenu
         menu.addItem(presetMenuItem)
 
@@ -141,11 +130,28 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
 
         menu.addItem(.separator())
 
-        // Output device (non-interactive)
+        // Output device (non-interactive) + device-pin toggle
         let outputItem = NSMenuItem(title: "Output: \(audioEngine.outputDeviceName)",
                                      action: nil, keyEquivalent: "")
         outputItem.isEnabled = false
         menu.addItem(outputItem)
+
+        if let uid = audioEngine.outputDeviceUID {
+            let pinnedID = presetStore.pinnedPresetID(forDeviceUID: uid)
+            let pinItem: NSMenuItem
+            if pinnedID == activePresetID {
+                pinItem = NSMenuItem(title: "Unpin \"\(audioEngine.activePreset.name)\" from This Device",
+                                      action: #selector(toggleDevicePin(_:)), keyEquivalent: "")
+            } else if let pinnedID, let pinnedName = presetStore.preset(for: pinnedID)?.name {
+                pinItem = NSMenuItem(title: "Re-pin \"\(audioEngine.activePreset.name)\" to This Device (was \"\(pinnedName)\")",
+                                      action: #selector(toggleDevicePin(_:)), keyEquivalent: "")
+            } else {
+                pinItem = NSMenuItem(title: "Pin \"\(audioEngine.activePreset.name)\" to This Device",
+                                      action: #selector(toggleDevicePin(_:)), keyEquivalent: "")
+            }
+            pinItem.target = self
+            menu.addItem(pinItem)
+        }
 
         // Error display
         if let error = audioEngine.error {
@@ -177,38 +183,27 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
 
     // MARK: - Presets
 
-    private static let pinImage: NSImage = {
-        let image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: "Pinned")!
-        image.isTemplate = true
-        return image
-    }()
+    private func selectPresetAndClose(id: UUID) {
+        applyPreset(id: id)
+        statusItem.menu?.cancelTracking()
+    }
 
-    private func presetItem(for preset: EQPresetData) -> NSMenuItem {
-        let item = NSMenuItem(title: preset.name,
-                              action: #selector(selectPreset(_:)), keyEquivalent: "")
-        item.target = self
-        item.representedObject = preset.id.uuidString
-        item.state = audioEngine.activePreset.id == preset.id ? .on : .off
-        item.indentationLevel = 1
-        if presetStore.isFavorite(preset.id) {
-            item.image = Self.pinImage
+    private func toggleFavorite(_ id: UUID) -> Bool {
+        presetStore.toggleFavorite(id)
+        return presetStore.isFavorite(id)
+    }
+
+    @objc private func toggleDevicePin(_ sender: NSMenuItem) {
+        guard let uid = audioEngine.outputDeviceUID else { return }
+        let activeID = audioEngine.activePreset.id
+        if presetStore.pinnedPresetID(forDeviceUID: uid) == activeID {
+            presetStore.unpinPreset(fromDeviceUID: uid)
+        } else {
+            presetStore.pinPreset(activeID, toDeviceUID: uid)
         }
-        return item
     }
 
     // MARK: - Actions
-
-    @objc private func selectPreset(_ sender: NSMenuItem) {
-        guard let uuidString = sender.representedObject as? String,
-              let id = UUID(uuidString: uuidString) else { return }
-
-        if NSEvent.modifierFlags.contains(.option) {
-            presetStore.toggleFavorite(id)
-            return
-        }
-
-        applyPreset(id: id)
-    }
 
     /// Switches the active preset. Shared by the menu's `selectPreset(_:)` and the CLI.
     @discardableResult

--- a/Sources/iQualize/PresetMenuBuilder.swift
+++ b/Sources/iQualize/PresetMenuBuilder.swift
@@ -1,0 +1,191 @@
+import AppKit
+
+/// A preset row rendered as a custom NSMenuItem view so ⌥-click-to-favorite can keep
+/// the menu open — a plain title/action NSMenuItem always closes the menu on any click,
+/// with no way to distinguish "favorite" from "select" without closing either way.
+/// Shared by MenuBarController (status-item dropdown) and PresetPickerButton (in-app
+/// toolbar) so both surfaces render and behave identically from one source of truth.
+final class PresetRowView: NSView {
+    var presetID: UUID!
+    var onSelect: (() -> Void)?
+    var onToggleFavorite: (() -> Void)?
+
+    weak var labelView: NSTextField?
+    weak var checkmarkView: NSImageView?
+    weak var starView: NSImageView?
+
+    private var trackingArea: NSTrackingArea?
+    private var isHighlighted = false {
+        didSet {
+            guard isHighlighted != oldValue else { return }
+            needsDisplay = true
+            let tint: NSColor? = isHighlighted ? .white : nil
+            labelView?.textColor = isHighlighted ? .white : .labelColor
+            checkmarkView?.contentTintColor = tint
+            starView?.contentTintColor = tint
+        }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeAlways], owner: self)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) { isHighlighted = true }
+    override func mouseExited(with event: NSEvent) { isHighlighted = false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        if isHighlighted {
+            NSColor.selectedContentBackgroundColor.setFill()
+            NSBezierPath(roundedRect: bounds.insetBy(dx: 5, dy: 0), xRadius: 4, yRadius: 4).fill()
+        }
+        super.draw(dirtyRect)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if event.modifierFlags.contains(.option) {
+            onToggleFavorite?()
+        } else {
+            onSelect?()
+        }
+    }
+}
+
+@MainActor
+enum PresetMenuBuilder {
+    static func makeRowItem(
+        for preset: EQPresetData,
+        isActive: Bool,
+        isFavorite: Bool,
+        onSelect: @escaping () -> Void,
+        onToggleFavorite: @escaping () -> Bool
+    ) -> NSMenuItem {
+        let item = NSMenuItem()
+        // Where the checkmark sits, measured from the row's leading edge — matches the
+        // ~14pt left margin plain NSMenuItems use, so header rows and preset rows line up.
+        let checkmarkLeading: CGFloat = 14
+
+        // Initial frame only seeds a starting size. AppKit resizes a custom NSMenuItem
+        // view's frame to the menu's computed width, but only applies that resize if the
+        // view's autoresizingMask allows flexible width — without it the row stays stuck
+        // at its intrinsic size, leaving a highlight/star that fall short of the real edge.
+        // The Auto Layout constraints below then keep the star pinned to that resized
+        // trailing edge and the label filling the space in between.
+        let row = PresetRowView(frame: NSRect(x: 0, y: 0, width: 240, height: 22))
+        row.autoresizingMask = [.width, .height]
+        row.presetID = preset.id
+        row.onSelect = onSelect
+        row.onToggleFavorite = { [weak row] in
+            let isFavoriteNow = onToggleFavorite()
+            (row?.viewWithTag(1) as? NSImageView)?.alphaValue = isFavoriteNow ? 1 : 0
+        }
+
+        let checkmark = NSImageView()
+        checkmark.translatesAutoresizingMaskIntoConstraints = false
+        checkmark.image = NSImage(systemSymbolName: "checkmark", accessibilityDescription: nil)
+        checkmark.image?.isTemplate = true
+        checkmark.alphaValue = isActive ? 1 : 0
+        row.addSubview(checkmark)
+        row.checkmarkView = checkmark
+
+        let label = NSTextField(labelWithString: preset.name)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .menuFont(ofSize: 13)
+        label.lineBreakMode = .byTruncatingTail
+        label.drawsBackground = false
+        row.addSubview(label)
+        row.labelView = label
+
+        let star = NSImageView()
+        star.translatesAutoresizingMaskIntoConstraints = false
+        star.image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: "Favorited")
+        star.image?.isTemplate = true
+        star.alphaValue = isFavorite ? 1 : 0
+        star.tag = 1
+        row.addSubview(star)
+        row.starView = star
+
+        NSLayoutConstraint.activate([
+            checkmark.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: checkmarkLeading),
+            checkmark.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            checkmark.widthAnchor.constraint(equalToConstant: 14),
+            checkmark.heightAnchor.constraint(equalToConstant: 16),
+
+            label.leadingAnchor.constraint(equalTo: checkmark.trailingAnchor, constant: 2),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: star.leadingAnchor, constant: -8),
+            label.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+
+            star.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -14),
+            star.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            star.widthAnchor.constraint(equalToConstant: 14),
+            star.heightAnchor.constraint(equalToConstant: 16),
+        ])
+
+        item.view = row
+        return item
+    }
+
+    /// Appends a "Favorites" header + rows + a trailing separator — only if `presets` is non-empty.
+    static func addFavorites(
+        to menu: NSMenu,
+        presets: [EQPresetData],
+        activePresetID: UUID,
+        onSelect: @escaping (UUID) -> Void,
+        onToggleFavorite: @escaping (UUID) -> Bool
+    ) {
+        guard !presets.isEmpty else { return }
+        let favoritesHeader = NSMenuItem(title: "Favorites", action: nil, keyEquivalent: "")
+        favoritesHeader.isEnabled = false
+        menu.addItem(favoritesHeader)
+        for preset in presets {
+            menu.addItem(makeRowItem(
+                for: preset, isActive: preset.id == activePresetID, isFavorite: true,
+                onSelect: { onSelect(preset.id) }, onToggleFavorite: { onToggleFavorite(preset.id) }
+            ))
+        }
+        menu.addItem(.separator())
+    }
+
+    /// Appends a "Built-in" header + rows, an optional "Custom" header + rows, then a
+    /// trailing separator and a hint row explaining ⌥-click.
+    static func addPresetSections(
+        to menu: NSMenu,
+        builtIn: [EQPresetData],
+        custom: [EQPresetData],
+        favoriteIDs: Set<UUID>,
+        activePresetID: UUID,
+        onSelect: @escaping (UUID) -> Void,
+        onToggleFavorite: @escaping (UUID) -> Bool
+    ) {
+        let builtInHeader = NSMenuItem(title: "Built-in", action: nil, keyEquivalent: "")
+        builtInHeader.isEnabled = false
+        menu.addItem(builtInHeader)
+        for preset in builtIn {
+            menu.addItem(makeRowItem(
+                for: preset, isActive: preset.id == activePresetID, isFavorite: favoriteIDs.contains(preset.id),
+                onSelect: { onSelect(preset.id) }, onToggleFavorite: { onToggleFavorite(preset.id) }
+            ))
+        }
+
+        if !custom.isEmpty {
+            menu.addItem(.separator())
+            let customHeader = NSMenuItem(title: "Custom", action: nil, keyEquivalent: "")
+            customHeader.isEnabled = false
+            menu.addItem(customHeader)
+            for preset in custom {
+                menu.addItem(makeRowItem(
+                    for: preset, isActive: preset.id == activePresetID, isFavorite: favoriteIDs.contains(preset.id),
+                    onSelect: { onSelect(preset.id) }, onToggleFavorite: { onToggleFavorite(preset.id) }
+                ))
+            }
+        }
+
+        menu.addItem(.separator())
+        let favoriteHint = NSMenuItem(title: "⌥-click a preset to favorite/unfavorite", action: nil, keyEquivalent: "")
+        favoriteHint.isEnabled = false
+        menu.addItem(favoriteHint)
+    }
+}

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -10,6 +10,8 @@ final class PresetStore {
     private(set) var favoritePresetIDs: [UUID] = []
     /// Built-in presets the user has deleted from their picker. Flat can never appear here.
     private(set) var hiddenBuiltInPresetIDs: [UUID] = []
+    /// Preset pinned per output device, keyed by the device's stable CoreAudio UID.
+    private(set) var pinnedPresetIDByDeviceUID: [String: UUID] = [:]
 
     var allPresets: [EQPresetData] {
         EQPresetData.builtInPresets.filter { !hiddenBuiltInPresetIDs.contains($0.id) } + customPresets
@@ -29,6 +31,7 @@ final class PresetStore {
     private static let key = "com.iqualize.customPresets"
     private static let favoritesKey = "com.iqualize.favoritePresetIDs"
     private static let hiddenBuiltInsKey = "com.iqualize.hiddenBuiltInPresetIDs"
+    private static let devicePinsKey = "com.iqualize.pinnedPresetsByDevice"
 
     init() {
         load()
@@ -51,6 +54,24 @@ final class PresetStore {
         persistFavorites()
     }
 
+    func pinnedPresetID(forDeviceUID uid: String) -> UUID? {
+        pinnedPresetIDByDeviceUID[uid]
+    }
+
+    func pinnedPreset(forDeviceUID uid: String) -> EQPresetData? {
+        pinnedPresetID(forDeviceUID: uid).flatMap { preset(for: $0) }
+    }
+
+    func pinPreset(_ id: UUID, toDeviceUID uid: String) {
+        pinnedPresetIDByDeviceUID[uid] = id
+        persistDevicePins()
+    }
+
+    func unpinPreset(fromDeviceUID uid: String) {
+        pinnedPresetIDByDeviceUID.removeValue(forKey: uid)
+        persistDevicePins()
+    }
+
     func saveCustomPreset(_ preset: EQPresetData) {
         if let index = customPresets.firstIndex(where: { $0.id == preset.id }) {
             customPresets[index] = preset
@@ -67,6 +88,10 @@ final class PresetStore {
             favoritePresetIDs.removeAll { $0 == id }
             persistFavorites()
         }
+        if pinnedPresetIDByDeviceUID.values.contains(id) {
+            pinnedPresetIDByDeviceUID = pinnedPresetIDByDeviceUID.filter { $0.value != id }
+            persistDevicePins()
+        }
     }
 
     /// Hides a built-in preset from the picker. Flat is protected — several places in the app
@@ -78,6 +103,10 @@ final class PresetStore {
         if favoritePresetIDs.contains(id) {
             favoritePresetIDs.removeAll { $0 == id }
             persistFavorites()
+        }
+        if pinnedPresetIDByDeviceUID.values.contains(id) {
+            pinnedPresetIDByDeviceUID = pinnedPresetIDByDeviceUID.filter { $0.value != id }
+            persistDevicePins()
         }
     }
 
@@ -124,6 +153,10 @@ final class PresetStore {
            let ids = try? JSONDecoder().decode([UUID].self, from: data) {
             hiddenBuiltInPresetIDs = ids
         }
+        if let data = UserDefaults.standard.data(forKey: Self.devicePinsKey),
+           let pins = try? JSONDecoder().decode([String: UUID].self, from: data) {
+            pinnedPresetIDByDeviceUID = pins
+        }
     }
 
     private func persist() {
@@ -141,6 +174,12 @@ final class PresetStore {
     private func persistHiddenBuiltIns() {
         if let data = try? JSONEncoder().encode(hiddenBuiltInPresetIDs) {
             UserDefaults.standard.set(data, forKey: Self.hiddenBuiltInsKey)
+        }
+    }
+
+    private func persistDevicePins() {
+        if let data = try? JSONEncoder().encode(pinnedPresetIDByDeviceUID) {
+            UserDefaults.standard.set(data, forKey: Self.devicePinsKey)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Pin a preset to an output device — from the EQ window toolbar or the menu bar — and it's recalled automatically whenever that device becomes the active output, including at app launch (#79)
- Renamed the existing favorite-preset feature from "pin" to "favorite" (star icon) to avoid confusion with the new device pin
- The in-app EQ window's preset picker now shares the exact same native `NSMenu`-based implementation as the menu bar dropdown (`PresetMenuBuilder`/`PresetPickerButton`), so both surfaces render and behave identically — Favorites/Built-in/Custom sections, hover highlighting, ⌥-click-to-favorite without closing the menu
- Toggling a device pin or a favorite is now a plain click/⌥-click instead of requiring extra modifiers to distinguish pin from unpin
- The EQ window's output-device label now shows the device's pinned preset name, if any
- Fixed a custom-menu-row layout bug (`autoresizingMask` wasn't set, so rows never stretched to the menu's real width) and an indentation mismatch between the Favorites section and Built-in/Custom sections
- Bumped to 0.40.0, updated CHANGELOG.md and README.md

## Test plan
- [x] `swift build` — clean
- [x] `bash install.sh` + launch verification — app starts
- [x] Manually verified in the running app: menu bar dropdown (Favorites header, star icons, full-width rows, device-pin item with pin/unpin/re-pin wording) and the in-app EQ window's preset picker (same layout, consistent left margin across all sections)
- [x] Device pin persists across relaunch and recalls on device switch (via `AudioEngine.handleDeviceChange`)

Fixes #79