### PR TITLE
fix: compensate tap headroom attenuation on multi-channel outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.48.1] - 2026-07-26
+
+### Fixed
+- Playback through iQualize was much quieter than without it on multi-channel output devices — -6 dB on 4-channel interfaces, -9.5 dB on 6-channel devices like MacBook Pro speakers, -12 dB on 8-channel. Core Audio attenuates the capture tap's stereo mixdown by the output device's stereo-pair count for headroom; the lost gain is now multiplied back in at the source node, ahead of the EQ and limiter. Stereo devices are unaffected. Reported with the diagnosis and verified on a 4-channel Audient iD4 MKII by @iv-re (#107)
+
+### Changed
+- Re-enabled the SPM test target (`swift test`, needs full Xcode): fixed the stale preset/state tests and added coverage for the new tap-headroom compensation, the Bypass gain neutralization from #118, and the render callback's deinterleave/gain math. Added an end-to-end BlackHole loopback harness (`Spikes/TapAttenuationE2E`) that measures the OS tap attenuation and verifies unity through the app
+
 ## [0.48.0] - 2026-07-25
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -60,12 +60,13 @@ let package = Package(
                 .linkedFramework("AudioToolbox"),
             ]
         ),
-        // Requires Xcode (not just Command Line Tools) for XCTest
-        // .testTarget(
-        //     name: "iQualizeTests",
-        //     dependencies: ["iQualize"],
-        //     path: "Tests/iQualizeTests"
-        // ),
+        // Needs full Xcode for XCTest — Command Line Tools alone can't build
+        // the test bundle.
+        .testTarget(
+            name: "iQualizeTests",
+            dependencies: ["iQualize"],
+            path: "Tests/iQualizeTests"
+        ),
     ],
     swiftLanguageModes: [.v6]
 )

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -28,6 +28,10 @@ nonisolated(unsafe) private var rtScratchCapacity: Int = 0
 nonisolated(unsafe) private var rtBalanceLeft: Float = 1.0
 nonisolated(unsafe) private var rtBalanceRight: Float = 1.0
 nonisolated(unsafe) private var rtInputGain: Float = 1.0
+/// Multiplies back the stereo-pair headroom attenuation of the mixdown tap
+/// (see GainPolicy.tapHeadroomCompensation). Applied unconditionally — the tap
+/// attenuates in Bypass too, so Bypass must compensate to sound like app-off.
+nonisolated(unsafe) private var rtVolumeCompensation: Float = 1.0
 /// Per-channel biquad filter chains for split channel mode.
 /// Only active when rtSplitChannelActive is true.
 /// Channels 2+ (e.g. 5.1/7.1 surround) pass through unprocessed — per-channel
@@ -65,11 +69,9 @@ private func renderCallback(
 
     for i in 0..<bufferList.count {
         guard let outData = bufferList[i].mData?.assumingMemoryBound(to: Float.self) else { continue }
-        let channelIndex = i
-        let gain = channelIndex == 0 ? rtBalanceLeft : rtBalanceRight
-        for f in 0..<frames {
-            outData[f] = scratch[f * ch + channelIndex] * rtInputGain * gain
-        }
+        let balance = i == 0 ? rtBalanceLeft : rtBalanceRight
+        deinterleaveChannel(scratch, into: outData, channel: i, channelCount: ch,
+                            frames: frames, gain: rtInputGain * balance * rtVolumeCompensation)
     }
 
     // Apply per-channel biquad EQ when split channel mode is active.
@@ -84,6 +86,22 @@ private func renderCallback(
     }
 
     return noErr
+}
+
+/// Copy one channel out of an interleaved buffer, applying the channel's total
+/// linear gain. The render callback's only per-sample math; exercised directly
+/// by the unit tests with synthetic buffers.
+func deinterleaveChannel(
+    _ input: UnsafePointer<Float>,
+    into output: UnsafeMutablePointer<Float>,
+    channel: Int,
+    channelCount: Int,
+    frames: Int,
+    gain: Float
+) {
+    for f in 0..<frames {
+        output[f] = input[f * channelCount + channel] * gain
+    }
 }
 
 // MARK: - AudioEngine
