### PR TITLE
fix: pick up newly-launched apps' audio into the process tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.40.1] - 2026-07-12
+
+### Fixed
+- App launched after iQualize (e.g. Discord) had no audio output until iQualize was quit (#87). The global process tap doesn't reliably pick up processes that start after it, so iQualize now polls for newly-appeared Core Audio processes every 2s while running and restarts the tap when one shows up, so late-launching apps get captured without needing a manual device switch or restart
+
 ## [0.40.0] - 2026-07-12
 
 ### Added

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -101,6 +101,8 @@ final class AudioEngine {
 
     @ObservationIgnored
     nonisolated(unsafe) private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
+    private var knownProcessObjectIDs: Set<AudioObjectID> = []
+    private var processListPollWorkItem: DispatchWorkItem?
     var onStateChange: (() -> Void)?
     /// Resolves a pinned preset for a device UID, if any. Wired by the caller that owns
     /// both AudioEngine and PresetStore — kept as a closure so AudioEngine stays decoupled
@@ -170,6 +172,7 @@ final class AudioEngine {
             outputDeviceName = "Unknown"
         }
         installDeviceChangeListener()
+        knownProcessObjectIDs = (try? getProcessObjectList()).map(Set.init) ?? []
     }
 
     deinit {
@@ -431,11 +434,17 @@ final class AudioEngine {
         )
 
         isRunning = true
+        knownProcessObjectIDs = (try? getProcessObjectList()).map(Set.init) ?? knownProcessObjectIDs
+        if processListPollWorkItem == nil {
+            scheduleProcessListPoll()
+        }
     }
 
     func stop() {
         guard isRunning else { return }
         isRunning = false
+        processListPollWorkItem?.cancel()
+        processListPollWorkItem = nil
 
         rtRingBuffer = nil
         ringBuffer = nil
@@ -592,17 +601,63 @@ final class AudioEngine {
             }
         }
 
-        if isRunning {
-            isRestarting = true
-            stop()
-            do {
-                try start()
-            } catch {
-                self.error = error.localizedDescription
-            }
-            isRestarting = false
-        }
-
+        restartTap()
         onStateChange?()
+    }
+
+    /// Stops and restarts the tap/aggregate device in place, guarded against reentrancy
+    /// from listener callbacks the restart itself can trigger (tearing down the aggregate
+    /// device fires a default-output-device notification).
+    private func restartTap() {
+        guard isRunning, !isRestarting else { return }
+        isRestarting = true
+        stop()
+        do {
+            try start()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isRestarting = false
+    }
+
+    // MARK: - New-process tap coverage
+    //
+    // The global process tap is supposed to dynamically pick up processes that start
+    // after it was created, but in practice a newly-launched app can end up muted
+    // without its audio actually flowing through the tap — i.e. silently dropped
+    // (see #87, e.g. Discord launched while iQualize is running). Restarting the tap
+    // once a new Core Audio process appears reliably picks it up (confirmed: manually
+    // switching output devices, which restarts the tap as a side effect, fixes Discord's
+    // audio without quitting iQualize).
+    //
+    // kAudioHardwarePropertyProcessObjectList is *supposed* to notify listeners of this,
+    // but verified experimentally that it goes silent for a process that itself holds an
+    // active CATap — the exact situation we're in. So instead of listening, poll the
+    // process list on an interval while running and restart the tap when it grows.
+    // Processes disappearing (e.g. quitting an app) never needs a tap restart.
+
+    private static let processListPollInterval: TimeInterval = 2.0
+
+    private func scheduleProcessListPoll() {
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.pollProcessList()
+        }
+        processListPollWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.processListPollInterval, execute: workItem)
+    }
+
+    private func pollProcessList() {
+        guard isRunning else { return }
+        let current = (try? getProcessObjectList()).map(Set.init) ?? knownProcessObjectIDs
+        let grew = !current.subtracting(knownProcessObjectIDs).isEmpty
+        knownProcessObjectIDs = current
+        if grew {
+            // restartTap() calls stop() then start(), and start() already reschedules
+            // the next poll cycle — scheduling again here would run two poll loops.
+            restartTap()
+            onStateChange?()
+            return
+        }
+        scheduleProcessListPoll()
     }
 }

--- a/Sources/iQualize/CoreAudioHelpers.swift
+++ b/Sources/iQualize/CoreAudioHelpers.swift
@@ -38,6 +38,31 @@ func getDeviceUID(_ deviceID: AudioDeviceID) throws -> String {
     return uid as String
 }
 
+/// All Core Audio process objects currently known to the HAL (one per process with an
+/// open audio client) — used to detect newly-launched apps that need to be captured by
+/// an already-running global process tap.
+func getProcessObjectList() throws -> [AudioObjectID] {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyProcessObjectList,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let systemObject = AudioObjectID(kAudioObjectSystemObject)
+    var size: UInt32 = 0
+    try caCheck(
+        AudioObjectGetPropertyDataSize(systemObject, &address, 0, nil, &size),
+        "Failed to get process object list size"
+    )
+    let count = Int(size) / MemoryLayout<AudioObjectID>.size
+    guard count > 0 else { return [] }
+    var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+    try caCheck(
+        AudioObjectGetPropertyData(systemObject, &address, 0, nil, &size, &ids),
+        "Failed to get process object list"
+    )
+    return ids
+}
+
 func getDeviceName(_ deviceID: AudioDeviceID) throws -> String {
     var address = AudioObjectPropertyAddress(
         mSelector: kAudioObjectPropertyName,

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.40.0</string>
+	<string>0.40.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.40.0</string>
+	<string>0.40.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Apps launched while iQualize is already running (e.g. Discord) got no audio output — the global process tap doesn't reliably start routing audio from a process that appears after the tap was created, even though Apple's docs suggest it should
- Tried the issue's own candidate fix first (listen for `kAudioHardwarePropertyProcessObjectList` changes), but verified experimentally that this notification goes silent for a process that itself holds an active `CATap` — confirmed via a standalone test program with no tap, where the same listener code fires reliably for both `afplay` and launching Discord
- Switched to polling the process list every 2s while running, restarting the tap when it grows (new process appeared) — never on processes disappearing
- Bumped to 0.40.1, updated CHANGELOG.md

## Test plan
- [x] `swift build` — clean
- [x] `bash install.sh` + launch verification — app starts
- [x] Real A/B test with the reporter (@dariuscorvus): pre-fix build reproduced the Discord-silence bug reliably across multiple repro attempts; the polling-based fix build resolved it within ~2s of Discord launching, with no manual device switch or iQualize restart needed, repeated successfully twice

Fixes #87