### PR TITLE
feat: add balance control to the iqualize CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.46.0] - 2026-07-24
+
+### Added
+- `iqualize balance [value]` — get or set stereo balance (-1 to 1) from the command line, matching the existing `gain input`/`gain output` commands. `iqualize status` now also reports balance
+
 ## [0.45.1] - 2026-07-24
 
 ### Fixed

--- a/Sources/IQControlProtocol/CLIControlMessages.swift
+++ b/Sources/IQControlProtocol/CLIControlMessages.swift
@@ -27,6 +27,7 @@ public enum CLICommand {
     public static let toggleBypass = "toggleBypass"
     public static let setInputGain = "setInputGain"
     public static let setOutputGain = "setOutputGain"
+    public static let setBalance = "setBalance"
 }
 
 // MARK: - Response
@@ -59,16 +60,18 @@ public struct CLIStatusPayload: Codable, Sendable {
     public var activePresetName: String
     public var inputGainDB: Float
     public var outputGainDB: Float
+    public var balance: Float
     public var gainIsGlobal: Bool
     public var outputDeviceName: String
     public var isRunning: Bool
 
-    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool) {
+    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool) {
         self.bypassed = bypassed
         self.activePresetID = activePresetID
         self.activePresetName = activePresetName
         self.inputGainDB = inputGainDB
         self.outputGainDB = outputGainDB
+        self.balance = balance
         self.gainIsGlobal = gainIsGlobal
         self.outputDeviceName = outputDeviceName
         self.isRunning = isRunning

--- a/Sources/iQualize/CLIControlServer.swift
+++ b/Sources/iQualize/CLIControlServer.swift
@@ -15,6 +15,7 @@ protocol CLICommandHandling: AnyObject {
     @discardableResult func toggleBypassed() -> Bool
     func setInputGain(_ db: Float)
     func setOutputGain(_ db: Float)
+    func setBalance(_ value: Float)
 }
 
 /// Local control channel for the `iqualize` CLI: a Unix domain socket serving one
@@ -168,6 +169,11 @@ final class CLIControlServer: @unchecked Sendable {
         case CLICommand.setOutputGain:
             guard let db = request.floatArg else { return .failure("missing gain value") }
             handler.setOutputGain(db)
+            return .success(status: handler.statusSnapshot())
+
+        case CLICommand.setBalance:
+            guard let value = request.floatArg else { return .failure("missing balance value") }
+            handler.setBalance(value)
             return .success(status: handler.statusSnapshot())
 
         default:

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -103,6 +103,10 @@ final class EQWindowController: NSWindowController {
         viewModel.gainIsGlobal = on
     }
 
+    func syncBalance(_ value: Float) {
+        viewModel.balance = value
+    }
+
     func syncMaxGain(_ db: Float) {
         viewModel.maxGainDB = db
     }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.45.1</string>
+	<string>0.46.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.45.1</string>
+	<string>0.46.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -343,6 +343,17 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         eqWindowController?.syncUIToPreset()
     }
 
+    /// Sets stereo balance (-1 = hard left, +1 = hard right) — global, not per-preset,
+    /// mirroring the DreamUI footer slider's own clamp range.
+    func setBalance(_ value: Float) {
+        let clamped = min(max(value, -1), 1)
+        audioEngine.balance = clamped
+        var s = iQualizeState.load()
+        s.balance = clamped
+        s.save()
+        eqWindowController?.syncBalance(clamped)
+    }
+
     /// Resolves a preset by UUID string or case-insensitive exact name match.
     func resolvePreset(idOrName: String) -> EQPresetData? {
         if let id = UUID(uuidString: idOrName), let preset = presetStore.preset(for: id) {
@@ -358,6 +369,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             activePresetName: audioEngine.activePreset.name,
             inputGainDB: audioEngine.inputGainDB,
             outputGainDB: audioEngine.outputGainDB,
+            balance: audioEngine.balance,
             gainIsGlobal: audioEngine.gainIsGlobal,
             outputDeviceName: audioEngine.outputDeviceName,
             isRunning: audioEngine.isRunning

--- a/Sources/iqualize-cli/BalanceCommand.swift
+++ b/Sources/iqualize-cli/BalanceCommand.swift
@@ -1,0 +1,20 @@
+import ArgumentParser
+import IQControlProtocol
+
+struct Balance: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Get or set stereo balance, from -1 (hard left) to 1 (hard right)."
+    )
+
+    @Argument(help: "Balance from -1 to 1. Omit to just print the current value.")
+    var value: Float?
+
+    func run() {
+        let request = value.map { CLIRequest(command: CLICommand.setBalance, floatArg: $0) }
+            ?? CLIRequest(command: CLICommand.status)
+        let response = requireOK(sendOrExit(request))
+        if let status = response.status {
+            print("Balance: \(formatBalance(status.balance))")
+        }
+    }
+}

--- a/Sources/iqualize-cli/CLIOutput.swift
+++ b/Sources/iqualize-cli/CLIOutput.swift
@@ -28,12 +28,19 @@ func requireOK(_ response: CLIResponse) -> CLIResponse {
     return response
 }
 
+func formatBalance(_ value: Float) -> String {
+    if abs(value) < 0.01 { return "center" }
+    let pct = Int(round(abs(value) * 100))
+    return value < 0 ? "L\(pct)" : "R\(pct)"
+}
+
 func formatStatus(_ status: CLIStatusPayload) -> String {
     let mode = status.gainIsGlobal ? "shared" : "per-preset"
     return """
     Bypass: \(status.bypassed ? "on" : "off")
     Preset: \(status.activePresetName)
     Gain: \(String(format: "input %+.1f dB, output %+.1f dB", status.inputGainDB, status.outputGainDB)) (\(mode))
+    Balance: \(formatBalance(status.balance))
     Output device: \(status.outputDeviceName)
     """
 }

--- a/Sources/iqualize-cli/Iqualize.swift
+++ b/Sources/iqualize-cli/Iqualize.swift
@@ -6,7 +6,7 @@ struct Iqualize: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "iqualize",
         abstract: "Control a running iQualize instance from the command line.",
-        subcommands: [Status.self, Presets.self, PresetCommand.self, Bypass.self, Gain.self],
+        subcommands: [Status.self, Presets.self, PresetCommand.self, Bypass.self, Gain.self, Balance.self],
         defaultSubcommand: Status.self
     )
 }


### PR DESCRIPTION
## Summary
- `iqualize balance [value]` — get or set stereo balance (-1 hard left to 1 hard right), mirroring the existing `gain input`/`gain output` commands and clamped to the same range as the DreamUI footer slider.
- `iqualize status` now reports balance alongside bypass/preset/gain.
- Setting balance from the CLI syncs live to an open EQ window (same `sync*` pattern used by bypass/gain-is-global/etc.) and persists to `iQualizeState`, same as the other footer controls.

Follow-up from #120 — verifying the Bypass passthrough fix needed to drive balance externally, and there was no CLI path for it since only In/Out/Bypass were previously exposed.

## Test plan
- [x] `iqualize balance` prints the current value
- [x] `iqualize balance -- -0.5` / `iqualize balance 0.25` set it, format as `L50`/`R25`, and persist across `iqualize status` calls
- [x] Out-of-range values clamp (`5` → `R100`, `-5` → `L100`)
- [x] Setting balance, then toggling `iqualize bypass on`/`off`, shows the stored value in `status` never changes while bypass neutralizes the applied signal — confirms this composes correctly with #120's fix
- [x] Build, install, and launch verified (`bash install.sh && open /Applications/iQualize.app`)