### PR TITLE
fix: hide deleted built-in presets from the in-app picker (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.42.1] - 2026-07-15
+
+### Fixed
+- Deleting a built-in preset left it in the in-app picker, where it still showed but could no longer be selected (#109). The in-app picker built its built-in section from the raw preset list while the menu bar filtered out hidden ones, so the two disagreed. The picker now uses the same hidden-filtered list — deleted built-ins disappear from it and are restored from the Preset Browser's iQualize tab, matching the menu bar
+
 ## [0.42.0] - 2026-07-15
 
 ### Changed

--- a/Sources/iQualize/DreamUI/PresetPickerButton.swift
+++ b/Sources/iQualize/DreamUI/PresetPickerButton.swift
@@ -46,7 +46,7 @@ struct PresetPickerButton: NSViewRepresentable {
                 onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }
             )
             PresetMenuBuilder.addPresetSections(
-                to: menu, builtIn: EQPresetData.builtInPresets, custom: vm.presetStore.customPresets,
+                to: menu, builtIn: vm.presetStore.allPresets.filter(\.isBuiltIn), custom: vm.presetStore.customPresets,
                 favoriteIDs: Set(vm.presetStore.favoritePresetIDs), activePresetID: vm.activePresetID,
                 onSelect: { [weak self] id in self?.select(id); menu.cancelTracking() },
                 onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.42.0</string>
+	<string>0.42.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.42</string>
+	<string>0.42.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary

Deleting a built-in preset left it in the in-app picker, where it still showed but could no longer be selected (#109).

The in-app preset picker built its built-in section from the raw `EQPresetData.builtInPresets`, while the menu-bar dropdown filtered out hidden built-ins via `presetStore.allPresets.filter(\.isBuiltIn)` (`MenuBarController.swift:111`). So deleting a built-in removed it from the menu bar but left it stranded in the in-app picker — visible but dead. Favorites and custom presets already filtered correctly; only that one built-in section (`PresetPickerButton.swift:49`) used the unfiltered list.

The fix uses the same hidden-filtered list in both places. Deleted built-ins now disappear from the in-app picker and are restored from the Preset Browser's iQualize tab, matching the menu bar and the existing hide/restore design.

Fixes #109.

## Scope

- `PresetPickerButton.swift:49` — build the built-in section from `vm.presetStore.allPresets.filter(\.isBuiltIn)` instead of `EQPresetData.builtInPresets`.
- Version bump `0.42.0` → `0.42.1` and CHANGELOG entry.

Graying the deleted built-ins out in the picker (the reporter's suggested alternative) was deliberately not done — it would create a second restore surface alongside the browser's iQualize tab and contradict the existing hide/restore flow.

## Test plan

- [x] `swift build` clean (pre-existing `@preconcurrency` warning only)
- [x] `install.sh` + launch — app running
- [x] Not driven end-to-end in the GUI. The change is a one-line alignment to the already-correct menu-bar code path.

Thanks to @nordicdata for the detailed report.