### PR TITLE
Report app version and build commit in iqualize status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.51.0] - 2026-07-26
+
+### Added
+- `iqualize status` now reports the app version and build commit as its first line (`Version: 0.51.0 (abc1234)`), read live from the running app over the control socket. The About dialog shows the same. install.sh stamps the commit into the installed app's Info.plist (`IQGitCommit`, with a `-dirty` suffix for uncommitted changes); builds without git omit it. Suggested by Gary (@nordicdata, #136)
+
 ## [0.50.0] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to iQualize will be documented in this file.
 ## [0.51.0] - 2026-07-26
 
 ### Added
-- `iqualize status` now reports the app version and build commit as its first line (`Version: 0.51.0 (abc1234)`), read live from the running app over the control socket. The About dialog shows the same. install.sh stamps the commit into the installed app's Info.plist (`IQGitCommit`, with a `-dirty` suffix for uncommitted changes); builds without git omit it. Suggested by Gary (@nordicdata, #136)
+- `iqualize status` now reports the app version and build commit as its first line (`Version: 0.51.0 (abc1234)`), read live from the running app over the control socket. A new `iqualize version` subcommand prints just `0.51.0 (abc1234)`. The About dialog shows the same. install.sh stamps the commit into the installed app's Info.plist (`IQGitCommit`, with a `-dirty` suffix for uncommitted changes); builds without git omit it. Suggested by Gary (@nordicdata, #136)
 
 ## [0.50.0] - 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ button needed.)
 
 ```
 iqualize                      # same as `iqualize status`
-iqualize status               # bypass state, active preset, gain, output device
+iqualize status               # app version, bypass state, active preset, gain, balance, output device
 iqualize presets               # list all presets (* = active, ♥ = favorite)
 iqualize preset "Bass Boost"   # switch the active preset by name or ID
 iqualize bypass [on|off|toggle]

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ button needed.)
 ```
 iqualize                      # same as `iqualize status`
 iqualize status               # app version, bypass state, active preset, gain, balance, output device
+iqualize version              # just the app version and build commit
 iqualize presets               # list all presets (* = active, ♥ = favorite)
 iqualize preset "Bass Boost"   # switch the active preset by name or ID
 iqualize bypass [on|off|toggle]

--- a/Sources/IQControlProtocol/CLIControlMessages.swift
+++ b/Sources/IQControlProtocol/CLIControlMessages.swift
@@ -64,8 +64,14 @@ public struct CLIStatusPayload: Codable, Sendable {
     public var gainIsGlobal: Bool
     public var outputDeviceName: String
     public var isRunning: Bool
+    /// App version (CFBundleShortVersionString). Optional so a newer CLI still decodes
+    /// responses from an older app that doesn't send it.
+    public var appVersion: String?
+    /// Git commit the app was built from (IQGitCommit, stamped by install.sh).
+    /// nil for unstamped builds (e.g. plain `swift build` outside a git checkout).
+    public var gitCommit: String?
 
-    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool) {
+    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool, appVersion: String? = nil, gitCommit: String? = nil) {
         self.bypassed = bypassed
         self.activePresetID = activePresetID
         self.activePresetName = activePresetName
@@ -75,6 +81,8 @@ public struct CLIStatusPayload: Codable, Sendable {
         self.gainIsGlobal = gainIsGlobal
         self.outputDeviceName = outputDeviceName
         self.isRunning = isRunning
+        self.appVersion = appVersion
+        self.gitCommit = gitCommit
     }
 }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.50.0</string>
+	<string>0.51.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.50.0</string>
+	<string>0.51.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -374,6 +374,16 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         return presetStore.allPresets.first { $0.name.caseInsensitiveCompare(idOrName) == .orderedSame }
     }
 
+    var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    /// Git commit stamped into the installed Info.plist by install.sh; nil for
+    /// unstamped builds.
+    var appGitCommit: String? {
+        Bundle.main.infoDictionary?["IQGitCommit"] as? String
+    }
+
     func statusSnapshot() -> CLIStatusPayload {
         CLIStatusPayload(
             bypassed: audioEngine.bypassed,
@@ -384,7 +394,9 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             balance: audioEngine.balance,
             gainIsGlobal: audioEngine.gainIsGlobal,
             outputDeviceName: audioEngine.outputDeviceName,
-            isRunning: audioEngine.isRunning
+            isRunning: audioEngine.isRunning,
+            appVersion: appVersion,
+            gitCommit: appGitCommit
         )
     }
 
