### PR TITLE
fix: rebuild OPRA preset browser as a fixed two-pane layout (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.42.0] - 2026-07-15
+
+### Changed
+- Reorganized the Preset Browser's sidebar: search field pinned at the top, the scrolling catalog list in the middle, and the OPRA/iQualize catalog picker moved to the bottom of the sidebar. Search now filters whichever catalog is active. The sidebar is a fixed-width column that can't be collapsed or dragged shut
+
+### Fixed
+- In the Preset Browser's OPRA tab, the headphone list scrolled straight through the sidebar search box, overwriting it (#108). The search field is now a fixed sibling above the list instead of a transparent overlay inside it, so the rows can no longer draw through it
+
 ## [0.41.1] - 2026-07-14
 
 ### Fixed

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -1,7 +1,15 @@
 import SwiftUI
 
-/// Top-level Preset Browser container: a catalog picker switching between OPRA's community
-/// database and iQualize's own built-in presets the user has hidden from their picker.
+/// Top-level Preset Browser: a `NavigationSplitView` whose sidebar stacks a search field on
+/// top, the scrolling catalog list in the middle, and the OPRA/iQualize catalog picker pinned
+/// at the bottom. The picker switches between OPRA's community database and iQualize's own
+/// built-in presets the user has hidden from their picker. The detail pane shows the selected
+/// OPRA product's community EQ curves.
+///
+/// The search field is a plain `VStack` sibling above the `List`, not `.searchable`. A
+/// `.searchable(placement: .sidebar)` field renders as a transparent overlay inside the
+/// scrolling list and the rows draw straight through it (issue #108); a fixed sibling can't be
+/// overlapped.
 @available(macOS 14.2, *)
 struct PresetBrowserView: View {
     let presetStore: PresetStore
@@ -14,31 +22,7 @@ struct PresetBrowserView: View {
 
     @State private var catalog: Catalog = .opra
 
-    var body: some View {
-        VStack(spacing: 0) {
-            Picker("Catalog", selection: $catalog) {
-                ForEach(Catalog.allCases, id: \.self) { Text($0.rawValue).tag($0) }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(8)
-            Divider()
-            switch catalog {
-            case .opra:
-                OPRACatalogBrowserView(onImport: onImportOPRA)
-            case .iqualize:
-                IQualizeCatalogView(presetStore: presetStore)
-            }
-        }
-    }
-}
-
-/// Search-and-import UI for OPRA's community headphone EQ database. Sidebar lists matching
-/// products; selecting one shows its available community EQ curves in the detail pane.
-@available(macOS 14.2, *)
-struct OPRACatalogBrowserView: View {
-    let onImport: (OPRAProductEntry, OPRACurveEntry) -> Void
-
+    // OPRA catalog state.
     @State private var products: [OPRAProductEntry] = []
     @State private var searchText = ""
     @State private var selectedProductID: String?
@@ -53,18 +37,78 @@ struct OPRACatalogBrowserView: View {
         }
     }
 
+    private var filteredHiddenPresets: [EQPresetData] {
+        let hidden = presetStore.hiddenBuiltInPresets
+        guard !searchText.isEmpty else { return hidden }
+        return hidden.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
     var body: some View {
-        NavigationSplitView {
-            sidebar
-                .navigationSplitViewColumnWidth(min: 240, ideal: 280)
-        } detail: {
+        // A fixed two-pane HStack rather than a NavigationSplitView. The split view's divider
+        // stays user-draggable even with the toggle removed and `columnVisibility` pinned, so
+        // the sidebar could be dragged shut. A fixed-width sidebar has no draggable divider and
+        // can't collapse. Selection is driven by `selectedProductID`, so we don't need the
+        // split view's navigation behavior.
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                searchField
+                Divider()
+                sidebarList
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                Divider()
+                Picker("Catalog", selection: $catalog) {
+                    ForEach(Catalog.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .padding(8)
+            }
+            .frame(width: 280)
+            Divider()
             detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task { await load() }
     }
 
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search", text: $searchText)
+                .textFieldStyle(.plain)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.background)
+    }
+
+    // MARK: - Sidebar list
+
     @ViewBuilder
-    private var sidebar: some View {
+    private var sidebarList: some View {
+        switch catalog {
+        case .opra:
+            opraSidebar
+        case .iqualize:
+            iqualizeSidebar
+        }
+    }
+
+    @ViewBuilder
+    private var opraSidebar: some View {
         switch loadState {
         case .loading:
             ProgressView("Loading OPRA database…")
@@ -83,7 +127,29 @@ struct OPRACatalogBrowserView: View {
                 productRow(product).tag(product.id)
             }
             .listStyle(.sidebar)
-            .searchable(text: $searchText, placement: .sidebar, prompt: "Search headphones…")
+        }
+    }
+
+    @ViewBuilder
+    private var iqualizeSidebar: some View {
+        let hidden = filteredHiddenPresets
+        if hidden.isEmpty {
+            Text(searchText.isEmpty
+                 ? "All built-in presets are already in your list"
+                 : "No matching presets")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(hidden) { preset in
+                HStack {
+                    Text(preset.name)
+                    Spacer()
+                    Button("Restore") { presetStore.restoreBuiltInPreset(id: preset.id) }
+                }
+            }
+            .listStyle(.sidebar)
         }
     }
 
@@ -119,28 +185,48 @@ struct OPRACatalogBrowserView: View {
         .frame(width: 32, height: 24)
     }
 
+    // MARK: - Detail
+
     @ViewBuilder
     private var detail: some View {
-        if let selectedProductID, let product = products.first(where: { $0.id == selectedProductID }) {
-            List(product.curves) { curve in
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(curve.author).font(.body)
-                        if let details = curve.details {
-                            Text(details).font(.caption).foregroundStyle(.secondary)
+        switch catalog {
+        case .opra:
+            if let selectedProductID, let product = products.first(where: { $0.id == selectedProductID }) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("\(product.vendorName) \(product.productName)")
+                        .font(.headline)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                    Divider()
+                    List(product.curves) { curve in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(curve.author).font(.body)
+                                if let details = curve.details {
+                                    Text(details).font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Button("Import") { onImportOPRA(product, curve) }
                         }
                     }
-                    Spacer()
-                    Button("Import") { onImport(product, curve) }
                 }
+            } else {
+                placeholder("Select a headphone to see available EQ profiles")
             }
-            .navigationTitle("\(product.vendorName) \(product.productName)")
-        } else {
-            Text("Select a headphone to see available EQ profiles")
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .iqualize:
+            placeholder("Restore a built-in preset to add it back to your picker")
         }
     }
+
+    private func placeholder(_ text: String) -> some View {
+        Text(text)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Loading
 
     private func load() async {
         loadState = .loading
@@ -149,31 +235,6 @@ struct OPRACatalogBrowserView: View {
             loadState = .loaded
         } catch {
             loadState = .failed(error.localizedDescription)
-        }
-    }
-}
-
-/// Lists built-in presets the user has deleted from their picker, with a one-click way to
-/// bring each back. Unlike an OPRA import, restoring doesn't switch the active EQ curve —
-/// it just makes the preset selectable again from the normal preset picker.
-@available(macOS 14.2, *)
-struct IQualizeCatalogView: View {
-    let presetStore: PresetStore
-
-    var body: some View {
-        let hidden = presetStore.hiddenBuiltInPresets
-        if hidden.isEmpty {
-            Text("All built-in presets are already in your list")
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            List(hidden) { preset in
-                HStack {
-                    Text(preset.name)
-                    Spacer()
-                    Button("Restore") { presetStore.restoreBuiltInPreset(id: preset.id) }
-                }
-            }
         }
     }
 }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.41.2</string>
+	<string>0.42.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.41.2</string>
+	<string>0.42</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.41.1</string>
+	<string>0.41.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.41.1</string>
+	<string>0.41.2</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/PresetBrowserWindowController.swift
+++ b/Sources/iQualize/PresetBrowserWindowController.swift
@@ -15,25 +15,25 @@ final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate 
             backing: .buffered, defer: true
         )
         window.title = "Preset Browser"
-        window.minSize = NSSize(width: 480, height: 360)
+        window.minSize = NSSize(width: 520, height: 400)
         window.center()
         window.isReleasedWhenClosed = false
 
         super.init(window: window)
         window.delegate = self
 
-        // Host the SwiftUI content as the window's `contentViewController` (via
-        // `NSHostingController`) rather than a bare `NSHostingView` subview. This gives the
-        // `NavigationSplitView` a real window scene, so its sidebar `.searchable` field pins
-        // to a native, opaque toolbar area instead of floating over the scrolling headphone
-        // list (issue #108). `sceneBridgingOptions` lets SwiftUI own the window's toolbar and
-        // title; `.unified` merges that toolbar into the titlebar.
-        let hosting = NSHostingController(
-            rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA)
-        )
-        hosting.sceneBridgingOptions = [.title, .toolbars]
-        window.contentViewController = hosting
-        window.toolbarStyle = .unified
+        let host = NSHostingView(rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA))
+        host.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(host)
+        NSLayoutConstraint.activate([
+            host.topAnchor.constraint(equalTo: container.topAnchor),
+            host.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            host.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+        window.contentView = container
     }
 
     @available(*, unavailable)

--- a/Sources/iQualize/PresetBrowserWindowController.swift
+++ b/Sources/iQualize/PresetBrowserWindowController.swift
@@ -22,18 +22,18 @@ final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate 
         super.init(window: window)
         window.delegate = self
 
-        let host = NSHostingView(rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA))
-        host.translatesAutoresizingMaskIntoConstraints = false
-
-        let container = NSView()
-        container.addSubview(host)
-        NSLayoutConstraint.activate([
-            host.topAnchor.constraint(equalTo: container.topAnchor),
-            host.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            host.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            host.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-        ])
-        window.contentView = container
+        // Host the SwiftUI content as the window's `contentViewController` (via
+        // `NSHostingController`) rather than a bare `NSHostingView` subview. This gives the
+        // `NavigationSplitView` a real window scene, so its sidebar `.searchable` field pins
+        // to a native, opaque toolbar area instead of floating over the scrolling headphone
+        // list (issue #108). `sceneBridgingOptions` lets SwiftUI own the window's toolbar and
+        // title; `.unified` merges that toolbar into the titlebar.
+        let hosting = NSHostingController(
+            rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA)
+        )
+        hosting.sceneBridgingOptions = [.title, .toolbars]
+        window.contentViewController = hosting
+        window.toolbarStyle = .unified
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
Fixes #108

## Summary
In the Preset Browser's OPRA tab, the sidebar search box got overwritten by the headphone list while scrolling — rows drew straight through the search field.

Root cause: `.searchable(placement: .sidebar)` renders the search field as a transparent overlay *inside* the scrolling `List`, with no opaque backing and no reserved layout space, so the rows bled through it.

The first attempt (81e4d98) moved search into the window's native toolbar via `sceneBridgingOptions`. Driving the real UI showed that didn't fully hold, and it introduced its own problems (toolbar overflow chevron, a collapsible sidebar that could be dragged shut to a dead end). So this PR rebuilds the browser layout instead.

## Scope
- `PresetBrowserView.swift` — replaced `NavigationSplitView` with a fixed `HStack`: a 280pt sidebar (search on top, scrolling catalog list in the middle, OPRA/iQualize picker at the bottom) and a plain, non-draggable divider to the detail pane.
  - Search is a fixed sibling above the list, not `.searchable`, so nothing overlays it.
  - The sidebar is a fixed-width column — it can't be collapsed or dragged shut. `NavigationSplitView` kept its divider draggable even with the toggle removed and `columnVisibility` pinned.
  - Search filters whichever catalog is active. Selecting a headphone still populates the detail via `selectedProductID`; the detail's old `navigationTitle` became an in-pane header.
- `PresetBrowserWindowController.swift` — reverted to the plain `NSHostingView` hosting (pre-#110); the toolbar/scene-bridging is gone now that search isn't in the toolbar. Min window size 520x400.
- Version `0.41.2 -> 0.42.0` (UI change) + CHANGELOG.

## Test plan
Built, installed, and driven end-to-end in the real app (menu bar → Open iQualize → Preset Browser → OPRA):
- [x] `swift build` clean; installs and launches (`OK: app running`)
- [x] Type "Sennheiser" → list filters; scroll the filtered list → search field stays pinned and opaque, no rows bleed through (the #108 repro)
- [x] Drag the sidebar/detail boundary left → sidebar stays fixed, doesn't collapse
- [x] Shrink the window to its minimum → search, list, and tabs all stay visible
- [x] Switch to the iQualize tab → list and prompt update, tabs stay pinned at the bottom
- [x] Select a headphone → detail shows the product header, its curves, and Import