### PR TITLE
feat: automated releases with universal (Intel + Apple Silicon) DMGs

### DIFF
--- a/.github/release-notes/install-signed.md
+++ b/.github/release-notes/install-signed.md
@@ -1,0 +1,5 @@
+## Install
+
+Download the `.dmg`, open it, and drag iQualize to Applications. Universal build — Apple Silicon and Intel, macOS 14.2+. Signed and notarized; opens without any Gatekeeper workaround.
+
+For the `iqualize` command line tool: Settings (⌘,) → General → Install Command Line Tool.

--- a/.github/release-notes/install-unsigned.md
+++ b/.github/release-notes/install-unsigned.md
@@ -1,0 +1,11 @@
+## Install
+
+Download the `.dmg`, open it, and drag iQualize to Applications. Universal build — Apple Silicon and Intel, macOS 14.2+.
+
+iQualize is ad-hoc signed, not notarized. macOS quarantines web downloads, and for an unnotarized app that shows up as **"iQualize is damaged and can't be opened"**. It isn't. Clear the flag once:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/iQualize.app
+```
+
+Then open it normally. For the `iqualize` command line tool: Settings (⌘,) → General → Install Command Line Tool.

--- a/.github/scripts/release-thanks.sh
+++ b/.github/scripts/release-thanks.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Build a "Thanks" section for the release notes: the authors of the issues
+# closed by the PRs in this release range. GitHub's auto-generated notes
+# credit PR authors only — the people who filed the bug reports and feature
+# requests deserve the mention (and the notification) too.
+#
+# Usage: release-thanks.sh <tag-or-ref>       (repo root, needs GH_TOKEN/gh auth)
+# Prints the section to stdout; prints nothing when there is nobody to thank.
+set -euo pipefail
+
+TAG="$1"
+PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+RANGE="${PREV:+${PREV}..}${TAG}"
+OWNER_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+OWNER=${OWNER_REPO%%/*}
+REPO=${OWNER_REPO##*/}
+
+# PR numbers from merge commits in the range — this repo merges PRs with
+# merge commits, so every landed PR shows up here.
+prs=$(git log --merges --format=%s "$RANGE" | sed -n 's/^Merge pull request #\([0-9]*\).*/\1/p')
+[ -n "$prs" ] || exit 0
+
+entries=""
+for pr in $prs; do
+    rows=$(gh api graphql \
+        -F owner="$OWNER" -F repo="$REPO" -F pr="$pr" \
+        -f query='
+          query($owner: String!, $repo: String!, $pr: Int!) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $pr) {
+                closingIssuesReferences(first: 10) {
+                  nodes { number title author { login } }
+                }
+              }
+            }
+          }' \
+        --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]
+              | "\(.author.login)\t\(.number)\t\(.title)"' 2>/dev/null || true)
+    [ -n "$rows" ] && entries+="$rows"$'\n'
+done
+
+# Skip the repo owner's own reports, dedupe by issue number.
+thanks=$(printf '%s' "$entries" | awk -F'\t' -v owner="$OWNER" \
+    '$1 != "" && $1 != owner && !seen[$2]++ {
+        printf "- @%s for reporting #%s — %s\n", $1, $2, $3
+    }')
+[ -n "$thanks" ] || exit 0
+
+printf '\n## Thanks\n\n%s\n' "$thanks"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+# Release: build a universal (Apple Silicon + Intel) DMG on every version tag
+# and publish a GitHub Release with auto-generated notes plus a thanks section
+# for the people whose issue reports the release closes.
+#
+# The DMG is ad-hoc signed unless the APPLE_* secrets are configured —
+# downloads need `xattr -dr com.apple.quarantine`, same as every release so
+# far (see README). Secrets for a signed + notarized release:
+#   APPLE_CERTIFICATE            base64 .p12 Developer ID certificate
+#   APPLE_CERTIFICATE_PASSWORD   its password
+#   APPLE_SIGNING_IDENTITY       e.g. "Developer ID Application: …"
+# Additionally, for notarization:
+#   APPLE_ID, APPLE_PASSWORD (app-specific), APPLE_TEAM_ID
+#
+# workflow_dispatch is the dry run: build + test + DMG as an artifact,
+# no release created.
+
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    # The secrets context is not available in step `if` conditions;
+    # these flags carry the presence check instead.
+    env:
+      HAS_SIGNING_CREDENTIALS: ${{ secrets.APPLE_CERTIFICATE != '' }}
+      HAS_NOTARY_CREDENTIALS: ${{ secrets.APPLE_ID != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the thanks section walks merge history between tags
+
+      - name: Check the tag matches the app version
+        if: github.event_name == 'push'
+        run: |
+          version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Sources/iQualize/Info.plist)
+          test "v$version" = "${GITHUB_REF_NAME}" || {
+            echo "Tag ${GITHUB_REF_NAME} does not match Info.plist version $version" >&2
+            exit 1
+          }
+
+      - name: Run tests
+        run: swift test
+
+      - name: Import signing certificate when configured
+        if: env.HAS_SIGNING_CREDENTIALS == 'true'
+        run: |
+          echo "${{ secrets.APPLE_CERTIFICATE }}" | base64 -d > /tmp/cert.p12
+          security create-keychain -p ci-keychain ci.keychain
+          security default-keychain -s ci.keychain
+          security unlock-keychain -p ci-keychain ci.keychain
+          security import /tmp/cert.p12 -k ci.keychain \
+            -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k ci-keychain ci.keychain
+          rm /tmp/cert.p12
+          echo "IQ_SIGN_IDENTITY=${{ secrets.APPLE_SIGNING_IDENTITY }}" >> "$GITHUB_ENV"
+
+      - name: Build the DMG (universal, verified)
+        run: bash create-dmg.sh
+
+      - name: Verify both architectures inside the DMG
+        run: |
+          hdiutil attach -readonly -mountpoint /tmp/iq-dmg iQualize-*.dmg
+          lipo -archs /tmp/iq-dmg/iQualize.app/Contents/MacOS/iQualize \
+            | tee /dev/stderr | grep -q "x86_64 arm64"
+          hdiutil detach /tmp/iq-dmg
+
+      - name: Notarize when configured
+        if: env.HAS_NOTARY_CREDENTIALS == 'true'
+        run: |
+          xcrun notarytool submit iQualize-*.dmg --wait \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --password "${{ secrets.APPLE_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}"
+          xcrun stapler staple iQualize-*.dmg
+
+      - name: Upload DMG artifact (dry run)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: iQualize-dmg
+          path: iQualize-*.dmg
+
+      - name: Build the thanks section for issue reporters
+        if: github.event_name == 'push'
+        run: bash .github/scripts/release-thanks.sh "${GITHUB_REF_NAME}" > /tmp/thanks.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create the release
+        if: github.event_name == 'push'
+        run: |
+          if [ "$HAS_SIGNING_CREDENTIALS" = "true" ] && [ "$HAS_NOTARY_CREDENTIALS" = "true" ]; then
+            install_note=.github/release-notes/install-signed.md
+          else
+            install_note=.github/release-notes/install-unsigned.md
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "iQualize ${GITHUB_REF_NAME}" \
+            --notes "$(cat "$install_note" /tmp/thanks.md)" \
+            --generate-notes \
+            iQualize-*.dmg
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.50.0] - 2026-07-26
+
+### Added
+- Intel support: distributable DMGs are now universal binaries (Apple Silicon + Intel). `create-dmg.sh` builds both slices and refuses to package a DMG where any of the three binaries (app, capture helper, CLI) is missing an architecture. Local dev builds stay native-only for speed; `IQ_UNIVERSAL=1 bash install.sh` opts in
+- Automated releases: pushing a `vX.Y.Z` tag now builds, tests, verifies, and publishes the GitHub Release with the DMG attached (`.github/workflows/release.yml`). Release notes are auto-generated from merged PRs, plus a Thanks section crediting the people whose issue reports the release closes. The workflow scaffolds Developer ID signing + notarization behind `APPLE_*` secrets for later; until then releases stay ad-hoc signed with the usual quarantine instructions
+
 ## [0.49.1] - 2026-07-26
 
 ### Fixed

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.49.1</string>
+	<string>0.50.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.49.1</string>
+	<string>0.50.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/create-dmg.sh
+++ b/create-dmg.sh
@@ -9,7 +9,24 @@ DMG_NAME="iQualize-${VERSION}.dmg"
 DMG_VOLUME="iQualize"
 
 echo "=== Building iQualize v${VERSION} ==="
+# Distributable DMGs are universal (Apple Silicon + Intel) unless overridden
+# with IQ_UNIVERSAL=0 for a quick local test build.
+export IQ_UNIVERSAL="${IQ_UNIVERSAL:-1}"
 bash install.sh
+
+if [ "$IQ_UNIVERSAL" = "1" ]; then
+    for bin in \
+        /Applications/iQualize.app/Contents/MacOS/iQualize \
+        /Applications/iQualize.app/Contents/Helpers/iQualizeCapture \
+        /Applications/iQualize.app/Contents/Resources/bin/iqualize; do
+        archs=$(lipo -archs "$bin")
+        case "$archs" in
+            *x86_64*arm64*|*arm64*x86_64*) ;;
+            *) echo "ERROR: $bin is not universal (archs: $archs)"; exit 1 ;;
+        esac
+    done
+    echo "Universal check passed (arm64 + x86_64 in all three binaries)"
+fi
 
 echo "=== Creating DMG ==="
 

--- a/install.sh
+++ b/install.sh
@@ -4,25 +4,38 @@ set -e
 
 cd "$(dirname "$0")"
 
-# Pick a signing identity: a real Apple Development cert if one is installed,
-# otherwise ad-hoc ("-"). Ad-hoc is fine for local dev — TCC keys on the cdhash,
-# which stays stable across rebuilds when the binary is unchanged. It is NOT
-# accepted by Gatekeeper on quarantined downloads (macOS reports "damaged"), so
-# distributed DMGs still need the quarantine xattr stripped — see README.
+# Pick a signing identity: an explicit IQ_SIGN_IDENTITY (release CI sets this
+# to a Developer ID cert when configured), else a real Apple Development cert
+# if one is installed, otherwise ad-hoc ("-"). Ad-hoc is fine for local dev —
+# TCC keys on the cdhash, which stays stable across rebuilds when the binary is
+# unchanged. It is NOT accepted by Gatekeeper on quarantined downloads (macOS
+# reports "damaged"), so distributed DMGs still need the quarantine xattr
+# stripped — see README.
 # Previously this always passed "Apple Development"; when that cert is absent the
 # codesign call failed silently and the app shipped with a broken signature.
-if security find-identity -v -p codesigning 2>/dev/null | grep -q "Apple Development"; then
+if [ -n "${IQ_SIGN_IDENTITY:-}" ]; then
+    SIGN_ID="$IQ_SIGN_IDENTITY"
+elif security find-identity -v -p codesigning 2>/dev/null | grep -q "Apple Development"; then
     SIGN_ID="Apple Development"
 else
     SIGN_ID="-"
 fi
 
-echo "Building iQualize..."
-swift build -c release 2>&1 | tail -5
+# IQ_UNIVERSAL=1 builds both slices (Apple Silicon + Intel) — used for
+# distributable DMGs (create-dmg.sh). Default dev builds stay native-only:
+# the x86_64 slice roughly doubles compile time for nothing during iteration.
+BUILD_FLAGS=(-c release)
+if [ "${IQ_UNIVERSAL:-0}" = "1" ]; then
+    BUILD_FLAGS+=(--arch arm64 --arch x86_64)
+    echo "Building iQualize (universal: arm64 + x86_64)..."
+else
+    echo "Building iQualize..."
+fi
+swift build "${BUILD_FLAGS[@]}" 2>&1 | tail -5
 
 APP=/Applications/iQualize.app
 BIN="$APP/Contents/MacOS/iQualize"
-BIN_PATH="$(swift build -c release --show-bin-path)"
+BIN_PATH="$(swift build "${BUILD_FLAGS[@]}" --show-bin-path)"
 SRC="$BIN_PATH/iQualize"
 CLI_SRC="$BIN_PATH/iqualize-cli"
 CLI_BIN="$APP/Contents/Resources/bin/iqualize"


### PR DESCRIPTION
## Summary

Pushing a `vX.Y.Z` tag now cuts the release end to end, modeled on markive's workflow: version check, tests, universal DMG build, verification, and a GitHub Release with auto-generated notes — plus a Thanks section that @-mentions the people whose issue reports the release closes. Tagging stays manual: a release still takes a deliberate human action, CI just replaces the build-and-publish steps.

Auto-generated notes credit PR authors only, which in this repo means one name on every line. `release-thanks.sh` fixes that: it resolves each released PR's closing issues via GraphQL and appends the reporters. Tested against real history (`v0.45.0..HEAD`): produces @iv-re (#107) and @nordicdata (#119), filters the repo owner's own reports. Credit rides on the "Fixes #N" convention — plain mentions and Discussions don't link (that's why #129/@json20 doesn't surface; #129 is a Discussion).

Distributable DMGs are now universal (Apple Silicon + Intel, macOS 14.2+). Dev builds stay native-only for compile speed.

## Scope

- `.github/workflows/release.yml` — tag-triggered release: tag-vs-`Info.plist` check, `swift test`, `create-dmg.sh` (the #115 `verify-dmg.sh` gate applies unchanged in CI), lipo check inside the mounted DMG, `gh release create --generate-notes` with the install prelude and Thanks section. `workflow_dispatch` = dry run (DMG as artifact, no release). Developer ID signing + notarization scaffolded behind `APPLE_*` secrets, inert until configured.
- `.github/scripts/release-thanks.sh` — reporters section via `closingIssuesReferences`
- `.github/release-notes/install-{unsigned,signed}.md` — release-notes preludes; unsigned carries the usual `xattr -dr com.apple.quarantine` instructions
- `install.sh` — `IQ_UNIVERSAL=1` builds both slices; `IQ_SIGN_IDENTITY` override for the future signed path
- `create-dmg.sh` — defaults to universal and refuses to package if the app, capture helper, or CLI binary is missing an architecture
- Version 0.50.0 + CHANGELOG

Out of scope: actual Developer ID signing/notarization (needs the $99/yr developer program; the workflow lights it up when the secrets appear).

## Test plan

- [x] Full universal DMG build locally: all three binaries report `x86_64 arm64` both installed and inside `iQualize-0.50.0.dmg`; `verify-dmg.sh` passes; app launches; `swift test` 29/29
- [x] `release-thanks.sh` against `v0.45.0..HEAD`: correct reporters, owner filtered, empty-range and no-linked-issues cases exit silently
- [x] Workflow YAML parses
- [x] Runner-side behavior (Finder AppleScript DMG styling, `/Applications` copy) — not testable locally. Plan: merge, run the `workflow_dispatch` dry run, then tag `v0.50.0` for the first automated release
