### PR TITLE
Fix native footer slider behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.41.1] - 2026-07-14
+
+### Fixed
+- Stereo balance once again snaps to center near zero and resets to center on double-click. Both behaviors were lost in the DreamUI rewrite (#99)
+- In, Out, and Balance now use the same native macOS slider control. Track clicks animate to the target value over `100 ms`, and all three reset to center on double-click
+
 ## [0.41.0] - 2026-07-13
 
 ### Added

--- a/Sources/iQualize/DreamUI/DreamControls.swift
+++ b/Sources/iQualize/DreamUI/DreamControls.swift
@@ -168,14 +168,160 @@ struct DreamSlider: View {
     let range: ClosedRange<Double>
     let step: Double
     var width: CGFloat = 90
-
-    @Environment(\.dreamTheme) private var theme
+    var onDoubleClick: (() -> Void)? = nil
 
     var body: some View {
-        Slider(value: $value, in: range, step: step)
-            .controlSize(.mini)
-            .tint(theme.accent)
-            .frame(width: width)
+        NativeDreamSlider(
+            value: $value,
+            range: range,
+            step: step,
+            onDoubleClick: onDoubleClick
+        )
+        .frame(width: width)
+    }
+}
+
+private struct NativeDreamSlider: NSViewRepresentable {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+    let onDoubleClick: (() -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSSlider {
+        let slider = AnimatedTrackClickSlider(
+            value: value,
+            minValue: range.lowerBound,
+            maxValue: range.upperBound,
+            target: context.coordinator,
+            action: #selector(Coordinator.valueChanged(_:))
+        )
+        slider.isContinuous = true
+        slider.controlSize = .mini
+
+        if onDoubleClick != nil {
+            let doubleClick = NSClickGestureRecognizer(
+                target: context.coordinator,
+                action: #selector(Coordinator.doubleClicked(_:))
+            )
+            doubleClick.numberOfClicksRequired = 2
+            slider.addGestureRecognizer(doubleClick)
+        }
+
+        return slider
+    }
+
+    func updateNSView(_ slider: NSSlider, context: Context) {
+        context.coordinator.parent = self
+        slider.minValue = range.lowerBound
+        slider.maxValue = range.upperBound
+        if slider.doubleValue != value {
+            slider.doubleValue = value
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var parent: NativeDreamSlider
+
+        init(parent: NativeDreamSlider) {
+            self.parent = parent
+        }
+
+        @objc func valueChanged(_ slider: NSSlider) {
+            let offset = slider.doubleValue - parent.range.lowerBound
+            let stepped = parent.range.lowerBound + (offset / parent.step).rounded() * parent.step
+            let value = min(max(stepped, parent.range.lowerBound), parent.range.upperBound)
+            slider.doubleValue = value
+            parent.value = value
+        }
+
+        @objc func doubleClicked(_ recognizer: NSClickGestureRecognizer) {
+            parent.onDoubleClick?()
+            (recognizer.view as? NSSlider)?.doubleValue = parent.value
+        }
+    }
+}
+
+private final class AnimatedTrackClickSlider: NSSlider {
+    private static let trackClickDuration: TimeInterval = 0.1
+    private static let frameInterval: TimeInterval = 1.0 / 120.0
+
+    private var animationTimer: Timer?
+    private var animationStartTime: TimeInterval = 0
+    private var animationStartValue: Double = 0
+    private var animationTargetValue: Double = 0
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount == 1,
+           let sliderCell = cell as? NSSliderCell,
+           !sliderCell.isVertical {
+            let location = convert(event.locationInWindow, from: nil)
+            let knobRect = sliderCell.knobRect(flipped: isFlipped)
+
+            if !knobRect.contains(location) {
+                let trackRect = sliderCell.trackRect
+                let halfKnob = sliderCell.knobThickness / 2
+                let usableMinX = trackRect.minX + halfKnob
+                let usableMaxX = trackRect.maxX - halfKnob
+                let usableWidth = usableMaxX - usableMinX
+
+                if usableWidth > 0 {
+                    let fraction = min(max((location.x - usableMinX) / usableWidth, 0), 1)
+                    animateTrackClick(to: minValue + fraction * (maxValue - minValue))
+                    return
+                }
+            }
+        }
+
+        cancelTrackClickAnimation()
+        super.mouseDown(with: event)
+    }
+
+    private func animateTrackClick(to targetValue: Double) {
+        cancelTrackClickAnimation()
+
+        animationStartTime = ProcessInfo.processInfo.systemUptime
+        animationStartValue = doubleValue
+        animationTargetValue = targetValue
+
+        let timer = Timer(
+            timeInterval: Self.frameInterval,
+            target: self,
+            selector: #selector(advanceTrackClickAnimation(_:)),
+            userInfo: nil,
+            repeats: true
+        )
+        animationTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+        advanceTrackClickAnimation(timer)
+    }
+
+    @objc private func advanceTrackClickAnimation(_ timer: Timer) {
+        guard timer === animationTimer else {
+            timer.invalidate()
+            return
+        }
+
+        let elapsed = ProcessInfo.processInfo.systemUptime - animationStartTime
+        let progress = min(elapsed / Self.trackClickDuration, 1)
+        let easedProgress = progress * progress * (3 - 2 * progress)
+
+        doubleValue = animationStartValue
+            + (animationTargetValue - animationStartValue) * easedProgress
+        sendAction(action, to: target)
+
+        if progress >= 1 {
+            cancelTrackClickAnimation()
+        }
+    }
+
+    private func cancelTrackClickAnimation() {
+        animationTimer?.invalidate()
+        animationTimer = nil
     }
 }
 

--- a/Sources/iQualize/DreamUI/DreamFooter.swift
+++ b/Sources/iQualize/DreamUI/DreamFooter.swift
@@ -110,7 +110,12 @@ struct DreamFooter: View {
                     set: { value.wrappedValue = Float($0); onChange() }
                 ),
                 range: -24...24,
-                step: 0.5
+                step: 0.5,
+                onDoubleClick: {
+                    guard value.wrappedValue != 0 else { return }
+                    value.wrappedValue = 0
+                    onChange()
+                }
             )
             Text(formatSigned(value.wrappedValue))
                 .font(.system(size: 11, design: .monospaced))
@@ -133,11 +138,12 @@ struct DreamFooter: View {
             DreamSlider(
                 value: Binding(
                     get: { Double(vm.balance) },
-                    set: { vm.balance = Float($0); vm.applyBalance() }
+                    set: { setBalance(Float($0)) }
                 ),
                 range: -1...1,
                 step: 0.05,
-                width: 70
+                width: 70,
+                onDoubleClick: { setBalance(0) }
             )
             Text(formatBalance(vm.balance))
                 .font(.system(size: 11, design: .monospaced))
@@ -219,5 +225,10 @@ struct DreamFooter: View {
         if abs(v) < 0.01 { return "0" }
         let pct = Int(round(abs(v) * 100))
         return v < 0 ? "L\(pct)" : "R\(pct)"
+    }
+
+    private func setBalance(_ value: Float) {
+        vm.balance = abs(value) <= 0.05 ? 0 : value
+        vm.applyBalance()
     }
 }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.41.0</string>
+	<string>0.41.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.41.0</string>
+	<string>0.41.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary

The DreamUI rewrite replaced the original AppKit sliders and dropped balance snap-to-center and double-click reset. A SwiftUI gesture around `Slider` was not reliable because the underlying native control consumed the pointer sequence.

Restore all three footer controls as native macOS sliders. Balance snaps to center at `±0.05`. In, Out, and Balance reset to center on double-click. Track clicks use a repeatable `100 ms` interpolation instead of AppKit’s slower one-off animation.

## Scope

- Replace the footer’s SwiftUI slider wrapper with an `NSSlider`-backed implementation.
- Preserve the existing ranges, steps, bindings, gain persistence, and thumb dragging.
- Add cancellable track-click interpolation that restarts from the current value.
- Bump the version from `0.41.0` to `0.41.1` and update the changelog.

Fixes #99

## Test plan

- [x] `swift build`
- [x] Build and install with `install.sh`
- [x] Verify the installed app launches with `pgrep`
- [x] Verify Balance snaps from `R5` to `0`
- [x] Verify Balance resets from a non-zero value on double-click
- [x] Verify Out resets from `-18 dB` to `0 dB` on double-click, then restore `-18 dB`
- [x] Verify a Balance track click reaches the selected target through the custom animation path
- [x] Verify slider values persist across relaunch
- [x] `git diff --check`
- [x] `plutil -lint Sources/iQualize/Info.plist`