### PR TITLE
install.sh: fix skip detection so unchanged binaries are actually skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.50.1] - 2026-07-26
+
+### Fixed
+- `install.sh` claimed to skip unchanged binaries but re-copied and re-signed on every run: it compared fresh build products against installed binaries that signing had already rewritten (the capture helper individually, the main binary via the bundle seal), so they never byte-matched again. Change detection now compares against hashes of the pre-sign build products, recorded in a `build-hashes` sidecar sealed into the bundle. TCC was unaffected either way — ad-hoc grants pin the cdhash, which is deterministic for an unchanged product — but a no-op install no longer rewrites the executable of a running app
+- The capture helper is now signed with an explicit identifier (`com.iqualize.capture`). Without one, codesign derives an identifier from the Mach-O UUID, which changes on every relink and would break a cert-based TCC grant across rebuilds
+
 ## [0.50.0] - 2026-07-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ When closing a task via PR, use "Fixes #N" in the PR body to auto-close the issu
 ## Build & Install
 
 ```bash
-bash install.sh          # builds, signs with Apple Development cert, installs to /Applications
+bash install.sh          # builds, signs, installs to /Applications
 open /Applications/iQualize.app
 ```
 
@@ -50,8 +50,8 @@ open /Applications/iQualize.app
 
 - Build with `swift build` (SPM, no Xcode project)
 - After code changes: `pkill -x iQualize; bash install.sh && open /Applications/iQualize.app`
-- Binary is codesigned with "Apple Development" cert to preserve TCC permissions across rebuilds
-- install.sh skips binary copy if unchanged (preserves cdhash)
+- install.sh signs with `IQ_SIGN_IDENTITY` if set, else an installed "Apple Development" cert, else ad-hoc. Ad-hoc TCC grants pin the cdhash: no-op reinstalls keep it (the re-sign is deterministic), but any real code change gets a fresh TCC prompt — only a cert-based signature survives those
+- install.sh skips binary copies when the fresh build products match the hashes recorded in `Contents/Resources/build-hashes` at the last install. Installed binaries themselves never byte-match a fresh product — signing rewrites them — so don't compare against those
 
 ### Launch verification (REQUIRED)
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.50.0</string>
+	<string>0.50.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.50.0</string>
+	<string>0.50.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/install.sh
+++ b/install.sh
@@ -46,22 +46,40 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources/bin" "$APP/Contents/Help
 
 NEEDS_RESIGN=0
 
+# Change detection: installed binaries never byte-match fresh build products,
+# because signing rewrites them — the helper individually below, the main
+# binary when the bundle seal is applied — so cmp against the installed copy
+# always reports a change. Instead, compare each fresh product against the
+# hash recorded at the previous install (build-hashes sidecar, sealed into the
+# bundle). TCC does not depend on this skip: it pins the cdhash, which is
+# deterministic when the product is unchanged and changes with any real code
+# update regardless. What the skip buys is a truthful no-op — in particular it
+# never rewrites the executable of a running app, which macOS punishes with
+# SIGKILL.
+HASHES="$APP/Contents/Resources/build-hashes"
+hash_of() { shasum -a 256 "$1" | cut -d' ' -f1; }
+recorded() { grep "^$1=" "$HASHES" 2>/dev/null | cut -d= -f2; }
+MAIN_HASH=$(hash_of "$SRC")
+HELPER_HASH=$(hash_of "$HELPER_SRC")
+CLI_HASH=$(hash_of "$CLI_SRC")
+
 # Install + sign the capture helper FIRST (the main binary's enclosing
 # signature covers the helper, so the helper must already be in place when
 # we sign the main bundle below). It owns the CATap + aggregate IOProc in a
-# separate process — see CONTINUITY.md.
-if [ -f "$HELPER_BIN" ] && cmp -s "$HELPER_SRC" "$HELPER_BIN"; then
+# separate process — see CONTINUITY.md. The explicit --identifier matters:
+# without it, codesign derives one from the Mach-O UUID, which changes on
+# every relink and would break a cert-based TCC grant across rebuilds.
+if [ -f "$HELPER_BIN" ] && [ "$HELPER_HASH" = "$(recorded helper)" ]; then
     :
 else
     cp -f "$HELPER_SRC" "$HELPER_BIN"
