### PR TITLE
feat: add zoom control to the EQ graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.48.0] - 2026-07-25
+
+### Added
+- Zoom control for the EQ graph: Full / Sub / Bass / Mid / Pres / Treb segmented toggle floating on top of the graph. Zooming rescales the graph, gridlines, and axis labels to a frequency sub-range (Sub-bass 20-60Hz, Bass 60-250Hz, Mid 250Hz-2kHz, Presence 2-4kHz, Treble 4-20kHz) for finer control when working on one part of the spectrum. Dragging a band knob is clamped to the current zoom window, and the canvas-edge "Add Band" buttons/"Add Suggested Band" add within the visible range while zoomed. Everything else (keyboard nudges, the readout grid's numeric fields, `updateBand`'s own frequency clamp) stays full-range regardless of zoom
+- Fixed a rendering bug the zoom feature surfaced: the graph's frequency-to-x-position mapping clamped any frequency below the visible range onto the exact left-edge pixel instead of letting it map off-canvas like the high-frequency side already did, so the real-time spectrum trace showed a flat plateau on the left edge whenever the graph was zoomed into a sub-range
+
 ## [0.47.0] - 2026-07-24
 
 ### Fixed

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -36,6 +36,7 @@ final class DreamViewModel {
     var altPressed: Bool = false
     var bandwidthDisplay: BandwidthDisplay = .oct
     var snapToSemitone: Bool = false
+    var zoomRange: ZoomRange = .full
     var theme: DreamThemePreference = .auto
     var editing: EditingTarget?
 
@@ -120,6 +121,7 @@ final class DreamViewModel {
         let s = iQualizeState.load()
         if let raw = s.dreamTheme, let t = DreamThemePreference(rawValue: raw) { theme = t }
         snapToSemitone = s.snapToSemitone
+        zoomRange = s.zoomRange.flatMap(ZoomRange.init(rawValue:)) ?? .full
         bandwidthDisplay = s.showBandwidthAsQ ? .q : .oct
         peakLimiter = s.peakLimiter
         bypass = s.bypassed
@@ -147,6 +149,12 @@ final class DreamViewModel {
     func persistSnap() {
         var s = iQualizeState.load()
         s.snapToSemitone = snapToSemitone
+        s.save()
+    }
+
+    func persistZoomRange() {
+        var s = iQualizeState.load()
+        s.zoomRange = zoomRange.rawValue
         s.save()
     }
 
@@ -464,38 +472,54 @@ final class DreamViewModel {
 
     enum AddMode { case left, right, suggest }
 
+    /// Bands added from the canvas edges land within the current zoom window — the buttons sit
+    /// at the edges of what's currently visible, so a click there should add something in view.
     func addBand(_ mode: AddMode) {
         mutate("Add Band") {
+            let range = self.zoomRange.bounds
             if self.bands.isEmpty {
-                self.bands.append(EQBand(frequency: 1000, gain: 0, bandwidth: 1.0))
+                self.bands.append(EQBand(frequency: Self.zoomMidpoint(range), gain: 0, bandwidth: 1.0))
                 return
             }
             let sorted = self.bands.sorted { $0.frequency < $1.frequency }
             switch mode {
             case .left:
                 let template = sorted.first!
-                let f = max(20, template.frequency / 1.5)
+                let f = Self.clampToZoom(template.frequency / 1.5, range)
                 self.bands.append(EQBand(frequency: f, gain: template.gain, bandwidth: template.bandwidth, filterType: template.filterType))
             case .right:
                 let template = sorted.last!
-                let f = min(20000, template.frequency * 1.5)
+                let f = Self.clampToZoom(template.frequency * 1.5, range)
                 self.bands.append(EQBand(frequency: f, gain: template.gain, bandwidth: template.bandwidth, filterType: template.filterType))
             case .suggest:
-                let f = self.findLargestGap(in: sorted)
+                let f = self.findLargestGap(in: sorted, range: range)
                 self.bands.append(EQBand(frequency: f, gain: 0, bandwidth: 1.0))
             }
         }
     }
 
-    private func findLargestGap(in sorted: [EQBand]) -> Float {
-        guard sorted.count >= 2 else { return 1000 }
+    private static func clampToZoom(_ f: Float, _ range: ClosedRange<Double>) -> Float {
+        max(Float(range.lowerBound), min(Float(range.upperBound), f))
+    }
+
+    private static func zoomMidpoint(_ range: ClosedRange<Double>) -> Float {
+        Float((range.lowerBound * range.upperBound).squareRoot())
+    }
+
+    /// Widest gap between bands that fall within `range` — bands outside the current zoom
+    /// window aren't candidates, so "Add Suggested Band" only ever lands somewhere visible.
+    private func findLargestGap(in sorted: [EQBand], range: ClosedRange<Double>) -> Float {
+        let bounds = Float(range.lowerBound)...Float(range.upperBound)
+        let within = sorted.filter { bounds.contains($0.frequency) }
+        let fallback = Self.zoomMidpoint(range)
+        guard within.count >= 2 else { return fallback }
         var bestRatio: Float = 0
-        var bestF: Float = 1000
-        for i in 0..<(sorted.count - 1) {
-            let ratio = sorted[i + 1].frequency / sorted[i].frequency
+        var bestF: Float = fallback
+        for i in 0..<(within.count - 1) {
+            let ratio = within[i + 1].frequency / within[i].frequency
             if ratio > bestRatio {
                 bestRatio = ratio
-                bestF = sqrt(sorted[i].frequency * sorted[i + 1].frequency)
+                bestF = sqrt(within[i].frequency * within[i + 1].frequency)
             }
         }
         return bestF
@@ -1002,6 +1026,35 @@ enum BandwidthDisplay: String, Sendable {
 
 enum ChannelMode: String, Sendable {
     case linked, l, r
+}
+
+/// Restricts the EQ canvas's visible/editable frequency window, for working precisely on one
+/// part of the spectrum. Purely a view preference — never persisted with a preset, doesn't
+/// affect `updateBand`'s clamp, keyboard nudges, or the readout grid, all of which stay full-range.
+enum ZoomRange: String, CaseIterable, Sendable {
+    case full, subBass, bass, mid, presence, treble
+
+    var bounds: ClosedRange<Double> {
+        switch self {
+        case .full: return 20...20000
+        case .subBass: return 20...60
+        case .bass: return 60...250
+        case .mid: return 250...2000
+        case .presence: return 2000...4000
+        case .treble: return 4000...20000
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .full: return "Full"
+        case .subBass: return "Sub"
+        case .bass: return "Bass"
+        case .mid: return "Mid"
+        case .presence: return "Pres"
+        case .treble: return "Treb"
+        }
+    }
 }
 
 struct EditingTarget: Equatable {

--- a/Sources/iQualize/DreamUI/EQCanvasView.swift
+++ b/Sources/iQualize/DreamUI/EQCanvasView.swift
@@ -32,11 +32,38 @@ struct EQCanvasView: View {
 
                 addButton(.left)
                 addButton(.right)
+
+                zoomControl
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .padding(.top, 8)
             }
             .background(theme.bgCanvas)
             .clipped()
         }
         .frame(maxWidth: .infinity, minHeight: 380, idealHeight: 380, maxHeight: .infinity)
+    }
+
+    // MARK: - Zoom control
+
+    @ViewBuilder
+    private var zoomControl: some View {
+        DreamSegment(
+            selection: Binding(
+                get: { vm.zoomRange },
+                set: { vm.zoomRange = $0; vm.persistZoomRange() }
+            ),
+            options: ZoomRange.allCases.map { ($0, $0.label) }
+        )
+        .help("Zoom the graph into a frequency range")
+        .padding(3)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.bgControl.opacity(0.9))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.line, lineWidth: 1)
+        )
     }
 
     // MARK: - +Add buttons
@@ -116,41 +143,36 @@ struct EQCanvasView: View {
             )
         }
 
-        // Frequency grid
-        let decades: [Double] = [10, 100, 1000, 10000]
-        let minors: [Double] = [
-            20,30,40,50,60,70,80,90,
-            200,300,400,500,600,700,800,900,
-            2000,3000,4000,5000,6000,7000,8000,9000,
-            11000,12000,13000,14000,15000,16000,17000,18000,19000
-        ]
-        for f in minors where f >= 20 && f <= 20000 {
+        // Frequency grid — the full-spectrum view keeps its hand-tuned tick arrays; zoomed
+        // sub-ranges generate the same decade/minor/labeled tiers programmatically, since a
+        // fixed array can't cover an arbitrary window.
+        let (minors, decades, labeled) = gridTicks(for: domain)
+        for f in minors where f >= domain.lowerBound && f <= domain.upperBound {
             let x = freqToX(f, W: W)
             var p = Path(); p.move(to: .init(x: x, y: 0)); p.addLine(to: .init(x: x, y: H))
             ctx.stroke(p, with: .color(ink(0.035)), lineWidth: 0.5)
             var t = Path(); t.move(to: .init(x: x, y: H - 1)); t.addLine(to: .init(x: x, y: H - 4))
             ctx.stroke(t, with: .color(ink(0.12)), lineWidth: 1)
         }
-        for f in decades where f >= 20 && f <= 20000 {
+        for f in decades where f >= domain.lowerBound && f <= domain.upperBound {
             let x = freqToX(f, W: W)
             var p = Path(); p.move(to: .init(x: x, y: 0)); p.addLine(to: .init(x: x, y: H))
             ctx.stroke(p, with: .color(ink(0.10)), lineWidth: 1)
             var t = Path(); t.move(to: .init(x: x, y: H - 1)); t.addLine(to: .init(x: x, y: H - 7))
             ctx.stroke(t, with: .color(ink(0.28)), lineWidth: 1)
         }
-        // Frequency labels — unit suffixed only on the extremes (20 Hz, 20 kHz). Middle labels stay
-        // numeric to avoid a row of repetitive "Hz"/"kHz" tokens.
-        let labeled: [Double] = [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000]
-        for f in labeled where f >= 20 && f <= 20000 {
+        // Frequency labels — unit suffixed only on the visible extremes (e.g. "20 Hz"/"20 kHz"
+        // for the full view, or the current zoom's own bounds). Middle labels stay numeric to
+        // avoid a row of repetitive "Hz"/"kHz" tokens.
+        for f in labeled where f >= domain.lowerBound && f <= domain.upperBound {
             let x = freqToX(f, W: W)
             let base = f >= 1000 ? "\(Int(f/1000))k" : "\(Int(f))"
-            let label: String
-            if f == 20 { label = "20 Hz" }
-            else if f == 20000 { label = "20 kHz" }
-            else { label = base }
+            let isLowEdge = f == domain.lowerBound
+            let isHighEdge = f == domain.upperBound
+            let label = edgeLabel(for: f) ?? base
             let txt = Text(label).font(.system(size: 10)).foregroundStyle(ink(0.42))
-            let anchor: UnitPoint = (f == 20) ? .leading : (f == 20000) ? .trailing : .center
-            let px = (f == 20) ? x + 4 : (f == 20000) ? x - 4 : x
+            let anchor: UnitPoint = isLowEdge ? .leading : isHighEdge ? .trailing : .center
+            let px = isLowEdge ? x + 4 : isHighEdge ? x - 4 : x
             ctx.draw(txt, at: CGPoint(x: px, y: H - 10), anchor: anchor)
         }
 
@@ -158,7 +180,7 @@ struct EQCanvasView: View {
         if vm.snapToSemitone || vm.altPressed {
             for n in -60...72 {
                 let f = 440.0 * pow(2.0, Double(n) / 12.0)
-                if f < 20 || f > 20000 { continue }
+                if f < domain.lowerBound || f > domain.upperBound { continue }
                 let x = freqToX(f, W: W)
                 var p = Path(); p.addRect(.init(x: x, y: H - 14, width: 1, height: 8))
                 ctx.fill(p, with: .color(Color(rgba: 0x60a5fa, a: 0.18)))
@@ -480,7 +502,7 @@ struct EQCanvasView: View {
             if vm.snapToSemitone || vm.altPressed {
                 f = snapToNearest(f)
             }
-            f = max(20, min(20000, f))
+            f = max(domain.lowerBound, min(domain.upperBound, f))
             vm.updateBand(id: drag.bandID, frequency: Float(f), gain: Float(g))
         case .bandwidth:
             let dxFrac = (p.x - drag.startX) / W
@@ -599,16 +621,74 @@ struct EQCanvasView: View {
     private static let chartLeftPad: CGFloat = 14
     private static let chartRightPad: CGFloat = 14
 
+    /// The canvas's current frequency domain — the full spectrum, or a zoomed-in sub-range.
+    /// Every position/hit-test call site funnels through `freqToX`/`xToFreq`, so this one
+    /// property is the only thing that needs to change for the whole canvas to "zoom."
+    private var domain: ClosedRange<Double> { vm.zoomRange.bounds }
+
+    /// Maps a frequency to canvas x. Frequencies outside the current zoom domain map outside
+    /// [0, W] rather than clamping onto an edge — e.g. an FFT spectrum bin or a band below the
+    /// zoomed-in lower bound should scroll off-canvas, not collapse every sub-range value onto
+    /// the same pixel (which produced a flat plateau at the left edge of the spectrum trace
+    /// whenever the graph was zoomed to a sub-range). `max(0.0001, f)` only guards log10 against
+    /// non-positive input; it isn't a clamp to the domain.
     private func freqToX(_ f: Double, W: CGFloat) -> CGFloat {
         let chartW = max(1, W - Self.chartLeftPad - Self.chartRightPad)
-        let t = (log10(max(20.0, f)) - log10(20.0)) / (log10(20000.0) - log10(20.0))
+        let lo = domain.lowerBound, hi = domain.upperBound
+        let t = (log10(max(0.0001, f)) - log10(lo)) / (log10(hi) - log10(lo))
         return Self.chartLeftPad + chartW * CGFloat(t)
     }
 
     private func xToFreq(_ x: CGFloat, W: CGFloat) -> Double {
         let chartW = max(1, W - Self.chartLeftPad - Self.chartRightPad)
+        let lo = domain.lowerBound, hi = domain.upperBound
         let t = max(0, min(1, (x - Self.chartLeftPad) / chartW))
-        return pow(10.0, log10(20.0) + Double(t) * (log10(20000.0) - log10(20.0)))
+        return pow(10.0, log10(lo) + Double(t) * (log10(hi) - log10(lo)))
+    }
+
+    /// Frequency-grid ticks for `range`, split into faint "minor" lines, bold "decade" lines
+    /// (exact powers of ten), and a subset that gets a text label. The full-spectrum view keeps
+    /// its original hand-tuned arrays (including the denser 11-19 kHz fill in the top decade);
+    /// zoomed sub-ranges generate the same 2-9×decade minor / 1-2-5×decade major pattern
+    /// programmatically, since a fixed array can't span an arbitrary window.
+    private func gridTicks(for range: ClosedRange<Double>) -> (minors: [Double], decades: [Double], labeled: [Double]) {
+        guard vm.zoomRange != .full else {
+            return (
+                minors: [
+                    20, 30, 40, 50, 60, 70, 80, 90,
+                    200, 300, 400, 500, 600, 700, 800, 900,
+                    2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000,
+                    11000, 12000, 13000, 14000, 15000, 16000, 17000, 18000, 19000
+                ],
+                decades: [10, 100, 1000, 10000],
+                labeled: [20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000]
+            )
+        }
+        let lo = range.lowerBound, hi = range.upperBound
+        var minors: [Double] = []
+        var decades: [Double] = []
+        var labeled: Set<Double> = [lo, hi]
+        var decade = pow(10, floor(log10(lo)))
+        while decade <= hi {
+            if decade >= lo && decade <= hi { decades.append(decade); labeled.insert(decade) }
+            for m in [2.0, 5.0] where decade * m >= lo && decade * m <= hi { labeled.insert(decade * m) }
+            for m in stride(from: 2.0, through: 9.0, by: 1.0) where decade * m >= lo && decade * m <= hi {
+                minors.append(decade * m)
+            }
+            decade *= 10
+        }
+        return (minors, decades, labeled.sorted())
+    }
+
+    /// Full unit-suffixed text ("60 Hz", "4 kHz") for the two edges of the currently-visible
+    /// range — the full view keeps its original literal "20 Hz"/"20 kHz" text; other zoom levels
+    /// derive it from whatever the current bounds actually are.
+    private func edgeLabel(for f: Double) -> String? {
+        guard f == domain.lowerBound || f == domain.upperBound else { return nil }
+        if vm.zoomRange == .full {
+            return f == domain.lowerBound ? "20 Hz" : "20 kHz"
+        }
+        return formatHz(Float(f))
     }
 
     /// Pixels of margin above the +max grid line — the dB label sits with its bottom 2 pt above

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -37,6 +37,8 @@ struct iQualizeState: Codable {
     var dreamTheme: String?
     /// Snap newly-dragged band frequencies to musical semitones.
     var snapToSemitone: Bool
+    /// EQ canvas zoom range, e.g. "full" | "subBass" | "bass" | "mid" | "presence" | "treble". Nil = full.
+    var zoomRange: String?
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -60,12 +62,13 @@ struct iQualizeState: Codable {
         preEqFillEnabled: false,
         postEqFillEnabled: true,
         dreamTheme: nil,
-        snapToSemitone: false
+        snapToSemitone: false,
+        zoomRange: nil
     )
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = false, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = false, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false, zoomRange: String? = nil) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -92,6 +95,7 @@ struct iQualizeState: Codable {
         self.postEqFillEnabled = postEqFillEnabled
         self.dreamTheme = dreamTheme
         self.snapToSemitone = snapToSemitone
+        self.zoomRange = zoomRange
     }
 
     init(from decoder: Decoder) throws {
@@ -122,6 +126,7 @@ struct iQualizeState: Codable {
         postEqFillEnabled = (try? container.decode(Bool.self, forKey: .postEqFillEnabled)) ?? true
         dreamTheme = try? container.decode(String.self, forKey: .dreamTheme)
         snapToSemitone = (try? container.decode(Bool.self, forKey: .snapToSemitone)) ?? false
+        zoomRange = try? container.decode(String.self, forKey: .zoomRange)
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.47.0</string>
+	<string>0.48.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.47.0</string>
+	<string>0.48.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary
- New Full/Sub/Bass/Mid/Pres/Treb segmented control floating on top of the EQ graph, letting the user restrict the visible/editable frequency window for finer control over one part of the spectrum: Sub-bass 20-60Hz, Bass 60-250Hz, Mid 250Hz-2kHz, Presence 2-4kHz, Treble 4-20kHz.
- `freqToX`/`xToFreq` now read the zoom domain instead of a hardcoded 20-20000, which cascades correctly through gridlines, curve sampling, hit-testing, and auto-scale with no other call-site changes needed.
- Dragging a band knob clamps to the current zoom window. The canvas-edge "Add Band" buttons and "Add Suggested Band" add within the visible range while zoomed. Keyboard nudges, the readout grid's numeric fields, and `updateBand`'s own frequency clamp stay full-range regardless of zoom, since those aren't "what's on screen" gestures.
- Also fixes a rendering bug this surfaced: `freqToX` clamped any frequency below the current domain's lower bound onto the exact left-edge pixel instead of letting it map off-canvas like the high-frequency side already did. With the full 20-20000 domain this was a no-op, but once zoomed to a sub-range every FFT spectrum bin below the visible window collapsed onto the same pixel, producing a flat plateau on the left of the pre/post-EQ trace. The clamp is now just a log10 non-positive guard.

## Scope
Design discussed in chat before implementation: 5-band split (Sub-bass/Bass/Mid/Presence/Treble), add-band buttons respect the current zoom, and a 6-way segmented control with abbreviated labels. Placement went through two iterations — footer row first, then moved to float centered on top of the graph itself.

Version bumped 0.47.0 → 0.48.0, CHANGELOG updated.

## Test plan
- [x] `swift build` — clean, only pre-existing unrelated warnings
- [x] `install.sh` + launch verification — app launches successfully
- [x] Drove the running app: confirmed each zoom level (Full/Sub/Bass/Mid/Pres/Treb) rescales gridlines and axis labels to the correct range, dragging a knob while zoomed clamps to the visible window without crashing, control stays in place and clickable across zoom changes and redraws
- [x] Confirmed the floating control doesn't overlap the dB axis corner labels or the curve
- [x] Confirmed the spectrum-trace plateau bug is fixed across Bass/Sub/Treble/Mid (Mid stress-tests both edges being off-screen simultaneously)