@@ -411,10 +423,9 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     @objc func showAbout(_ sender: Any?) {
         let alert = NSAlert()
         alert.messageText = "iQualize"
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         alert.informativeText = """
         System-wide audio equalizer for macOS.
-        Version \(version)
+        Version \(appVersion)\(appGitCommit.map { " (\($0))" } ?? "")
 
         Headphone EQ profiles come from the OPRA project, licensed CC BY-SA 4.0.
         """

--- a/Sources/iqualize-cli/CLIOutput.swift
+++ b/Sources/iqualize-cli/CLIOutput.swift
@@ -36,7 +36,10 @@ func formatBalance(_ value: Float) -> String {
 
 func formatStatus(_ status: CLIStatusPayload) -> String {
     let mode = status.gainIsGlobal ? "shared" : "per-preset"
+    let version = status.appVersion ?? "unknown"
+    let versionLine = status.gitCommit.map { "\(version) (\($0))" } ?? version
     return """
+    Version: \(versionLine)
     Bypass: \(status.bypassed ? "on" : "off")
     Preset: \(status.activePresetName)
     Gain: \(String(format: "input %+.1f dB, output %+.1f dB", status.inputGainDB, status.outputGainDB)) (\(mode))

--- a/Sources/iqualize-cli/CLIOutput.swift
+++ b/Sources/iqualize-cli/CLIOutput.swift
@@ -34,12 +34,16 @@ func formatBalance(_ value: Float) -> String {
     return value < 0 ? "L\(pct)" : "R\(pct)"
 }
 
+/// "0.51.0 (abc1234)", commit omitted for unstamped builds.
+func formatVersion(_ status: CLIStatusPayload) -> String {
+    let version = status.appVersion ?? "unknown"
+    return status.gitCommit.map { "\(version) (\($0))" } ?? version
+}
+
 func formatStatus(_ status: CLIStatusPayload) -> String {
     let mode = status.gainIsGlobal ? "shared" : "per-preset"
-    let version = status.appVersion ?? "unknown"
-    let versionLine = status.gitCommit.map { "\(version) (\($0))" } ?? version
     return """
-    Version: \(versionLine)
+    Version: \(formatVersion(status))
     Bypass: \(status.bypassed ? "on" : "off")
     Preset: \(status.activePresetName)
     Gain: \(String(format: "input %+.1f dB, output %+.1f dB", status.inputGainDB, status.outputGainDB)) (\(mode))

--- a/Sources/iqualize-cli/Iqualize.swift
+++ b/Sources/iqualize-cli/Iqualize.swift
@@ -12,7 +12,7 @@ struct Iqualize: ParsableCommand {
 }
 
 struct Status: ParsableCommand {
-    static let configuration = CommandConfiguration(abstract: "Show bypass state, active preset, gain, and output device.")
+    static let configuration = CommandConfiguration(abstract: "Show app version, bypass state, active preset, gain, balance, and output device.")
 
     func run() {
         let response = requireOK(sendOrExit(CLIRequest(command: CLICommand.status)))

--- a/Sources/iqualize-cli/Iqualize.swift
+++ b/Sources/iqualize-cli/Iqualize.swift
@@ -6,9 +6,22 @@ struct Iqualize: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "iqualize",
         abstract: "Control a running iQualize instance from the command line.",
-        subcommands: [Status.self, Presets.self, PresetCommand.self, Bypass.self, Gain.self, Balance.self],
+        subcommands: [Status.self, Version.self, Presets.self, PresetCommand.self, Bypass.self, Gain.self, Balance.self],
         defaultSubcommand: Status.self
     )
+}
+
+struct Version: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Show the app version and build commit.")
+
+    func run() {
+        let response = requireOK(sendOrExit(CLIRequest(command: CLICommand.status)))
+        guard let status = response.status else {
+            printErr("Error: missing status in response")
+            return
+        }
+        print(formatVersion(status))
+    }
 }
 
 struct Status: ParsableCommand {

--- a/install.sh
+++ b/install.sh
@@ -84,13 +84,25 @@ cp -f Sources/iQualize/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
 # Copy README so the in-app Help window can render the Features section
 cp -f README.md "$APP/Contents/Resources/README.md"
 
-# Always update Info.plist — a plist change invalidates the signature too
-if ! cmp -s Sources/iQualize/Info.plist "$APP/Contents/Info.plist"; then
-    cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"
-    NEEDS_RESIGN=1
-else
-    cp -f Sources/iQualize/Info.plist "$APP/Contents/Info.plist"
+# Stamp the build's git commit into the installed Info.plist (IQGitCommit) so
+# the app can report it (iqualize status, About dialog). The source plist stays
+# unstamped; the stamp goes into a temp copy that is compared against the
+# installed plist — comparing the unstamped source directly would always differ
+# and force a re-sign on every run. No git / no repo → no stamp, app omits it.
+STAMPED_PLIST=$(mktemp)
+cp Sources/iQualize/Info.plist "$STAMPED_PLIST"
+GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || true)
+if [ -n "$GIT_COMMIT" ]; then
+    git diff --quiet HEAD 2>/dev/null || GIT_COMMIT="${GIT_COMMIT}-dirty"
+    /usr/libexec/PlistBuddy -c "Add :IQGitCommit string $GIT_COMMIT" "$STAMPED_PLIST"
 fi
+
+# Always update Info.plist — a plist change invalidates the signature too
+if ! cmp -s "$STAMPED_PLIST" "$APP/Contents/Info.plist"; then
+    NEEDS_RESIGN=1
+fi
+cp -f "$STAMPED_PLIST" "$APP/Contents/Info.plist"
+rm -f "$STAMPED_PLIST"
 
 if [ "$NEEDS_RESIGN" = "1" ]; then
     # Sign the whole bundle after every resource is in place so the sealed


### PR DESCRIPTION
## Summary

`iqualize status` (and bare `iqualize`) now leads with the app version and the git commit of the build: `Version: 0.51.0 (e8f671b)`. A new `iqualize version` subcommand prints just `0.51.0 (e8f671b)` for scripting. The About dialog shows the same string. Suggested by Gary (@nordicdata). Fixes #136.

The version comes from the running app over the control socket, not the CLI binary — `CLIStatusPayload` gains optional `appVersion` and `gitCommit` fields, so a newer CLI still decodes responses from an older app (`Sources/IQControlProtocol/CLIControlMessages.swift:57-91`). `iqualize version` reuses the status round-trip; no new protocol command.

The commit is not compiled in. `install.sh:87-105` stamps `git rev-parse --short HEAD` into the installed app's Info.plist as `IQGitCommit`, with a `-dirty` suffix when the tree has uncommitted changes. The source plist stays unstamped; the stamp goes into a temp copy that is compared against the installed plist, because comparing the unstamped source directly would force a re-sign on every run. `create-dmg.sh` and release CI build through `install.sh`, so DMGs get the stamp too. Builds without git omit the parenthetical.

Version 0.50.0 → 0.51.0 (minor, new CLI feature) with a CHANGELOG entry. The status `--help` abstract and the README CLI section now also mention balance, which status already printed but neither listed.

## Scope

Left out: install.sh's skip-if-unchanged binary copy never actually triggers — the installed helper and main binary are signed in place after copying, so they never byte-match fresh build products and every run re-copies and re-signs. Pre-existing at HEAD, unrelated to the plist path this PR touches; a fix is in progress separately.

## Test plan

- [x] `swift build` and `swift test` pass (29 tests, 0 failures)
- [x] App installs and launches
- [x] `iqualize status` prints `Version: 0.51.0 (63fd4c2-dirty)` on a dirty tree, `Version: 0.51.0 (e8f671b)` on a clean tree
- [x] `iqualize version` prints `0.51.0 (b959e95)` (and `0.51.0 (e8f671b-dirty)` pre-commit)
- [x] Other subcommands (`bypass`, `gain`, `balance`) output unchanged
- [x] Source `Info.plist` contains no `IQGitCommit`; PlistBuddy confirms the stamp only in the installed app
- [x] Re-running install.sh with no changes produces an identical stamped plist (no false re-sign from the plist comparison)
- [ ] DMG build (`create-dmg.sh`) — not run; it wraps the same install.sh path