### PR TITLE
fix: make Bypass a true passthrough for In/Out/Balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.45.1] - 2026-07-24
+
+### Fixed
+- Bypass wasn't a true passthrough: the In gain, Out gain, and Balance stages kept running while bypassed, so "bypassed" audio was still colored by whatever those controls were set to. Bypass now neutralizes In/Out to 0 dB and Balance to center in the signal path while bypassed, and restores their audible effect on un-bypass — the stored/displayed control values never change (#118)
+
 ## [0.45.0] - 2026-07-15
 
 ### Added

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -144,14 +144,16 @@ final class AudioEngine {
     }
 
     var bypassed: Bool = false {
-        didSet { applyBands() }
+        didSet {
+            applyBands()
+            updateInputGain()
+            updateBalance()
+            updateOutputGain()
+        }
     }
 
     var balance: Float = 0.0 {
-        didSet {
-            rtBalanceLeft = balance <= 0 ? 1.0 : 1.0 - balance
-            rtBalanceRight = balance >= 0 ? 1.0 : 1.0 + balance
-        }
+        didSet { updateBalance() }
     }
 
     var splitChannelActive: Bool = false {
@@ -162,13 +164,32 @@ final class AudioEngine {
     }
 
     var inputGainDB: Float = 0.0 {
-        didSet {
-            rtInputGain = powf(10, inputGainDB / 20)
-        }
+        didSet { updateInputGain() }
     }
 
     var outputGainDB: Float = 0.0 {
-        didSet { outputGainEQ?.globalGain = outputGainDB }
+        didSet { updateOutputGain() }
+    }
+
+    /// Bypass is a true passthrough: In, Out, and Balance are neutralized while
+    /// bypassed and restored on un-bypass, without touching the stored/displayed
+    /// control values (see #118).
+    private func updateInputGain() {
+        rtInputGain = bypassed ? 1.0 : powf(10, inputGainDB / 20)
+    }
+
+    private func updateBalance() {
+        if bypassed {
+            rtBalanceLeft = 1.0
+            rtBalanceRight = 1.0
+        } else {
+            rtBalanceLeft = balance <= 0 ? 1.0 : 1.0 - balance
+            rtBalanceRight = balance >= 0 ? 1.0 : 1.0 + balance
+        }
+    }
+
+    private func updateOutputGain() {
+        outputGainEQ?.globalGain = bypassed ? 0 : outputGainDB
     }
 
     var maxGainDB: Float = 12
@@ -293,8 +314,8 @@ final class AudioEngine {
         self.limiter = limiterNode
 
         let outputGainNode = AVAudioUnitEQ(numberOfBands: 0)
-        outputGainNode.globalGain = outputGainDB
         self.outputGainEQ = outputGainNode
+        updateOutputGain()
 
         avEngine.attach(sourceNode)
         avEngine.attach(eqNode)

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.45.0</string>
+	<string>0.45.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.45.0</string>
+	<string>0.45.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- Bypass only gated the EQ bands and limiter — the In gain, Out gain, and Balance stages kept running unconditionally, so bypassed audio was still colored by whatever those controls were set to.
- `bypassed`'s setter now neutralizes all three (In/Out → 0 dB, Balance → center) in the applied signal path, and restores their effect on un-bypass. The stored/displayed control values are never touched — this is a signal-path change, not a state reset.
- Applies equally in split-channel mode, since In gain/Balance are applied unconditionally in the render callback regardless of `splitChannelActive`.

## Verification
Live signal-level test against the actual production code (not a reimplementation): temporarily instrumented the render callback and the post-Out-gain tap with peak logging, played a continuous tone through the system, and drove the running app via its `iqualize` CLI + a temporary debug balance hook. Measured peak amplitude at both taps:

| State | post-In/Balance (L / R) | post-Out-gain |
|---|---|---|
| Baseline (In 0, Out 0, Bal 0, bypass off) | 0.600 / 0.600 | 0.600 |
| In −12 dB, Out +6 dB, Balance −0.5, bypass off | 0.151 / 0.075 | 0.301 |
| Same settings, bypass **on** | 0.600 / 0.600 | 0.600 |
| Bypass off again | 0.151 / 0.075 | 0.301 |

Bypass on snapped both taps back to the exact "app fully off" baseline despite non-default In/Out/Balance, and un-bypassing restored the exact prior levels while `iqualize status` confirmed the displayed values never changed. All temporary debug instrumentation was reverted before this PR — the diff here is only the real fix.

Fixes #118

## Test plan
- [x] Set In to a non-zero dB, toggle Bypass — output level matches the app being fully quit (verified via live signal measurement above)
- [x] Set Out to a non-zero dB, toggle Bypass — no boost/cut in bypass
- [x] Set Balance off-center, toggle Bypass — audio is centered in bypass
- [x] Un-bypass — In/Out/Balance values and their audible effect return unchanged
- [x] Split-channel mode uses the same unconditional render-callback gain application, so the same neutralization applies there (confirmed by code path, not separately re-measured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)