### PR TITLE
chore: verify DMG signature before every release

### DIFF
--- a/.claude/hooks/verify-dmg-before-release.sh
+++ b/.claude/hooks/verify-dmg-before-release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# PreToolUse(Bash) guard: block a `gh release create`/`gh release upload` that
+# attaches a .dmg unless the image passes verify-dmg.sh (valid signature, not
+# "damaged" — issue #115). Any other command is allowed through untouched.
+#
+# Reads the PreToolUse JSON on stdin; exit 0 allows, exit 2 blocks and shows the
+# reason to Claude. Detection and extraction run in python so that a mere
+# *mention* of "gh release create" inside another command's text (e.g. a PR body
+# describing this very hook) does not trigger it — the release invocation must
+# sit at a real shell-command boundary.
+input=$(cat)
+
+dmg=$(printf '%s' "$input" | /usr/bin/python3 -c '
+import sys, json, re
+
+command = json.load(sys.stdin).get("tool_input", {}).get("command", "")
+
+# Match "gh release create|upload" only at the start of a command or right after
+# a shell separator (optionally behind a `cd ... &&`), never mid-string.
+trigger = re.compile(
+    r"(?:^|[\n;&|(])\s*(?:cd\s+[^\n;&|]*?&&\s*)?gh\s+release\s+(?:create|upload)\b"
+)
+if not trigger.search(command):
+    sys.exit(0)
+
+# Pull the first .dmg argument (a bare-word path, not one buried in a quoted
+# heredoc body). Good enough: a real release names the artifact positionally.
+m = re.search(r"(?<![\"'\''`])(\S+\.dmg)\b", command)
+if m:
+    print(m.group(1))
+' 2>/dev/null) || exit 0
+
+[ -z "$dmg" ] && exit 0
+
+proj="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+case "$dmg" in
+    /*) dmg_path="$dmg" ;;
+    *)  dmg_path="$proj/$dmg" ;;
+esac
+
+if ! output=$(bash "$proj/verify-dmg.sh" "$dmg_path" 2>&1); then
+    echo "Blocked: $dmg failed pre-release verification (macOS would report it as \"damaged\")." >&2
+    echo "$output" >&2
+    echo "Rebuild with 'bash create-dmg.sh' (which now verifies) before releasing." >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-dmg-before-release.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Only do this when the user explicitly asks to cut/tag/publish a release — not 
 
 1. Bump the version and update `CHANGELOG.md` (should already be done in the merge PR, per above — backfill on `main` first if it wasn't).
 2. Tag the merge commit on `main`: `git tag vX.Y.Z <commit>` (lightweight tag, matching every existing tag in this repo) then `git push origin vX.Y.Z`.
-3. Build the installer: `bash create-dmg.sh` — builds, signs, and packages `iQualize-X.Y.Z.dmg` in the repo root.
+3. Build the installer: `bash create-dmg.sh` — builds, signs, packages, and verifies `iQualize-X.Y.Z.dmg` in the repo root. It runs `verify-dmg.sh` at the end and aborts if the app inside has a broken/invalid signature (the state macOS reports as "damaged" — issue #115). A `PreToolUse` hook (`.claude/settings.json`) also blocks `gh release create` on a DMG that fails the same check. The app is ad-hoc signed, not notarized, so downloads still need `xattr -dr com.apple.quarantine`.
 4. Publish the GitHub Release with the DMG attached: `gh release create vX.Y.Z iQualize-X.Y.Z.dmg --title "vX.Y.Z — <short description>" --notes "..."`. Look at a recent release (`gh release view vX.Y.Z-1`) for the notes format — highlights list, a link to the CHANGELOG diff, and the Gatekeeper `xattr -dr com.apple.quarantine` install instructions.
 5. Publishing a Release (step 4) is a distinct public action from tagging (step 2) — confirm with the user separately before running `gh release create`, even if they already approved the tag.
 

--- a/create-dmg.sh
+++ b/create-dmg.sh
@@ -65,5 +65,11 @@ hdiutil convert "$TMP_DMG" -format UDZO -imagekey zlib-level=9 -o "$DMG_NAME"
 rm -rf "$STAGING" "$TMP_DMG"
 
 echo ""
+echo "=== Verifying DMG ==="
+# Gate the build on a valid signature so a "damaged" DMG (issue #115) can never
+# be produced. set -e aborts create-dmg.sh if this fails.
+bash "$(dirname "$0")/verify-dmg.sh" "$DMG_NAME"
+
+echo ""
 echo "=== Done: $DMG_NAME ==="
 ls -lh "$DMG_NAME"

--- a/verify-dmg.sh
+++ b/verify-dmg.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Verify a built DMG is safe to release.
+#
+# The failure this guards against is issue #115: an app signed against a
+# certificate that isn't on the build machine ends up with a broken/inconsistent
+# code signature, which macOS reports to users as "iQualize is damaged and can't
+# be opened." `codesign --verify` catches exactly that state, so this runs it on
+# the app inside the image before any release.
+#
+# Note: this deliberately does NOT run `spctl`. The app is ad-hoc signed, not
+# notarized, so Gatekeeper (spctl) rejects it by design — gating on spctl would
+# fail every legitimate build. A valid ad-hoc signature is the bar here; users
+# still strip the quarantine xattr per the README.
+#
+# Exit status: 0 = OK, non-zero = do not release.
+set -euo pipefail
+
+DMG="${1:?usage: verify-dmg.sh <path-to-dmg>}"
+if [ ! -f "$DMG" ]; then
+    echo "verify-dmg: FAIL — no such file: $DMG" >&2
+    exit 1
+fi
+
+echo "verify-dmg: checking $DMG"
+
+# 1) Disk image integrity.
+if ! hdiutil verify "$DMG" >/dev/null 2>&1; then
+    echo "verify-dmg: FAIL — disk image checksum is invalid" >&2
+    exit 1
+fi
+
+# 2) Mount read-only in a private mountpoint (no Finder window).
+MOUNT="$(mktemp -d)"
+cleanup() {
+    hdiutil detach "$MOUNT" >/dev/null 2>&1 || true
+    rmdir "$MOUNT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT" >/dev/null
+
+APP="$MOUNT/iQualize.app"
+if [ ! -d "$APP" ]; then
+    echo "verify-dmg: FAIL — iQualize.app not found in the image" >&2
+    exit 1
+fi
+
+# 3) The signature must be valid and consistent — the "damaged" check.
+if ! codesign --verify --deep --strict --verbose=2 "$APP" 2>&1; then
+    echo "verify-dmg: FAIL — app signature is invalid; macOS would report this as \"damaged\"" >&2
+    exit 1
+fi
+
+VERSION="$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' "$APP/Contents/Info.plist" 2>/dev/null || echo '?')"
+echo "verify-dmg: OK — iQualize.app v${VERSION}, signature valid, image intact"


### PR DESCRIPTION
## Summary

Guard against shipping another "damaged" DMG (issue #115). The root cause was a broken/invalid code signature that macOS reports as "damaged"; codesign --verify catches exactly that, so run it before any release.

## Scope

- **verify-dmg.sh** — mounts a DMG read-only, runs `codesign --verify --deep --strict` on the app inside plus `hdiutil verify`, exits non-zero with a clear message. Deliberately does not run spctl (the app is ad-hoc, not notarized, so Gatekeeper rejects it by design — that would fail every build).
- **create-dmg.sh** — calls verify-dmg.sh at the end, so set -e aborts the build if the DMG is broken.
- **.claude hook** — a PreToolUse guard that blocks a release command attaching a DMG that fails the same check. Triggers only on an actual release invocation at a shell boundary, not a mention in another command's text.
- **CLAUDE.md** — release step 3 documents the gate.

No app change, so no version bump.

## Test plan

- [x] verify-dmg.sh passes on the valid 0.45.0 DMG (exit 0), fails on a missing path (exit 1)
- [x] Hook allows non-release commands, a PR-create that merely mentions the phrase, and a release with a valid DMG (exit 0)
- [x] Hook blocks a release referencing a missing/broken DMG (exit 2, reason shown)