-    codesign --force --sign "$SIGN_ID" --entitlements iQualizeCapture.entitlements "$HELPER_BIN" && echo "Helper signed ($SIGN_ID)"
+    codesign --force --sign "$SIGN_ID" --identifier com.iqualize.capture --entitlements iQualizeCapture.entitlements "$HELPER_BIN" && echo "Helper signed ($SIGN_ID)"
     NEEDS_RESIGN=1
     echo "Helper binary updated"
 fi
 
-# Only replace binary if it actually changed — preserves TCC permissions (cdhash stays the same)
-if [ -f "$BIN" ] && cmp -s "$SRC" "$BIN"; then
-    echo "Binary unchanged — skipping copy (TCC permissions preserved)"
+if [ -f "$BIN" ] && [ "$MAIN_HASH" = "$(recorded main)" ]; then
+    echo "Binary unchanged — skipping copy"
 else
     cp -f "$SRC" "$BIN"
     NEEDS_RESIGN=1
@@ -69,7 +87,7 @@ else
 fi
 
 # Bundle the CLI so it rides along in the DMG too (see Settings > "Install Command Line Tool")
-if [ -f "$CLI_BIN" ] && cmp -s "$CLI_SRC" "$CLI_BIN"; then
+if [ -f "$CLI_BIN" ] && [ "$CLI_HASH" = "$(recorded cli)" ]; then
     :
 else
     cp -f "$CLI_SRC" "$CLI_BIN"
@@ -93,6 +111,9 @@ else
 fi
 
 if [ "$NEEDS_RESIGN" = "1" ]; then
+    # Record the pre-sign product hashes first so the sidecar is covered by
+    # the bundle seal.
+    printf 'helper=%s\nmain=%s\ncli=%s\n' "$HELPER_HASH" "$MAIN_HASH" "$CLI_HASH" > "$HASHES"
     # Sign the whole bundle after every resource is in place so the sealed
     # CodeResources is consistent (a partial/stale seal reads as "damaged").
     codesign --force --sign "$SIGN_ID" --entitlements iQualize.entitlements "$APP" && echo "Signed with: $SIGN_ID"


### PR DESCRIPTION
## Summary

install.sh claimed to skip copying binaries when unchanged, but every run re-copied and re-signed all of them. The cmp checks compared fresh build products against installed binaries that signing had already rewritten — the capture helper is signed individually at copy time, and the bundle codesign rewrites the main executable — so they never byte-matched again. Only the CLI, which is sealed but never re-signed, skipped correctly.

Change detection now hashes the pre-sign build products into `Contents/Resources/build-hashes`, written just before the bundle seal so the signature covers it. The next run compares fresh product hashes against the sidecar. `create-dmg.sh` calls install.sh, so the sidecar ships in DMGs with no extra work.

TCC was unaffected either way: ad-hoc grants pin the cdhash (`designated => cdhash H"..."`), and replaying the copy+sign sequence three times on scratch copies of the installed bundle produced identical cdhashes each pass. What the fix buys is a truthful no-op — in particular it no longer rewrites the executable of a running app, which macOS kills on the spot.

Alternatives rejected: comparing cdhashes (a fresh product carries a linker ad-hoc signature with a different identifier and no entitlements, so its cdhash can never equal the installed one) and stripping signatures before cmp (`codesign --remove-signature` leaves a 1–2 byte header residue even on the same link).

Also in this PR:
- The helper is now signed with an explicit `--identifier com.iqualize.capture`. Without one, codesign derives the identifier from the Mach-O UUID (`iQualizeCapture-55554944<uuid>`), which changes on every relink and would break a cert-based TCC grant across rebuilds. Harmless today under ad-hoc, cheap insurance for when a real cert returns.
- CLAUDE.md corrected: the unconditional "signed with Apple Development cert" claim was stale — signing is `IQ_SIGN_IDENTITY` if set, else an installed Apple Development cert, else ad-hoc.
- Version 0.50.1 + changelog.

## Test plan

All on an ad-hoc-signing machine (no Apple Development cert installed):

- [x] Run 1 (no sidecar yet): copies all three binaries, signs, app launches
- [x] Run 2 without killing the app: prints "Binary unchanged — skipping copy", no helper/CLI update lines, no re-sign, and the running app survives the reinstall
- [x] `codesign --verify --deep --strict` passes with the sealed sidecar
- [x] Helper identifier is `com.iqualize.capture`
- [ ] DMG flow not re-run — create-dmg.sh reuses install.sh unchanged