### PR TITLE
fix: unsaved preset forks no longer appear in the picker before Save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.47.0] - 2026-07-24
+
+### Fixed
+- Editing the per-preset Input/Output dB gain on a built-in preset forked and immediately saved it to the custom-preset store, so an unsaved fork showed up in the picker's Custom section before the user ever hit Save — and the title's unsaved-changes dot never lit up for it either. Band edits already deferred saving until Save; gain edits now follow the same rule (#100)
+- Pinning a preset to an output device while it had unsaved changes could pin an id that isn't in the preset store, silently dangling the pin the moment the fork was discarded. The pin button is now disabled while there are unsaved changes (#100)
+- Switching presets or starting a new preset while there were unsaved changes discarded them with no warning; now prompts Save / Cancel / Don't Save first. Deleting the active preset never asked for confirmation at all, saved or not; it now always asks before hiding a built-in or removing a custom preset (#100)
+
 ## [0.46.1] - 2026-07-24
 
 ### Fixed

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -97,9 +97,12 @@ struct DreamToolbar: View {
                 .font(.system(size: 12, weight: .medium))
         }
         .controlSize(.regular)
+        .disabled(vm.isModified && !vm.isCurrentDevicePinnedToActivePreset)
         .help(vm.isCurrentDevicePinnedToActivePreset
               ? "Unpin from \(vm.outputDeviceName)"
-              : "Pin to \(vm.outputDeviceName)")
+              : vm.isModified
+                ? "Save this preset before pinning it"
+                : "Pin to \(vm.outputDeviceName)")
 
         Button(action: { vm.onOpenSettings?() }) {
             Image(systemName: "gearshape").font(.system(size: 12, weight: .medium))

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -82,11 +82,13 @@ final class DreamViewModel {
     }
 
     /// Unpins if the active preset is already the one pinned here, otherwise pins it.
+    /// No-ops while there are unsaved changes — pinning an unsaved fork would point at an
+    /// id that isn't in `PresetStore`, silently dangling the pin.
     func toggleDevicePin() {
         guard let uid = audioEngine.outputDeviceUID else { return }
         if isCurrentDevicePinnedToActivePreset {
             presetStore.unpinPreset(fromDeviceUID: uid)
-        } else {
+        } else if !isModified {
             presetStore.pinPreset(audioEngine.activePreset.id, toDeviceUID: uid)
         }
     }
@@ -226,7 +228,10 @@ final class DreamViewModel {
     /// different identity and would otherwise leave a phantom dirty dot.
     private func contentMatchesSaved(_ preset: EQPresetData) -> Bool {
         guard let saved = savedSnapshot else { return false }
-        return preset.bands == saved.bands && preset.rightBands == saved.rightBands
+        return preset.bands == saved.bands
+            && preset.rightBands == saved.rightBands
+            && preset.inputGainDB == saved.inputGainDB
+            && preset.outputGainDB == saved.outputGainDB
     }
 
     // MARK: - Mutation helpers
@@ -514,6 +519,10 @@ final class DreamViewModel {
     // MARK: - Mutations: preset
 
     func loadPreset(id: UUID) {
+        confirmDiscardIfNeeded { [weak self] in self?.performLoadPreset(id: id) }
+    }
+
+    private func performLoadPreset(id: UUID) {
         guard let preset = presetStore.preset(for: id) else { return }
         let oldPreset = audioEngine.activePreset
         audioEngine.activePreset = preset
@@ -544,6 +553,10 @@ final class DreamViewModel {
     }
 
     func newPreset() {
+        confirmDiscardIfNeeded { [weak self] in self?.performNewPreset() }
+    }
+
+    private func performNewPreset() {
         let existing = presetStore.allPresets.map { $0.name }
         var n = 1
         while existing.contains("Custom EQ \(n)") { n += 1 }
@@ -574,6 +587,9 @@ final class DreamViewModel {
         presetStore.saveCustomPreset(preset)
         savedSnapshot = preset
         isModified = false
+        var s = iQualizeState.load()
+        s.selectedPresetID = preset.id
+        s.save()
     }
 
     func saveAsPreset(name: String?) {
@@ -592,7 +608,9 @@ final class DreamViewModel {
             name: resolvedName,
             bands: bands,
             rightBands: rightBands,
-            isBuiltIn: false
+            isBuiltIn: false,
+            inputGainDB: audioEngine.activePreset.inputGainDB,
+            outputGainDB: audioEngine.activePreset.outputGainDB
         )
         presetStore.saveCustomPreset(newPreset)
         let old = audioEngine.activePreset
@@ -601,9 +619,31 @@ final class DreamViewModel {
         isModified = false
         syncFromAudioEngine()
         registerUndo(actionName: "Save As", oldPreset: old)
+        var s = iQualizeState.load()
+        s.selectedPresetID = newPreset.id
+        s.save()
     }
 
+    /// Confirms before deleting — a built-in is hidden (recoverable from the Preset Browser),
+    /// a custom preset is removed outright. Doesn't route through `confirmDiscardIfNeeded`:
+    /// offering to save unsaved edits first would be pointless when the whole preset is about
+    /// to be removed.
     func deleteCurrentPreset() {
+        guard activePresetID != EQPresetData.flat.id else { return }
+        let alert = NSAlert()
+        alert.messageText = "Delete \"\(presetName)\"?"
+        alert.informativeText = isBuiltIn
+            ? "This hides it from the picker. You can bring it back later from the Preset Browser."
+            : isModified
+                ? "This removes it and discards your unsaved changes. This can't be undone."
+                : "This can't be undone."
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        performDeleteCurrentPreset()
+    }
+
+    private func performDeleteCurrentPreset() {
         guard activePresetID != EQPresetData.flat.id else { return }
         if isBuiltIn {
             presetStore.hideBuiltInPreset(id: activePresetID)
@@ -627,6 +667,34 @@ final class DreamViewModel {
     func redo() { undoManager?.redo() }
 
     // MARK: - Native dialogs
+
+    /// If there are unsaved changes, asks Save / Cancel / Don't Save before running `then`.
+    /// Proceeds straight to `then` when there's nothing to lose. "Save" reuses the same
+    /// built-in-redirects-to-Save-As rule as the toolbar's Save button; if that dialog gets
+    /// cancelled, the whole action is treated as cancelled too.
+    func confirmDiscardIfNeeded(then: @escaping () -> Void) {
+        guard isModified else { then(); return }
+        let alert = NSAlert()
+        alert.messageText = "Save changes to \"\(presetName)\"?"
+        alert.informativeText = "Your changes will be lost if you don't save them."
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Don't Save")
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            if isBuiltIn {
+                presentSaveAsDialog()
+                if isModified { return } // the Save As name prompt was itself cancelled
+            } else {
+                savePreset()
+            }
+            then()
+        case .alertThirdButtonReturn:
+            then()
+        default:
+            return
+        }
+    }
 
     /// Show a native save-as dialog (NSAlert with a text field accessory) and persist the result
     /// as a new custom preset.
@@ -864,15 +932,7 @@ final class DreamViewModel {
             audioEngine.inputGainDB = inGainDB
             persistFooterToggles()
         } else {
-            forkIfBuiltIn()
-            var preset = audioEngine.activePreset
-            preset.inputGainDB = inGainDB
-            audioEngine.activePreset = preset
-            presetStore.saveCustomPreset(preset)
-            savedSnapshot = preset
-            var s = iQualizeState.load()
-            s.selectedPresetID = preset.id
-            s.save()
+            mutateGain("Adjust Input Gain") { $0.inputGainDB = inGainDB }
         }
     }
 
@@ -881,16 +941,23 @@ final class DreamViewModel {
             audioEngine.outputGainDB = outGainDB
             persistFooterToggles()
         } else {
-            forkIfBuiltIn()
-            var preset = audioEngine.activePreset
-            preset.outputGainDB = outGainDB
-            audioEngine.activePreset = preset
-            presetStore.saveCustomPreset(preset)
-            savedSnapshot = preset
-            var s = iQualizeState.load()
-            s.selectedPresetID = preset.id
-            s.save()
+            mutateGain("Adjust Output Gain") { $0.outputGainDB = outGainDB }
         }
+    }
+
+    /// Per-preset gain edit: forks a built-in in-memory only (matches `mutate()`'s band-edit
+    /// behavior) — no `PresetStore.saveCustomPreset` call, so the fork stays out of the picker
+    /// and out of persisted state until an explicit Save.
+    private func mutateGain(_ actionName: String, _ apply: (inout EQPresetData) -> Void) {
+        let oldPreset = audioEngine.activePreset
+        forkIfBuiltIn()
+        var preset = audioEngine.activePreset
+        apply(&preset)
+        audioEngine.activePreset = preset
+        let wasModified = isModified
+        isModified = !contentMatchesSaved(preset)
+        if wasModified != isModified { onTitleShouldUpdate?() }
+        registerUndo(actionName: actionName, oldPreset: oldPreset)
     }
 
     func applyBalance() {

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -91,6 +91,12 @@ final class EQWindowController: NSWindowController {
         viewModel.syncFromAudioEngine(initial: true)
     }
 
+    /// Guards an external preset switch (menu bar / CLI) behind the same unsaved-changes
+    /// confirmation the in-window picker uses.
+    func confirmDiscardIfNeeded(then: @escaping () -> Void) {
+        viewModel.confirmDiscardIfNeeded(then: then)
+    }
+
     func syncBypass(_ on: Bool) {
         viewModel.bypass = on
     }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.46.1</string>
+	<string>0.47.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.46.1</string>
+	<string>0.47.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -206,15 +206,27 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     // MARK: - Actions
 
     /// Switches the active preset. Shared by the menu's `selectPreset(_:)` and the CLI.
+    /// Guarded behind the EQ window's unsaved-changes confirmation, if it's open — the alert
+    /// runs modally, so `didApply` is settled before this returns.
     @discardableResult
     func applyPreset(id: UUID) -> Bool {
-        guard let preset = presetStore.preset(for: id) else { return false }
-        audioEngine.activePreset = preset
-        var s = iQualizeState.load()
-        s.selectedPresetID = preset.id
-        s.save()
-        eqWindowController?.syncUIToPreset()
-        return true
+        guard presetStore.preset(for: id) != nil else { return false }
+        var didApply = false
+        let proceed = { [weak self] in
+            guard let self, let preset = self.presetStore.preset(for: id) else { return }
+            self.audioEngine.activePreset = preset
+            var s = iQualizeState.load()
+            s.selectedPresetID = preset.id
+            s.save()
+            self.eqWindowController?.syncUIToPreset()
+            didApply = true
+        }
+        if let eqWindowController {
+            eqWindowController.confirmDiscardIfNeeded(then: proceed)
+        } else {
+            proceed()
+        }
+        return didApply
     }
 
     @objc private func openEQSettings(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary
- Editing a built-in preset's per-preset Input/Output dB gain forked and immediately saved it to the custom-preset store — unlike band edits, which already deferred saving until Save. That put an unsaved fork in the picker's Custom section before the user ever hit Save, and the title's unsaved-changes dot never lit up for it. Gain edits now follow the same fork-then-defer rule as band edits.
- Fixes the 3 concerns raised in the issue: the asterisk indicator (fixed via `contentMatchesSaved` now comparing gain fields), pinning an unsaved fork (pin button disables while `isModified`, `toggleDevicePin` no-ops), and switch-away (Save / Cancel / Don't Save prompt on `loadPreset`/`newPreset`; delete gets its own Delete/Cancel confirmation since offering to save right before deleting the whole preset doesn't make sense).
- Design was written up and discussed in the issue before implementation: https://github.com/dariuscorvus/iqualize/issues/100#issuecomment-5074360554

## Scope
Also fixed while auditing the same fork/save code paths:
- Gain-triggered forks now register an undo step, like every other mutation already did (previously had none).
- `saveAsPreset` was silently dropping `inputGainDB`/`outputGainDB` when building the new preset; now carries them over.
- `savePreset`/`saveAsPreset` now persist `selectedPresetID`, matching `loadPreset`/`deleteCurrentPreset`, so a relaunch after saving a fork reopens the right preset instead of the original built-in.
- Deleting the active preset never confirmed at all before this PR; it now always asks.

Left out of scope, by design (discussed in the issue):
- An output-device auto-pin switching the active preset while a fork is unsaved stays silent — not a direct user click.
- Quitting the app with an unsaved fork stays silent — no regression from current behavior, and a quit-time prompt is separate NSApplicationDelegate lifecycle work.

Version bumped 0.46.1 → 0.47.0 (UI-visible behavior change), CHANGELOG updated.

## Test plan
- [x] `swift build` — clean, only pre-existing unrelated warnings
- [x] `install.sh` + launch verification — app launches successfully
- [x] Manually drove the running app: forked a built-in via gain edit, confirmed the fork does NOT appear in the picker's Custom section, confirmed the title dot lights up, confirmed the pin button disables, confirmed switching presets while unsaved shows the Save/Cancel/Don't Save alert
- [x] Delete confirmation dialog not re-verified in-app after the follow-up commit (built + launched successfully, but not clicked through)

Fixes #100