@@ -173,23 +191,17 @@ final class AudioEngine {
 
     /// Bypass is a true passthrough: In, Out, and Balance are neutralized while
     /// bypassed and restored on un-bypass, without touching the stored/displayed
-    /// control values (see #118).
+    /// control values (see #118). The math lives in GainPolicy.
     private func updateInputGain() {
-        rtInputGain = bypassed ? 1.0 : powf(10, inputGainDB / 20)
+        rtInputGain = GainPolicy.inputGain(dB: inputGainDB, bypassed: bypassed)
     }
 
     private func updateBalance() {
-        if bypassed {
-            rtBalanceLeft = 1.0
-            rtBalanceRight = 1.0
-        } else {
-            rtBalanceLeft = balance <= 0 ? 1.0 : 1.0 - balance
-            rtBalanceRight = balance >= 0 ? 1.0 : 1.0 + balance
-        }
+        (rtBalanceLeft, rtBalanceRight) = GainPolicy.balanceGains(balance, bypassed: bypassed)
     }
 
     private func updateOutputGain() {
-        outputGainEQ?.globalGain = bypassed ? 0 : outputGainDB
+        outputGainEQ?.globalGain = GainPolicy.outputGainDB(outputGainDB, bypassed: bypassed)
     }
 
     var maxGainDB: Float = 12
@@ -326,6 +338,17 @@ final class AudioEngine {
         avEngine.connect(outputGainNode, to: limiterNode, format: format)
         avEngine.connect(limiterNode, to: avEngine.outputNode, format: format)
 
+        // The capture helper's stereo mixdown tap is attenuated by Core Audio
+        // on multi-channel output devices (#107) — multiply the loss back in
+        // at the source node, ahead of the EQ and limiter so the limiter still
+        // guards the restored level. Recomputed on every start(); device
+        // switches funnel through restartTap() -> stop() + start().
+        let outputChannels = Int(avEngine.outputNode.outputFormat(forBus: 0).channelCount)
+        rtVolumeCompensation = GainPolicy.tapHeadroomCompensation(outputChannels: outputChannels)
+        os_log(.default, log: appLog,
+               "output hw channels: %{public}d  tap headroom compensation: x%{public}.1f",
+               outputChannels, rtVolumeCompensation)
+
         try avEngine.start()
         self.engine = avEngine
 
@@ -383,6 +406,7 @@ final class AudioEngine {
         rtCaptureClient = nil
         rtBiquadChainL = nil
         rtBiquadChainR = nil
+        rtVolumeCompensation = 1.0
 
         // Remove spectrum taps before stopping engine
         sourceNode?.removeTap(onBus: 0)
@@ -427,6 +451,7 @@ final class AudioEngine {
         rtCaptureClient = nil
         rtBiquadChainL = nil
         rtBiquadChainR = nil
+        rtVolumeCompensation = 1.0
         sourceNode?.removeTap(onBus: 0)
         eq?.removeTap(onBus: 0)
         sourceNode = nil

--- a/Sources/iQualize/GainPolicy.swift
+++ b/Sources/iQualize/GainPolicy.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Pure gain math for the render path. AudioEngine's main-thread setters call
+/// these before writing the results into the rt* globals the render callback
+/// reads; the unit tests call them directly.
+enum GainPolicy {
+
+    /// Compensation for the headroom attenuation Core Audio applies to stereo
+    /// mixdown taps on multi-channel output devices: the tap scales the mix by
+    /// 1/(stereo pairs), so 2ch plays at 0 dB but 4ch at -6 dB, 6ch at -9.5 dB,
+    /// 8ch at -12 dB (#107, Apple Developer Forums thread 806799). Multiplying
+    /// by the pair count restores unity. 1.0 on stereo and mono devices. Odd
+    /// channel counts floor to the nearest full pair — the attenuation is only
+    /// documented for even counts.
+    static func tapHeadroomCompensation(outputChannels: Int) -> Float {
+        Float(max(1, outputChannels / 2))
+    }
+
+    /// Input gain as a linear factor. Unity while bypassed — Bypass is a true
+    /// passthrough (#118).
+    static func inputGain(dB: Float, bypassed: Bool) -> Float {
+        bypassed ? 1.0 : powf(10, dB / 20)
+    }
+
+    /// Per-channel balance factors. -1 = full left, 0 = center, +1 = full
+    /// right; panning attenuates the opposite channel. Neutral while bypassed
+    /// (#118).
+    static func balanceGains(_ balance: Float, bypassed: Bool) -> (left: Float, right: Float) {
+        if bypassed { return (1.0, 1.0) }
+        return (balance <= 0 ? 1.0 : 1.0 - balance,
+                balance >= 0 ? 1.0 : 1.0 + balance)
+    }
+
+    /// Output gain in dB for the output-gain EQ node. 0 dB while bypassed
+    /// (#118).
+    static func outputGainDB(_ dB: Float, bypassed: Bool) -> Float {
+        bypassed ? 0 : dB
+    }
+}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -6,20 +6,20 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>iQualize</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.iqualize.app</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleIconFile</key>
-	<string>AppIcon</string>
 	<key>CFBundleName</key>
 	<string>iQualize</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.48.0</string>
+	<string>0.48.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.48.0</string>
+	<string>0.48.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Spikes/TapAttenuationE2E/.gitignore
+++ b/Spikes/TapAttenuationE2E/.gitignore
@@ -1,0 +1,2 @@
+setoutput
+sine.wav

--- a/Spikes/TapAttenuationE2E/e2e-tap-test.sh
+++ b/Spikes/TapAttenuationE2E/e2e-tap-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# End-to-end verification of the #107 tap headroom compensation.
+#
+# Core Audio attenuates a stereo mixdown tap by the output device's
+# stereo-pair count (Apple Developer Forums thread 806799); iQualize
+# compensates by the same factor (GainPolicy.tapHeadroomCompensation).
+# This measures the real OS behavior — rerun after macOS updates: if Apple
+# ever removes the attenuation, the compensation over-boosts by the pair
+# count and this test catches it before users hear clipping.
+#
+# Routes system audio to BlackHole (a virtual loopback device), plays a
+# -30 dBFS sine, and records what actually arrives at the device:
+#   baseline  — iQualize killed: afplay reaches BlackHole directly
+#   iqualize  — iQualize running (Bypass on): the tap mutes afplay's direct
+#               feed, so the recording is exactly what iQualize renders
+# If the attenuation exists and the compensation restores it, baseline and
+# iqualize RMS match (within ~1 dB).
+#   iqualize ~= baseline        -> unity: attenuation exists, compensation correct
+#   iqualize ~= baseline + N dB -> over-boost: less OS attenuation than compensated
+#   iqualize ~= baseline - N dB -> under-compensation
+#
+# Needs: brew install sox blackhole-16ch (blackhole-2ch for the stereo
+# control run: ./e2e-tap-test.sh "BlackHole 2ch"). First run triggers a
+# macOS microphone-permission prompt — deny it and the capture is silent.
+# Takes over the default output for ~20 s and restarts iQualize; restores
+# both on exit.
+set -u
+DIR="$(cd "$(dirname "$0")" && pwd)"
+DEVICE="${1:-BlackHole 16ch}"
+SINE="$DIR/sine.wav"
+APP=/Applications/iQualize.app
+
+command -v sox >/dev/null || { echo "FAIL: sox not installed (brew install sox)"; exit 1; }
+[ -x "$DIR/setoutput" ] && [ "$DIR/setoutput" -nt "$DIR/setoutput.swift" ] \
+    || swiftc -O -framework CoreAudio -o "$DIR/setoutput" "$DIR/setoutput.swift" || exit 1
+[ -f "$SINE" ] || python3 "$DIR/gen_sine.py" "$SINE" || exit 1
+"$DIR/setoutput" 2>/dev/null | grep -qi "${DEVICE}" \
+    || { echo "FAIL: output device \"$DEVICE\" not found (brew install --cask blackhole-16ch)"; exit 1; }
+
+rms() { # capture 4s from $DEVICE (ch 1+2 only), print RMS dB
+    sox -q -t coreaudio "$DEVICE" -n trim 0 4 remix 1,2 stats 2>&1 \
+        | awk '/^RMS lev dB/ {print $4}'
+}
+
+play_and_measure() {
+    afplay "$SINE" &
+    local afpid=$!
+    sleep 1
+    local level
+    level=$(rms)
+    kill $afpid 2>/dev/null
+    wait $afpid 2>/dev/null
+    echo "$level"
+}
+
+PREV_OUTPUT=$("$DIR/setoutput" --current)
+restore() {
+    "$DIR/setoutput" "$PREV_OUTPUT" >/dev/null 2>&1
+    pgrep -x iQualize >/dev/null || open "$APP"
+}
+trap restore EXIT
+
+echo "test device: $DEVICE"
+echo "restoring output to: $PREV_OUTPUT (on exit)"
+"$DIR/setoutput" "$DEVICE" >/dev/null || exit 1
+
+# --- baseline: no iQualize in the path ---
+pkill -x iQualize; sleep 1
+BASELINE=$(play_and_measure)
+echo "baseline RMS (app off):     ${BASELINE} dB"
+
+# --- through iQualize, Bypass on ---
+open "$APP"; sleep 3
+pgrep -x iQualize >/dev/null || { echo "FAIL: iQualize did not start"; exit 1; }
+"$APP/Contents/Resources/bin/iqualize" bypass on >/dev/null 2>&1
+sleep 1
+THROUGH=$(play_and_measure)
+echo "iQualize RMS (bypass on):   ${THROUGH} dB"
+
+DELTA=$(echo "$THROUGH $BASELINE" | awk '{printf "%+.2f", $1 - $2}')
+echo "delta:                      ${DELTA} dB"
+echo "$DELTA" | awk '{d=$1; if (d<0) d=-d; exit !(d<=1.0)}' \
+    && echo "PASS: unity within 1 dB — OS attenuation exists and is fully compensated" \
+    || echo "FAIL: not unity — see delta (positive = over-boost, negative = under-compensation)"

--- a/Spikes/TapAttenuationE2E/gen_sine.py
+++ b/Spikes/TapAttenuationE2E/gen_sine.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Generate the e2e test tone: 440 Hz stereo sine at -30 dBFS, 48 kHz, 8 s.
+
+-30 dBFS leaves 18 dB of headroom, so even a wrongly-uncompensated x8 boost
+(16ch device) lands at -12 dBFS without clipping — every failure mode stays
+measurable instead of flat-topping.
+"""
+import math
+import struct
+import sys
+import wave
+
+SR = 48000
+SECONDS = 8
+FREQ = 440.0
+AMP_DB = -30.0
+
+amp = 10 ** (AMP_DB / 20)
+path = sys.argv[1] if len(sys.argv) > 1 else "sine.wav"
+
+w = wave.open(path, "w")
+w.setnchannels(2)
+w.setsampwidth(2)
+w.setframerate(SR)
+frames = bytearray()
+for i in range(SR * SECONDS):
+    s = int(amp * 32767 * math.sin(2 * math.pi * FREQ * i / SR))
+    frames += struct.pack("<hh", s, s)
+w.writeframes(bytes(frames))
+w.close()
+print(f"{path}: {SECONDS}s 440 Hz sine at {AMP_DB} dBFS, {SR} Hz stereo")

--- a/Spikes/TapAttenuationE2E/setoutput.swift
+++ b/Spikes/TapAttenuationE2E/setoutput.swift
@@ -1,0 +1,76 @@
+// Scratch tool: set the default output device by name substring.
+// Usage: setoutput <name-substring>   (or no args to list output devices,
+//        or --current to print the current default output device name)
+import CoreAudio
+import Foundation
+
+func propAddress(_ selector: AudioObjectPropertySelector,
+                 scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(mSelector: selector, mScope: scope,
+                               mElement: kAudioObjectPropertyElementMain)
+}
+
+func allDevices() -> [AudioObjectID] {
+    var addr = propAddress(kAudioHardwarePropertyDevices)
+    var size: UInt32 = 0
+    guard AudioObjectGetPropertyDataSize(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size) == noErr else { return [] }
+    var ids = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+    guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &ids) == noErr else { return [] }
+    return ids
+}
+
+func deviceName(_ id: AudioObjectID) -> String {
+    var addr = propAddress(kAudioDevicePropertyDeviceNameCFString)
+    var name: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    let err = withUnsafeMutablePointer(to: &name) { ptr in
+        AudioObjectGetPropertyData(id, &addr, 0, nil, &size, ptr)
+    }
+    return err == noErr ? (name as String) : "?"
+}
+
+func outputChannelCount(_ id: AudioObjectID) -> Int {
+    var addr = propAddress(kAudioDevicePropertyStreamConfiguration, scope: kAudioObjectPropertyScopeOutput)
+    var size: UInt32 = 0
+    guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size) == noErr, size > 0 else { return 0 }
+    let raw = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
+    defer { raw.deallocate() }
+    guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, raw) == noErr else { return 0 }
+    let abl = UnsafeMutableAudioBufferListPointer(raw.assumingMemoryBound(to: AudioBufferList.self))
+    return abl.reduce(0) { $0 + Int($1.mNumberChannels) }
+}
+
+let outputs = allDevices().map { (id: $0, name: deviceName($0), ch: outputChannelCount($0)) }
+    .filter { $0.ch > 0 }
+
+if CommandLine.arguments.count > 1, CommandLine.arguments[1] == "--current" {
+    var addr = propAddress(kAudioHardwarePropertyDefaultOutputDevice)
+    var id = AudioObjectID(kAudioObjectUnknown)
+    var size = UInt32(MemoryLayout<AudioObjectID>.size)
+    guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &id) == noErr else {
+        exit(1)
+    }
+    print(deviceName(id))
+    exit(0)
+}
+
+guard CommandLine.arguments.count > 1 else {
+    for d in outputs { print("\(d.id)\t\(d.ch)ch\t\(d.name)") }
+    exit(0)
+}
+
+let query = CommandLine.arguments[1].lowercased()
+guard let target = outputs.first(where: { $0.name.lowercased().contains(query) }) else {
+    FileHandle.standardError.write("no output device matching \"\(query)\"\n".data(using: .utf8)!)
+    exit(1)
+}
+
+var addr = propAddress(kAudioHardwarePropertyDefaultOutputDevice)
+var id = target.id
+let err = AudioObjectSetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil,
+                                     UInt32(MemoryLayout<AudioObjectID>.size), &id)
+guard err == noErr else {
+    FileHandle.standardError.write("set default output failed: OSStatus \(err)\n".data(using: .utf8)!)
+    exit(1)
+}
+print("default output -> \(target.name) (\(target.ch)ch)")

--- a/Tests/iQualizeTests/EQPresetTests.swift
+++ b/Tests/iQualizeTests/EQPresetTests.swift
@@ -12,10 +12,10 @@ final class EQBandTests: XCTestCase {
     }
 
     func testGainLabel() {
-        XCTAssertEqual(EQBand(frequency: 1000, gain: 0).gainLabel, "0")
-        XCTAssertEqual(EQBand(frequency: 1000, gain: 6).gainLabel, "+6")
-        XCTAssertEqual(EQBand(frequency: 1000, gain: -3).gainLabel, "-3")
-        XCTAssertEqual(EQBand(frequency: 1000, gain: 1.5).gainLabel, "+1.5")
+        XCTAssertEqual(EQBand(frequency: 1000, gain: 0).gainLabel, "0 dB")
+        XCTAssertEqual(EQBand(frequency: 1000, gain: 6).gainLabel, "+6 dB")
+        XCTAssertEqual(EQBand(frequency: 1000, gain: -3).gainLabel, "-3 dB")
+        XCTAssertEqual(EQBand(frequency: 1000, gain: 1.5).gainLabel, "+1.5 dB")
     }
 
     func testDefaultBandwidth() {
@@ -34,10 +34,10 @@ final class EQBandTests: XCTestCase {
 final class EQPresetDataTests: XCTestCase {
 
     func testBuiltInPresetsExist() {
-        XCTAssertEqual(EQPresetData.builtInPresets.count, 3)
-        XCTAssertTrue(EQPresetData.flat.isBuiltIn)
-        XCTAssertTrue(EQPresetData.bassBoost.isBuiltIn)
-        XCTAssertTrue(EQPresetData.vocalClarity.isBuiltIn)
+        XCTAssertEqual(EQPresetData.builtInPresets.count, 15)
+        for preset in EQPresetData.builtInPresets {
+            XCTAssertTrue(preset.isBuiltIn, "\(preset.name) must be marked built-in")
+        }
     }
 
     func testFlatIsFlat() {
@@ -45,9 +45,15 @@ final class EQPresetDataTests: XCTestCase {
         XCTAssertFalse(EQPresetData.bassBoost.isFlat)
     }
 
-    func testBuiltInPresetsHaveTenBands() {
+    func testBuiltInPresetBandCountsWithinLimits() {
+        // The classic 10-band presets keep 10 bands; the newer ones vary
+        // (Luzifer's Void 16, 0xDEADBEEF 20) but must fit the engine's cap.
+        XCTAssertEqual(EQPresetData.flat.bands.count, 10)
+        XCTAssertEqual(EQPresetData.bassBoost.bands.count, 10)
+        XCTAssertEqual(EQPresetData.vocalClarity.bands.count, 10)
         for preset in EQPresetData.builtInPresets {
-            XCTAssertEqual(preset.bands.count, 10)
+            XCTAssertGreaterThanOrEqual(preset.bands.count, EQPresetData.minBandCount)
+            XCTAssertLessThanOrEqual(preset.bands.count, EQPresetData.maxBandCount)
         }
     }
 
@@ -67,11 +73,6 @@ final class EQPresetDataTests: XCTestCase {
         XCTAssertLessThan(bands[1].gain, 0)  // 125 Hz cut
         XCTAssertGreaterThan(bands[5].gain, 0) // 1k boost
         XCTAssertGreaterThan(bands[6].gain, 0) // 2k boost
-    }
-
-    func testPreampGain() {
-        XCTAssertEqual(EQPresetData.flat.preampGain, 0)
-        XCTAssertLessThan(EQPresetData.bassBoost.preampGain, 0)
     }
 
     func testGainsWithinRange() {

--- a/Tests/iQualizeTests/GainPolicyTests.swift
+++ b/Tests/iQualizeTests/GainPolicyTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import iQualize
+
+final class GainPolicyTests: XCTestCase {
+
+    // MARK: - Tap headroom compensation (#107)
+
+    func testCompensationMatchesStereoPairCount() {
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 2), 1.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 4), 2.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 6), 3.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 8), 4.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 16), 8.0)
+    }
+
+    func testCompensationNeverDropsBelowUnity() {
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 0), 1.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 1), 1.0)
+    }
+
+    func testCompensationFloorsOddChannelCounts() {
+        // The attenuation is only documented for even channel counts (Apple
+        // Developer Forums thread 806799) — floor to the nearest full pair.
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 3), 1.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 5), 2.0)
+        XCTAssertEqual(GainPolicy.tapHeadroomCompensation(outputChannels: 7), 3.0)
+    }
+
+    // MARK: - Input gain (#118)
+
+    func testInputGainConvertsDecibels() {
+        XCTAssertEqual(GainPolicy.inputGain(dB: 0, bypassed: false), 1.0)
+        XCTAssertEqual(GainPolicy.inputGain(dB: -6, bypassed: false), 0.5012, accuracy: 0.001)
+        XCTAssertEqual(GainPolicy.inputGain(dB: 6, bypassed: false), 1.9953, accuracy: 0.001)
+        XCTAssertEqual(GainPolicy.inputGain(dB: 20, bypassed: false), 10.0, accuracy: 0.0001)
+    }
+
+    func testBypassNeutralizesInputGain() {
+        // The #107 report: a preset with negative input gain kept attenuating
+        // in Bypass. Bypass must force unity no matter the stored value.
+        XCTAssertEqual(GainPolicy.inputGain(dB: -5, bypassed: true), 1.0)
+        XCTAssertEqual(GainPolicy.inputGain(dB: 12, bypassed: true), 1.0)
+    }
+
+    // MARK: - Balance (#118)
+
+    func testBalanceCenterIsUnity() {
+        let g = GainPolicy.balanceGains(0, bypassed: false)
+        XCTAssertEqual(g.left, 1.0)
+        XCTAssertEqual(g.right, 1.0)
+    }
+
+    func testBalancePansByAttenuatingOppositeChannel() {
+        let halfRight = GainPolicy.balanceGains(0.5, bypassed: false)
+        XCTAssertEqual(halfRight.left, 0.5)
+        XCTAssertEqual(halfRight.right, 1.0)
+
+        let halfLeft = GainPolicy.balanceGains(-0.5, bypassed: false)
+        XCTAssertEqual(halfLeft.left, 1.0)
+        XCTAssertEqual(halfLeft.right, 0.5)
+
+        let fullRight = GainPolicy.balanceGains(1, bypassed: false)
+        XCTAssertEqual(fullRight.left, 0.0)
+        XCTAssertEqual(fullRight.right, 1.0)
+
+        let fullLeft = GainPolicy.balanceGains(-1, bypassed: false)
+        XCTAssertEqual(fullLeft.left, 1.0)
+        XCTAssertEqual(fullLeft.right, 0.0)
+    }
+
+    func testBypassNeutralizesBalance() {
+        let g = GainPolicy.balanceGains(1, bypassed: true)
+        XCTAssertEqual(g.left, 1.0)
+        XCTAssertEqual(g.right, 1.0)
+    }
+
+    // MARK: - Output gain (#118)
+
+    func testOutputGainPassesThroughWhenActive() {
+        XCTAssertEqual(GainPolicy.outputGainDB(-5, bypassed: false), -5)
+        XCTAssertEqual(GainPolicy.outputGainDB(3, bypassed: false), 3)
+    }
+
+    func testBypassNeutralizesOutputGain() {
+        XCTAssertEqual(GainPolicy.outputGainDB(-5, bypassed: true), 0)
+        XCTAssertEqual(GainPolicy.outputGainDB(3, bypassed: true), 0)
+    }
+
+    // MARK: - The #107 invariant
+
+    func testBypassDoesNotNeutralizeCompensation() {
+        // Bypass must sound like the app is off. The tap attenuates regardless
+        // of Bypass, so compensation stays in the render path: with every user
+        // gain neutralized, the channel gain is exactly the compensation
+        // factor. Anyone folding compensation into the bypass neutralization
+        // reintroduces the multi-channel volume drop and breaks this test.
+        let comp = GainPolicy.tapHeadroomCompensation(outputChannels: 6)
+        let input = GainPolicy.inputGain(dB: -5, bypassed: true)
+        let balance = GainPolicy.balanceGains(0.7, bypassed: true)
+        XCTAssertEqual(input * balance.left * comp, 3.0)
+        XCTAssertEqual(input * balance.right * comp, 3.0)
+    }
+}

--- a/Tests/iQualizeTests/RenderMathTests.swift
+++ b/Tests/iQualizeTests/RenderMathTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import iQualize
+
+/// Exercises deinterleaveChannel — the render callback's per-sample math —
+/// with synthetic buffers, so the production DSP path is tested without an
+/// audio device.
+final class RenderMathTests: XCTestCase {
+
+    /// Interleaved stereo: L = 0.1, 0.2, 0.3; R = -0.1, -0.2, -0.3.
+    private let stereoInput: [Float] = [0.1, -0.1, 0.2, -0.2, 0.3, -0.3]
+
+    private func extract(channel: Int, channelCount: Int, from input: [Float],
+                         frames: Int, gain: Float) -> [Float] {
+        var output = [Float](repeating: 0, count: frames)
+        input.withUnsafeBufferPointer { inPtr in
+            output.withUnsafeMutableBufferPointer { outPtr in
+                deinterleaveChannel(inPtr.baseAddress!, into: outPtr.baseAddress!,
+                                    channel: channel, channelCount: channelCount,
+                                    frames: frames, gain: gain)
+            }
+        }
+        return output
+    }
+
+    func testDeinterleavesStereo() {
+        XCTAssertEqual(extract(channel: 0, channelCount: 2, from: stereoInput, frames: 3, gain: 1.0),
+                       [0.1, 0.2, 0.3])
+        XCTAssertEqual(extract(channel: 1, channelCount: 2, from: stereoInput, frames: 3, gain: 1.0),
+                       [-0.1, -0.2, -0.3])
+    }
+
+    func testAppliesGain() {
+        let expected = [Float]([0.1, 0.2, 0.3]).map { $0 * 0.5 }
+        XCTAssertEqual(extract(channel: 0, channelCount: 2, from: stereoInput, frames: 3, gain: 0.5),
+                       expected)
+    }
+
+    func testBypassOnSixChannelDeviceTriplesTheTappedSignal() {
+        // End-to-end gain a bypassed engine applies on a 6ch device: input
+        // gain and balance neutralized (#118), compensation x3 (#107). Output
+        // must be exactly input x3 — cancelling the tap's 1/3 attenuation.
+        let gain = GainPolicy.inputGain(dB: -5, bypassed: true)
+            * GainPolicy.balanceGains(0.25, bypassed: true).left
+            * GainPolicy.tapHeadroomCompensation(outputChannels: 6)
+        let expected = [Float]([0.1, 0.2, 0.3]).map { $0 * 3.0 }
+        XCTAssertEqual(extract(channel: 0, channelCount: 2, from: stereoInput, frames: 3, gain: gain),
+                       expected)
+    }
+}


### PR DESCRIPTION
## Summary

Playback through iQualize was much quieter than without it on multi-channel output devices — in Bypass too. Core Audio attenuates a stereo mixdown tap by the output device's stereo-pair count for headroom: 0 dB on 2ch, -6.02 dB on 4ch, -9.54 dB on 6ch, -12.04 dB on 8ch ([Apple Developer Forums thread 806799](https://developer.apple.com/forums/thread/806799)). Our tap is exactly that configuration (`CATapDescription(stereoGlobalTapButExcludeProcesses:)`, `Sources/iQualizeCapture/main.swift:138`).

The fix multiplies the lost gain back in at the source node (`Sources/iQualize/AudioEngine.swift:340-350`), ahead of the EQ and limiter so the limiter still guards the restored level. The factor is the stereo-pair count of the output hardware format — exactly 1.0 on stereo devices — recomputed on every `start()`; device switches funnel through `restartTap()`. Compensation stays active in Bypass on purpose: the tap attenuates regardless, and Bypass must sound like the app is off.

The Bypass half of #107 (preset In/Out gains still applying) was already fixed on main by #118.

Reported with the full diagnosis by @iv-re, who verified the behavior and a -6 dB drop on a 4-channel Audient iD4 MKII.

Fixes #107

## Scope

- `Sources/iQualize/GainPolicy.swift` — render-path gain math as pure functions: the tap compensation, plus the #118 In/Out/Balance bypass neutralization that previously lived inline in `AudioEngine`
- `Sources/iQualize/AudioEngine.swift` — `rtVolumeCompensation` global applied in the render callback; the per-sample loop extracted into `deinterleaveChannel` with the gain hoisted out of the loop; factor computed in `start()`, reset in `stop()`/`cleanupPartialStart()`
- `Package.swift` — SPM test target re-enabled (needs full Xcode, not just Command Line Tools). Stale tests fixed: 15 built-in presets not 3, variable band counts, `preampGain` removed, `gainLabel` grew a " dB" suffix
- `Tests/iQualizeTests/GainPolicyTests.swift` + `RenderMathTests.swift` — the pair-count table, dB conversion, bypass neutralization, the render loop against synthetic buffers, and the invariant that Bypass does NOT neutralize compensation (folding it into the bypass path would reintroduce the drop)
- `Spikes/TapAttenuationE2E/` — BlackHole loopback harness that measures the real OS attenuation end to end. Rerun after macOS updates: if Apple ever removes the attenuation, the compensation would over-boost by the pair count, and this catches it before users hear clipping
- Version 0.48.1 + CHANGELOG

Out of scope: a CI workflow for `swift test` (repo has none yet), and the forum thread's claim that attenuation can differ per process routing — measured here, default-routed playback is attenuated uniformly.

## Test plan

- [x] `swift test`: 29 tests, 0 failures
- [x] `install.sh` + launch check: app running
- [x] Live device switching: MacBook Pro Speakers (2ch) logs `compensation: x1.0`, LG ULTRAGEAR+ (8ch DisplayPort) logs `x4.0`, and back — the engine's channel query matched the HAL stream configuration on both
- [x] End-to-end unity via BlackHole loopback (-30 dBFS sine, RMS app-off vs app-on-Bypass): 16ch delta -0.10 dB, 2ch control delta -0.14 dB. The 16ch case would read +18 dB if the OS didn't attenuate, -18 dB if the compensation didn't reach the output
- [x] E2E harness re-run from its final repo location (`Spikes/TapAttenuationE2E/e2e-tap-test.sh`): builds its own tooling, generates its own test tone, PASS at -0.14 dB
- [x] Not verified on real 4ch/6ch hardware — @iv-re, if you can test a build from this branch on the iD4 MKII, that closes the last gap
