### PR TITLE
feat: close windows with Cmd+W

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.49.0] - 2026-07-26
+
+### Added
+- Cmd+W closes the frontmost iQualize window — EQ, Settings, Preset Browser, and Help. Works in both Dock and menu-bar-only mode; the Window menu also gained a "Close Window" item. Requested by @json20 (#129)
+
 ## [0.48.1] - 2026-07-26
 
 ### Fixed

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -5,17 +5,12 @@ import SwiftUI
 
 @available(macOS 14.2, *)
 @MainActor
-final class EQWindow: NSWindow {
+final class EQWindow: ShortcutAwareWindow {
     var onKeyDown: ((NSEvent) -> Bool)?
 
     override func keyDown(with event: NSEvent) {
         if onKeyDown?(event) == true { return }
         super.keyDown(with: event)
-    }
-
-    override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if HelpShortcut.handles(event) { return true }
-        return super.performKeyEquivalent(with: event)
     }
 }
 

--- a/Sources/iQualize/HelpWindowController.swift
+++ b/Sources/iQualize/HelpWindowController.swift
@@ -15,13 +15,28 @@ enum HelpShortcut {
     }
 }
 
-/// NSWindow subclass that catches Cmd+? — used for the Settings window
-/// (and any other window where we want the help shortcut to fire).
+/// Routes Cmd+W to close the receiving window — same accessory-mode reasoning
+/// as `HelpShortcut`, since Close normally lives on a File menu this app
+/// doesn't show (#129).
 @available(macOS 14.2, *)
 @MainActor
-final class HelpAwareWindow: NSWindow {
+enum CloseShortcut {
+    static func handles(_ event: NSEvent, for window: NSWindow) -> Bool {
+        guard event.modifierFlags.intersection([.command, .shift, .option, .control]) == [.command],
+              event.charactersIgnoringModifiers == "w" else { return false }
+        window.performClose(nil)
+        return true
+    }
+}
+
+/// NSWindow subclass that catches the app-wide shortcuts (Cmd+?, Cmd+W) —
+/// base class for every titled window in the app.
+@available(macOS 14.2, *)
+@MainActor
+class ShortcutAwareWindow: NSWindow {
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if HelpShortcut.handles(event) { return true }
+        if CloseShortcut.handles(event, for: self) { return true }
         return super.performKeyEquivalent(with: event)
     }
 }
@@ -30,7 +45,7 @@ final class HelpAwareWindow: NSWindow {
 @MainActor
 final class HelpWindowController: NSWindowController, NSWindowDelegate, WKNavigationDelegate {
     init() {
-        let window = NSWindow(
+        let window = ShortcutAwareWindow(
             contentRect: NSRect(x: 0, y: 0, width: 720, height: 600),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered, defer: true

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.48.1</string>
+	<string>0.49.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.48.1</string>
+	<string>0.49.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/PresetBrowserWindowController.swift
+++ b/Sources/iQualize/PresetBrowserWindowController.swift
@@ -9,7 +9,7 @@ import SwiftUI
 @MainActor
 final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate {
     init(presetStore: PresetStore, onImportOPRA: @escaping (OPRAProductEntry, OPRACurveEntry) -> Void) {
-        let window = HelpAwareWindow(
+        let window = ShortcutAwareWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered, defer: true

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -35,7 +35,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         self.presetStore = presetStore
         self.eqWindowController = eqWindowController
 
-        let window = HelpAwareWindow(
+        let window = ShortcutAwareWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 0),
             styleMask: [.titled, .closable],
             backing: .buffered, defer: true

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -162,6 +162,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         // the names of open titled windows below the standard items.
         let windowMenuItem = NSMenuItem()
         let windowMenu = NSMenu(title: "Window")
+        let closeItem = windowMenu.addItem(withTitle: "Close Window",
+                                            action: #selector(NSWindow.performClose(_:)),
+                                            keyEquivalent: "w")
+        closeItem.keyEquivalentModifierMask = [.command]
         let minimizeItem = windowMenu.addItem(withTitle: "Minimize",
                                                action: #selector(NSWindow.miniaturize(_:)),
                                                keyEquivalent: "m")
@@ -179,7 +183,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
         // Help menu — standard macOS pattern. Not registered as NSApp.helpMenu so
         // macOS doesn't add the Help search popover (we ship our own help window).
-        // Cmd+? itself is handled by HelpAwareWindow.performKeyEquivalent so the
+        // Cmd+? itself is handled by ShortcutAwareWindow.performKeyEquivalent so the
         // shortcut works regardless of activation policy.
         let helpMenuItem = NSMenuItem()
         let helpMenu = NSMenu(title: "Help")


### PR DESCRIPTION
## Summary

Requested by @json20 in #129: Cmd+W now closes the frontmost iQualize window — EQ, Settings, Preset Browser, and Help.

Root cause: the main menu had no Close item (no File menu; the Window menu only had Minimize/Zoom), and in menu-bar-only mode there is no OS menu bar at all, so a menu shortcut alone could never fix it. The app already solved this for Cmd+? with `performKeyEquivalent` overrides on window subclasses; Cmd+W rides the same path.

- `CloseShortcut` (`Sources/iQualize/HelpWindowController.swift:22`) maps Cmd+W to `performClose(nil)` — same path as the close button, so window delegates and `windowOpen` persistence behave identically
- `HelpAwareWindow` renamed to `ShortcutAwareWindow` (it handles both shortcuts now), base class for every titled window: `EQWindow` inherits from it instead of duplicating the override, and the Help window switches from plain `NSWindow` — it previously had no shortcut handling at all
- "Close Window" (Cmd+W) added to the Window menu for Dock-mode discoverability
- Version 0.48.1 -> 0.49.0, CHANGELOG updated

## Test plan

- [x] `swift build` clean; `install.sh` + launch verification passed
- [x] Cmd+W sent to the live app closed the EQ window, with the app in accessory mode (`hideFromDock = true`) — the hard path where menu shortcuts don't exist
- [x] Persisted state flipped to `windowOpen = false`, proving the real `performClose` -> `willCloseNotification` path fired, not a hide
- [x] Settings / Preset Browser / Help windows not individually tested — same `ShortcutAwareWindow` code path
- [ ] Window menu item in Dock mode not tested (app was in accessory mode)