### PR TITLE
docs: credit nordicdata in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ iQualize captures audio at the tap's native sample rate; AVAudioEngine's output 
 
 ## Credits
 
+Huge thanks to [@nordicdata](https://github.com/nordicdata) (Gary) for the detailed, well-written bug reports and feature requests — a lot of the fixes and improvements in the changelog exist because he took the time to file them properly.
+
 The Preset Browser's headphone and IEM EQ profiles come from the [OPRA project](https://github.com/opra-project/OPRA) — Open Profiles for Revealing Audio, an open, community-maintained directory of product information and EQ compensation curves. OPRA's data is licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/); each imported profile credits its original author in the browser.
 
 ---


### PR DESCRIPTION
## Summary
- Adds a short thank-you to [@nordicdata](https://github.com/nordicdata) (Gary) in the README's Credits section, alongside the existing OPRA credit — he's filed a steady stream of detailed, well-written issues (#118, #119, and others) that have directly driven real fixes.

Docs-only, no version bump.