### PR TITLE
feat: scroll to adjust In, Out, and Balance sliders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to iQualize will be documented in this file.
 ## [0.42.0] - 2026-07-14
 
 ### Added
-- Scroll over the In, Out, and Balance sliders to nudge them by one step. Precise trackpad scrolls accumulate sub-step deltas so slow gestures still register, and holding Shift halves the step for fine adjustments
+- Scroll over the In, Out, and Balance sliders to nudge them by one step. Precise trackpad scrolls accumulate sub-step deltas so slow gestures still register, and holding Shift scrolls in fine increments (0.1 dB for In/Out, 0.01 for Balance)
 
 ## [0.41.1] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.42.0] - 2026-07-14
+
+### Added
+- Scroll over the In, Out, and Balance sliders to nudge them by one step. Precise trackpad scrolls accumulate sub-step deltas so slow gestures still register, and holding Shift halves the step for fine adjustments
+
 ## [0.41.1] - 2026-07-14
 
 ### Fixed

--- a/Sources/iQualize/DreamUI/DreamControls.swift
+++ b/Sources/iQualize/DreamUI/DreamControls.swift
@@ -167,6 +167,8 @@ struct DreamSlider: View {
     @Binding var value: Double
     let range: ClosedRange<Double>
     let step: Double
+    /// Step used while scrolling with Shift held. `0` disables fine scrolling.
+    var fineStep: Double = 0
     var width: CGFloat = 90
     var onDoubleClick: (() -> Void)? = nil
 
@@ -175,6 +177,7 @@ struct DreamSlider: View {
             value: $value,
             range: range,
             step: step,
+            fineStep: fineStep,
             onDoubleClick: onDoubleClick
         )
         .frame(width: width)
@@ -185,6 +188,7 @@ private struct NativeDreamSlider: NSViewRepresentable {
     @Binding var value: Double
     let range: ClosedRange<Double>
     let step: Double
+    let fineStep: Double
     let onDoubleClick: (() -> Void)?
 
     func makeCoordinator() -> Coordinator {
@@ -202,6 +206,12 @@ private struct NativeDreamSlider: NSViewRepresentable {
         slider.isContinuous = true
         slider.controlSize = .mini
         slider.scrollStep = step
+        slider.fineScrollStep = fineStep
+        // Scroll writes the value straight to the binding, bypassing the
+        // step-snapping in `valueChanged` so fine (Shift) increments survive.
+        slider.onScroll = { [weak coordinator = context.coordinator] newValue in
+            coordinator?.parent.value = newValue
+        }
 
         if onDoubleClick != nil {
             let doubleClick = NSClickGestureRecognizer(
@@ -257,6 +267,8 @@ private final class AnimatedTrackClickSlider: NSSlider {
     private var animationTargetValue: Double = 0
     private var scrollRemainder: Double = 0
     var scrollStep: Double = 1
+    var fineScrollStep: Double = 0
+    var onScroll: ((Double) -> Void)?
 
     override func mouseDown(with event: NSEvent) {
         if event.clickCount == 1,
@@ -292,7 +304,8 @@ private final class AnimatedTrackClickSlider: NSSlider {
 
         let direction = delta > 0 ? 1.0 : -1.0
         let precision = event.hasPreciseScrollingDeltas ? abs(delta) : 1.0
-        let stepScale = event.modifierFlags.contains(.shift) ? 0.5 : 1.0
+        let fine = fineScrollStep > 0 && event.modifierFlags.contains(.shift)
+        let stepSize = fine ? fineScrollStep : scrollStep
 
         scrollRemainder += direction * precision
 
@@ -301,7 +314,7 @@ private final class AnimatedTrackClickSlider: NSSlider {
 
         scrollRemainder -= Double(wholeSteps) * (scrollRemainder > 0 ? 1 : -1)
 
-        let proposedValue = doubleValue + Double(wholeSteps) * scrollStep * stepScale * direction
+        let proposedValue = doubleValue + Double(wholeSteps) * stepSize * direction
         let newValue = min(max(proposedValue, minValue), maxValue)
         guard newValue != doubleValue else {
             scrollRemainder = 0
@@ -309,7 +322,7 @@ private final class AnimatedTrackClickSlider: NSSlider {
         }
 
         doubleValue = newValue
-        sendAction(action, to: target)
+        onScroll?(newValue)
     }
 
     private func animateTrackClick(to targetValue: Double) {

--- a/Sources/iQualize/DreamUI/DreamControls.swift
+++ b/Sources/iQualize/DreamUI/DreamControls.swift
@@ -201,6 +201,7 @@ private struct NativeDreamSlider: NSViewRepresentable {
         )
         slider.isContinuous = true
         slider.controlSize = .mini
+        slider.scrollStep = step
 
         if onDoubleClick != nil {
             let doubleClick = NSClickGestureRecognizer(
@@ -254,6 +255,8 @@ private final class AnimatedTrackClickSlider: NSSlider {
     private var animationStartTime: TimeInterval = 0
     private var animationStartValue: Double = 0
     private var animationTargetValue: Double = 0
+    private var scrollRemainder: Double = 0
+    var scrollStep: Double = 1
 
     override func mouseDown(with event: NSEvent) {
         if event.clickCount == 1,
@@ -279,6 +282,34 @@ private final class AnimatedTrackClickSlider: NSSlider {
 
         cancelTrackClickAnimation()
         super.mouseDown(with: event)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        let delta = event.scrollingDeltaY != 0 ? event.scrollingDeltaY : -event.scrollingDeltaX
+        guard delta != 0 else { return }
+
+        cancelTrackClickAnimation()
+
+        let direction = delta > 0 ? 1.0 : -1.0
+        let precision = event.hasPreciseScrollingDeltas ? abs(delta) : 1.0
+        let stepScale = event.modifierFlags.contains(.shift) ? 0.5 : 1.0
+
+        scrollRemainder += direction * precision
+
+        let wholeSteps = Int(floor(scrollRemainder.magnitude))
+        guard wholeSteps > 0 else { return }
+
+        scrollRemainder -= Double(wholeSteps) * (scrollRemainder > 0 ? 1 : -1)
+
+        let proposedValue = doubleValue + Double(wholeSteps) * scrollStep * stepScale * direction
+        let newValue = min(max(proposedValue, minValue), maxValue)
+        guard newValue != doubleValue else {
+            scrollRemainder = 0
+            return
+        }
+
+        doubleValue = newValue
+        sendAction(action, to: target)
     }
 
     private func animateTrackClick(to targetValue: Double) {

--- a/Sources/iQualize/DreamUI/DreamFooter.swift
+++ b/Sources/iQualize/DreamUI/DreamFooter.swift
@@ -111,6 +111,7 @@ struct DreamFooter: View {
                 ),
                 range: -24...24,
                 step: 0.5,
+                fineStep: 0.1,
                 onDoubleClick: {
                     guard value.wrappedValue != 0 else { return }
                     value.wrappedValue = 0
@@ -142,6 +143,7 @@ struct DreamFooter: View {
                 ),
                 range: -1...1,
                 step: 0.05,
+                fineStep: 0.01,
                 width: 70,
                 onDoubleClick: { setBalance(0) }
             )

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.41.1</string>
+	<string>0.42.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.41.1</string>
+	<string>0.42.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary

The DreamUI In, Out, and Balance sliders only responded to clicks and drags. This adds scroll-wheel support — scrolling over a slider nudges its value by one step, matching how most native macOS controls behave. Holding Shift scrolls in fine increments.

## Scope

- `NativeDreamSlider` passes its `step` and a Shift `fineStep` through to the underlying `AnimatedTrackClickSlider`.
- `AnimatedTrackClickSlider.scrollWheel(with:)` handles the gesture:
  - Uses `scrollingDeltaY`, falling back to `-scrollingDeltaX`, so both vertical and horizontal scrolls work.
  - Precise trackpad deltas accumulate in a per-slider `scrollRemainder` so slow gestures still register whole steps instead of being rounded to zero.
  - Holding Shift switches to `fineScrollStep` — 0.1 dB for In/Out, 0.01 for Balance.
  - Cancels any in-flight track-click animation so scrolling takes over immediately.
  - Clamps to `[minValue, maxValue]` and only fires when the value actually changes.
- Scroll writes the value straight to the binding via an `onScroll` closure, bypassing the step-snapping in `valueChanged`. Without this the fine (and any sub-step) increment gets rounded back to the coarse step. Drag and track-click still snap to the coarse step. This matches how the EQ bands already scroll.
- Version bumped `0.41.1` → `0.42.0` and `CHANGELOG.md` updated.

## Test plan

- [x] `swift build` succeeds
- [x] Scroll over In/Out/Balance sliders moves them by one step per notch
- [x] Shift-scroll moves in fine increments (0.1 dB In/Out, 0.01 Balance)
- [x] Precise trackpad slow-scroll accumulates and eventually steps
- [x] Values clamp at min/max
- [x] Double-click still resets to default