### PR TITLE
feat: add native sidebar as an alternative preset picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.49.0] - 2026-07-25
+
+### Added
+- Native sidebar as an alternative to the toolbar's menu-based preset picker (#104): lists Favorites/Built-in/Custom presets, toggled from a new toolbar button, and stays in sync with the toolbar picker and menu bar dropdown automatically since it reads from the same `PresetStore`. Shown/hidden state persists across launches, off by default so existing users see no change. The window grows/shrinks by the sidebar's width when toggled so the graph doesn't get squeezed
+- Deleting or hiding a preset from the sidebar works even when it isn't the currently active one — the toolbar's Delete button only ever handled the active preset, so this generalizes that logic (`DreamViewModel.deletePreset(id:)`)
+
 ## [0.48.0] - 2026-07-25
 
 ### Added

--- a/Sources/iQualize/DreamUI/DreamHostingView.swift
+++ b/Sources/iQualize/DreamUI/DreamHostingView.swift
@@ -8,9 +8,12 @@ enum DreamHostingView {
     static func makeWindow(viewModel: DreamViewModel) -> EQWindow {
         // Default size matches the smallest comfortable layout for the toolbar + 10-band readouts.
         // Min is just below that so you can still nudge tighter; the band cells stretch to fill
-        // whatever width is available.
+        // whatever width is available. If the preset sidebar (issue #104) was left open last
+        // launch, both grow by its width up front so the canvas doesn't open pre-squeezed —
+        // toggling it at runtime instead resizes the live window (see `DreamRootView`).
+        let sidebarExtra: CGFloat = viewModel.presetSidebarVisible ? PresetSidebarView.width : 0
         let window = EQWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 880, height: 600),
+            contentRect: NSRect(x: 0, y: 0, width: 880 + sidebarExtra, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
@@ -19,7 +22,7 @@ enum DreamHostingView {
         window.titleVisibility = .visible
         window.center()
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 820, height: 560)
+        window.minSize = NSSize(width: 820 + sidebarExtra, height: 560)
 
         // Wire window's UndoManager into the view model
         viewModel.undoManager = window.undoManager

--- a/Sources/iQualize/DreamUI/DreamRootView.swift
+++ b/Sources/iQualize/DreamUI/DreamRootView.swift
@@ -10,18 +10,24 @@ struct DreamRootView: View {
         let resolvedScheme: ColorScheme = vm.theme.colorScheme ?? systemScheme
         let theme = DreamTheme(scheme: resolvedScheme)
 
-        VStack(spacing: 0) {
-            DreamToolbar(vm: vm)
-                .padding(.top, 6)
-            VStack(spacing: 0) {
-                EQCanvasView(vm: vm)
-                EQReadoutGrid(vm: vm)
+        HStack(spacing: 0) {
+            if vm.presetSidebarVisible {
+                PresetSidebarView(vm: vm)
+                theme.line.frame(width: 1)
             }
-            .overlay(alignment: .top)    { theme.line.frame(height: 1) }
-            .overlay(alignment: .bottom) { theme.line.frame(height: 1) }
-            .padding(.vertical, 6)
-            DreamFooter(vm: vm)
-                .padding(.bottom, 14)
+            VStack(spacing: 0) {
+                DreamToolbar(vm: vm)
+                    .padding(.top, 6)
+                VStack(spacing: 0) {
+                    EQCanvasView(vm: vm)
+                    EQReadoutGrid(vm: vm)
+                }
+                .overlay(alignment: .top)    { theme.line.frame(height: 1) }
+                .overlay(alignment: .bottom) { theme.line.frame(height: 1) }
+                .padding(.vertical, 6)
+                DreamFooter(vm: vm)
+                    .padding(.bottom, 14)
+            }
         }
         .background(theme.bgWindow)
         .environment(\.dreamTheme, theme)
@@ -31,6 +37,7 @@ struct DreamRootView: View {
         .onChange(of: systemScheme) { _, _ in
             if vm.theme == .auto { applyWindowAppearance(scheme: systemScheme) }
         }
+        .onChange(of: vm.presetSidebarVisible) { _, visible in adjustWindowForSidebar(visible: visible) }
         .background(
             KeyEventHandler(vm: vm)
         )
@@ -47,6 +54,21 @@ struct DreamRootView: View {
         case .dark:
             window.appearance = NSAppearance(named: .darkAqua)
         }
+    }
+
+    /// Grows/shrinks the window by exactly the sidebar's width when it's toggled at runtime, so
+    /// the canvas keeps its comfortable width instead of getting squeezed. The window's initial
+    /// size already accounts for a sidebar that's visible on launch (`DreamHostingView`); this
+    /// only needs to handle the live toggle.
+    private func adjustWindowForSidebar(visible: Bool) {
+        guard let window = NSApp.windows.first(where: { $0.title.isEmpty || $0.title.contains("iQualize") }) else { return }
+        let delta = PresetSidebarView.width
+        var minSize = window.minSize
+        minSize.width += visible ? delta : -delta
+        window.minSize = minSize
+        var frame = window.frame
+        frame.size.width += visible ? delta : -delta
+        window.setFrame(frame, display: true, animate: true)
     }
 }
 

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -10,6 +10,9 @@ struct DreamToolbar: View {
     var body: some View {
         HStack(spacing: 6) {
             DreamToolbarGroup {
+                sidebarToggleGroup
+            }
+            DreamToolbarGroup {
                 undoRedoGroup
             }
             DreamToolbarGroup {
@@ -23,6 +26,17 @@ struct DreamToolbar: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(theme.bgToolbar)
+    }
+
+    @ViewBuilder
+    private var sidebarToggleGroup: some View {
+        Button(action: { vm.togglePresetSidebar() }) {
+            Image(systemName: "sidebar.left")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(vm.presetSidebarVisible ? theme.accent : theme.text)
+        }
+        .controlSize(.regular)
+        .help(vm.presetSidebarVisible ? "Hide Preset Sidebar" : "Show Preset Sidebar")
     }
 
     @ViewBuilder

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -39,6 +39,9 @@ final class DreamViewModel {
     var zoomRange: ZoomRange = .full
     var theme: DreamThemePreference = .auto
     var editing: EditingTarget?
+    /// Whether the native preset sidebar (issue #104) is shown, as an alternative to the
+    /// toolbar's menu-based picker.
+    var presetSidebarVisible: Bool = false
 
     // MARK: - Audio mirror (rebuilt from audioEngine on change)
 
@@ -122,6 +125,7 @@ final class DreamViewModel {
         if let raw = s.dreamTheme, let t = DreamThemePreference(rawValue: raw) { theme = t }
         snapToSemitone = s.snapToSemitone
         zoomRange = s.zoomRange.flatMap(ZoomRange.init(rawValue:)) ?? .full
+        presetSidebarVisible = s.presetSidebarVisible
         bandwidthDisplay = s.showBandwidthAsQ ? .q : .oct
         peakLimiter = s.peakLimiter
         bypass = s.bypassed
@@ -155,6 +159,13 @@ final class DreamViewModel {
     func persistZoomRange() {
         var s = iQualizeState.load()
         s.zoomRange = zoomRange.rawValue
+        s.save()
+    }
+
+    func togglePresetSidebar() {
+        presetSidebarVisible.toggle()
+        var s = iQualizeState.load()
+        s.presetSidebarVisible = presetSidebarVisible
         s.save()
     }
 
@@ -648,32 +659,41 @@ final class DreamViewModel {
         s.save()
     }
 
-    /// Confirms before deleting — a built-in is hidden (recoverable from the Preset Browser),
-    /// a custom preset is removed outright. Doesn't route through `confirmDiscardIfNeeded`:
-    /// offering to save unsaved edits first would be pointless when the whole preset is about
-    /// to be removed.
+    /// Confirms before deleting the active preset — a built-in is hidden (recoverable from the
+    /// Preset Browser), a custom preset is removed outright.
     func deleteCurrentPreset() {
         guard activePresetID != EQPresetData.flat.id else { return }
+        deletePreset(id: activePresetID)
+    }
+
+    /// Confirms before deleting any preset by id, active or not — the sidebar (issue #104) can
+    /// delete/hide a row that isn't the one currently loaded, which the toolbar's Delete button
+    /// (always the active preset) never had to handle. Doesn't route through
+    /// `confirmDiscardIfNeeded`: offering to save unsaved edits first would be pointless when
+    /// the whole preset is about to be removed.
+    func deletePreset(id: UUID) {
+        guard id != EQPresetData.flat.id, let preset = presetStore.preset(for: id) else { return }
+        let isActive = id == activePresetID
         let alert = NSAlert()
-        alert.messageText = "Delete \"\(presetName)\"?"
-        alert.informativeText = isBuiltIn
+        alert.messageText = "Delete \"\(preset.name)\"?"
+        alert.informativeText = preset.isBuiltIn
             ? "This hides it from the picker. You can bring it back later from the Preset Browser."
-            : isModified
+            : (isActive && isModified)
                 ? "This removes it and discards your unsaved changes. This can't be undone."
                 : "This can't be undone."
         alert.addButton(withTitle: "Delete")
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        performDeleteCurrentPreset()
+        performDeletePreset(id: id, wasBuiltIn: preset.isBuiltIn, isActive: isActive)
     }
 
-    private func performDeleteCurrentPreset() {
-        guard activePresetID != EQPresetData.flat.id else { return }
-        if isBuiltIn {
-            presetStore.hideBuiltInPreset(id: activePresetID)
+    private func performDeletePreset(id: UUID, wasBuiltIn: Bool, isActive: Bool) {
+        if wasBuiltIn {
+            presetStore.hideBuiltInPreset(id: id)
         } else {
-            presetStore.deleteCustomPreset(id: activePresetID)
+            presetStore.deleteCustomPreset(id: id)
         }
+        guard isActive else { return }
         let old = audioEngine.activePreset
         audioEngine.activePreset = .flat
         savedSnapshot = .flat

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -51,7 +51,7 @@ struct PresetBrowserView: View {
         // split view's navigation behavior.
         HStack(spacing: 0) {
             VStack(spacing: 0) {
-                searchField
+                PresetSearchField(text: $searchText)
                 Divider()
                 sidebarList
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -78,29 +78,6 @@ struct PresetBrowserView: View {
         // otherwise filters the iQualize tab and hides deleted built-ins that are
         // actually there, ready to restore (#115).
         .onChange(of: catalog) { searchText = "" }
-    }
-
-    // MARK: - Search
-
-    private var searchField: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-            TextField("Search", text: $searchText)
-                .textFieldStyle(.plain)
-            if !searchText.isEmpty {
-                Button {
-                    searchText = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .background(.background)
     }
 
     // MARK: - Sidebar list

--- a/Sources/iQualize/DreamUI/PresetPickerButton.swift
+++ b/Sources/iQualize/DreamUI/PresetPickerButton.swift
@@ -46,7 +46,7 @@ struct PresetPickerButton: NSViewRepresentable {
                 onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }
             )
             PresetMenuBuilder.addPresetSections(
-                to: menu, builtIn: vm.presetStore.allPresets.filter(\.isBuiltIn), custom: vm.presetStore.customPresets,
+                to: menu, builtIn: vm.presetStore.builtInPresets, custom: vm.presetStore.customPresets,
                 favoriteIDs: Set(vm.presetStore.favoritePresetIDs), activePresetID: vm.activePresetID,
                 onSelect: { [weak self] id in self?.select(id); menu.cancelTracking() },
                 onToggleFavorite: { [weak self] id in self?.toggleFavorite(id) ?? false }

--- a/Sources/iQualize/DreamUI/PresetSearchField.swift
+++ b/Sources/iQualize/DreamUI/PresetSearchField.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Search field with a leading magnifying-glass icon and a trailing clear button, styled as a
+/// fixed sibling pinned above a scrolling list — not `.searchable`, which renders as a
+/// transparent overlay inside a `List` and lets rows draw straight through it (issue #108).
+/// Shared by the Preset Browser sidebar and the main window's preset sidebar.
+struct PresetSearchField: View {
+    @Binding var text: String
+    var placeholder: String = "Search"
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.background)
+    }
+}

--- a/Sources/iQualize/DreamUI/PresetSidebarView.swift
+++ b/Sources/iQualize/DreamUI/PresetSidebarView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Native sidebar alternative to the toolbar's menu-based preset picker (issue #104). Lists the
+/// same presets the picker shows — favorites, then built-in, then custom — reading straight from
+/// the same `DreamViewModel`/`PresetStore` instances the toolbar picker uses, so selecting,
+/// favoriting, and deleting here need no separate sync path: `@Observable` propagation keeps the
+/// toolbar button, the menu bar dropdown, and this list in lockstep automatically.
+@available(macOS 14.2, *)
+struct PresetSidebarView: View {
+    @Bindable var vm: DreamViewModel
+
+    @Environment(\.dreamTheme) private var theme
+    @State private var searchText = ""
+
+    /// Fixed width of the sidebar column, including its trailing divider — shared with
+    /// `DreamRootView`/`DreamHostingView` so the window grows/shrinks by exactly this much
+    /// when the sidebar is toggled.
+    static let width: CGFloat = 220
+
+    private var favorites: [EQPresetData] { filtered(vm.presetStore.favoritePresets) }
+    private var builtIn: [EQPresetData] { filtered(vm.presetStore.builtInPresets) }
+    private var custom: [EQPresetData] { filtered(vm.presetStore.customPresets) }
+
+    private func filtered(_ presets: [EQPresetData]) -> [EQPresetData] {
+        guard !searchText.isEmpty else { return presets }
+        return presets.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    /// Two-way: reflects `vm.activePresetID` so the list highlight tracks preset changes made
+    /// from the toolbar picker or menu bar, and routes a row click through `vm.loadPreset(id:)`
+    /// (unsaved-changes confirmation included) rather than mutating selection directly — if that
+    /// confirmation is cancelled, the getter simply resolves back to the unchanged id.
+    private var selection: Binding<UUID?> {
+        Binding(
+            get: { vm.activePresetID },
+            set: { newValue in
+                guard let id = newValue, id != vm.activePresetID else { return }
+                vm.loadPreset(id: id)
+            }
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PresetSearchField(text: $searchText)
+            Divider()
+            List(selection: selection) {
+                if !favorites.isEmpty {
+                    Section("Favorites") {
+                        ForEach(favorites) { row($0) }
+                    }
+                }
+                Section("Built-in") {
+                    ForEach(builtIn) { row($0) }
+                }
+                if !custom.isEmpty {
+                    Section("Custom") {
+                        ForEach(custom) { row($0) }
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+        }
+        .frame(width: Self.width - 1)
+        .background(theme.bgToolbar)
+    }
+
+    @ViewBuilder
+    private func row(_ preset: EQPresetData) -> some View {
+        let isFavorite = vm.presetStore.isFavorite(preset.id)
+        HStack(spacing: 6) {
+            Text(preset.name)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer()
+            Button {
+                vm.presetStore.toggleFavorite(preset.id)
+            } label: {
+                Image(systemName: isFavorite ? "star.fill" : "star")
+                    .foregroundStyle(isFavorite ? theme.accent : Color.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .tag(preset.id)
+        .contextMenu {
+            Button(isFavorite ? "Remove Favorite" : "Add to Favorites") {
+                vm.presetStore.toggleFavorite(preset.id)
+            }
+            if preset.id != EQPresetData.flat.id {
+                Divider()
+                Button(preset.isBuiltIn ? "Hide" : "Delete") {
+                    vm.deletePreset(id: preset.id)
+                }
+            }
+        }
+    }
+}

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -39,6 +39,9 @@ struct iQualizeState: Codable {
     var snapToSemitone: Bool
     /// EQ canvas zoom range, e.g. "full" | "subBass" | "bass" | "mid" | "presence" | "treble". Nil = full.
     var zoomRange: String?
+    /// Whether the main window's native preset sidebar (issue #104) is shown. Defaults to false —
+    /// it's an alternative to the toolbar picker, not a replacement, so existing users see no change.
+    var presetSidebarVisible: Bool
 
     static let defaultState = iQualizeState(
         isEnabled: false,
@@ -63,12 +66,13 @@ struct iQualizeState: Codable {
         postEqFillEnabled: true,
         dreamTheme: nil,
         snapToSemitone: false,
-        zoomRange: nil
+        zoomRange: nil,
+        presetSidebarVisible: false
     )
 
     private static let key = "com.iqualize.state"
 
-    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = false, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false, zoomRange: String? = nil) {
+    init(isEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = false, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false, zoomRange: String? = nil, presetSidebarVisible: Bool = false) {
         self.isEnabled = isEnabled
         self.selectedPresetID = selectedPresetID
         self.peakLimiter = peakLimiter
@@ -96,6 +100,7 @@ struct iQualizeState: Codable {
         self.dreamTheme = dreamTheme
         self.snapToSemitone = snapToSemitone
         self.zoomRange = zoomRange
+        self.presetSidebarVisible = presetSidebarVisible
     }
 
     init(from decoder: Decoder) throws {
@@ -127,6 +132,7 @@ struct iQualizeState: Codable {
         dreamTheme = try? container.decode(String.self, forKey: .dreamTheme)
         snapToSemitone = (try? container.decode(Bool.self, forKey: .snapToSemitone)) ?? false
         zoomRange = try? container.decode(String.self, forKey: .zoomRange)
+        presetSidebarVisible = (try? container.decode(Bool.self, forKey: .presetSidebarVisible)) ?? false
     }
 
     static func load() -> iQualizeState {

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.48.0</string>
+	<string>0.49.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.48.0</string>
+	<string>0.49.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -108,7 +108,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         let presetSubmenu = NSMenu()
         PresetMenuBuilder.addPresetSections(
             to: presetSubmenu,
-            builtIn: presetStore.allPresets.filter(\.isBuiltIn),
+            builtIn: presetStore.builtInPresets,
             custom: presetStore.customPresets,
             favoriteIDs: Set(presetStore.favoritePresetIDs),
             activePresetID: activePresetID,

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -17,6 +17,13 @@ final class PresetStore {
         EQPresetData.builtInPresets.filter { !hiddenBuiltInPresetIDs.contains($0.id) } + customPresets
     }
 
+    /// Built-in presets currently visible in the picker (i.e. not hidden). Shared by every
+    /// preset-list surface (menu bar dropdown, in-window picker, sidebar) so they can't drift
+    /// out of sync on filtering.
+    var builtInPresets: [EQPresetData] {
+        allPresets.filter(\.isBuiltIn)
+    }
+
     /// Favorited presets, in favorite order. Skips IDs that no longer resolve to a preset.
     var favoritePresets: [EQPresetData] {
         favoritePresetIDs.compactMap { preset(for: $0) }


### PR DESCRIPTION
## Summary
- Adds a native, toggleable sidebar to the main window listing Favorites/Built-in/Custom presets, as an alternative to the existing toolbar picker (kept unchanged) — closes #104.
- Sidebar selection, favoriting, and deletion reuse the same `DreamViewModel`/`PresetStore` instances the toolbar picker uses, so it stays in sync with the toolbar button and menu bar dropdown automatically via `@Observable` — no new sync plumbing needed.
- Generalizes `DreamViewModel.deleteCurrentPreset()` into `deletePreset(id:)` so the sidebar can delete/hide a preset that isn't the one currently loaded (the toolbar's Delete button only ever handled the active preset).
- Extracts a shared `PresetSearchField` and a `PresetStore.builtInPresets` helper so the Preset Browser, the menu bar dropdown, and the new sidebar stop duplicating the same filtering logic.
- Shown/hidden state persists across launches (`iQualizeState.presetSidebarVisible`), defaulting to `false` so existing users see no change on upgrade. The window grows/shrinks by the sidebar's width when toggled so the graph doesn't get squeezed.
- Version bump 0.48.0 → 0.49.0 (minor) + CHANGELOG entry per repo convention.

## Test plan
- [x] `swift build` — clean build, no new warnings
- [x] `pkill -x iQualize; bash install.sh && open /Applications/iQualize.app` — launches successfully
- [x] Toggled the sidebar via the new toolbar button; window resizes by exactly the sidebar width in both directions, repeatably
- [x] Sidebar lists the full Favorites/Built-in/Custom set matching the toolbar picker's contents
- [x] Selected a preset from the sidebar; confirmed via `iqualize status` (CLI) and the window title that the active preset and toolbar stay in sync
- [ ] Manual: favorite/unfavorite and delete/hide from the sidebar's context menu (implemented and code-reviewed against the existing toolbar Delete logic; not exercised interactively — AppleScript UI-scripting can't reliably synthesize right-clicks on SwiftUI List rows in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)