### PR TITLE
fix: give the app-menu About the same content as the menu bar's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.46.1] - 2026-07-24
+
+### Fixed
+- "About iQualize" under the Apple-menu-adjacent app menu opened macOS's generic standard About panel, missing the GitHub link and OPRA credit the menu bar dropdown's About already had (#119). Both entry points now open the same custom About dialog
+
 ## [0.46.0] - 2026-07-24
 
 ### Added

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.46.0</string>
+	<string>0.46.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.46.0</string>
+	<string>0.46.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -396,7 +396,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    @objc private func showAbout(_ sender: NSMenuItem) {
+    @objc func showAbout(_ sender: Any?) {
         let alert = NSAlert()
         alert.messageText = "iQualize"
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -107,6 +107,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         menuBarController?.openHelp(sender)
     }
 
+    @objc func showAbout(_ sender: Any?) {
+        menuBarController?.showAbout(sender)
+    }
+
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         if menuItem.action == #selector(toggleBypass(_:)) {
             menuItem.state = audioEngine?.bypassed == true ? .on : .off
@@ -120,7 +124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         // App menu
         let appMenuItem = NSMenuItem()
         let appMenu = NSMenu()
-        appMenu.addItem(withTitle: "About iQualize", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(withTitle: "About iQualize", action: #selector(showAbout(_:)), keyEquivalent: "")
         appMenu.addItem(.separator())
         let settingsItem = NSMenuItem(title: "Settings…", action: #selector(openSettings(_:)), keyEquivalent: ",")
         appMenu.addItem(settingsItem)


### PR DESCRIPTION
## Summary
- The app menu's "About iQualize" (next to the Apple menu, per the screenshots in #119) opened macOS's generic `orderFrontStandardAboutPanel`, which only shows name/version/copyright — missing the GitHub link and OPRA credit.
- The menu bar dropdown's own "About iQualize" already opens a custom `NSAlert` with both. The two had just drifted apart, as Darius noted in the issue.
- `MenuBarController.showAbout` is now `internal` (was `private`) and takes `Any?` instead of `NSMenuItem` (unused param, matches the existing `openHelp` forwarding convention), and `AppDelegate` gets a thin `showAbout` wrapper — same pattern already used for `openSettings`/`toggleBypass`/`openHelp`. Both menu items now call the same method.

Fixes #119

## Test plan
- [x] Build succeeds, app installs and launches (`bash install.sh && open /Applications/iQualize.app`, confirmed running)
- [ ] Manual: Apple-menu-adjacent "iQualize" → "About iQualize" now shows the GitHub/OPRA dialog (same as the menu bar dropdown's About) — I couldn't click through this myself, no Accessibility automation permission granted in this environment for native menu scripting, so this needs a manual click-through before merging