### PR TITLE
CI: clear Node 20 deprecation warnings in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       HAS_SIGNING_CREDENTIALS: ${{ secrets.APPLE_CERTIFICATE != '' }}
       HAS_NOTARY_CREDENTIALS: ${{ secrets.APPLE_ID != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # the thanks section walks merge history between tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload DMG artifact (dry run)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: iQualize-dmg
           path: iQualize-*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload DMG artifact (dry run)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: iQualize-dmg
           path: iQualize-*.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.51.1] - 2026-07-27
+
+### Changed
+- CI: bumped `actions/checkout` v4 → v5 in the release workflow. v4 targets Node 20, which GitHub Actions runners have deprecated; every v0.51.0 release job carried the deprecation warning
+
 ## [0.51.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to iQualize will be documented in this file.
 ## [0.51.1] - 2026-07-27
 
 ### Changed
-- CI: bumped `actions/checkout` v4 → v5 in the release workflow. v4 targets Node 20, which GitHub Actions runners have deprecated; every v0.51.0 release job carried the deprecation warning
+- CI: bumped `actions/checkout` and `actions/upload-artifact` v4 → v5 in the release workflow. v4 targets Node 20, which GitHub Actions runners have deprecated; the v0.51.0 release job warned on checkout, and the dispatch dry run additionally warned on upload-artifact (its step only runs on dry runs)
 
 ## [0.51.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to iQualize will be documented in this file.
 ## [0.51.1] - 2026-07-27
 
 ### Changed
-- CI: bumped `actions/checkout` and `actions/upload-artifact` v4 → v5 in the release workflow. v4 targets Node 20, which GitHub Actions runners have deprecated; the v0.51.0 release job warned on checkout, and the dispatch dry run additionally warned on upload-artifact (its step only runs on dry runs)
+- CI: bumped `actions/checkout` v4 → v5 and `actions/upload-artifact` v4 → v7 in the release workflow, clearing the runners' Node 20 deprecation warnings. The v0.51.0 release job warned on checkout; the dispatch dry run additionally warned on upload-artifact (its step only runs on dry runs), where v5 still targets Node 20 and v7 is the first Node 24 major with the same `name`/`path` inputs
 
 ## [0.51.0] - 2026-07-27
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.51.0</string>
+	<string>0.51.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.51.0</string>
+	<string>0.51.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary

The v0.51.0 release job annotated a deprecation warning: `actions/checkout@v4` targets Node 20, which GitHub Actions runners have deprecated and force onto Node 24. Bumped checkout to v5.

A `workflow_dispatch` dry run on this branch surfaced a second offender the tag run never hit: `actions/upload-artifact@v4`, whose step only executes on dry runs. v5 still targets Node 20 (verified against its action.yml), so it goes straight to v7 — the first Node 24 major, same `name`/`path` inputs.

This is the only workflow in the repo pinning actions; the CodeQL checks come from GitHub's default setup, not repo files.

Version 0.51.0 → 0.51.1 with a CHANGELOG entry.

## Test plan

- [x] `workflow_dispatch` dry run on this branch (build + test + DMG + artifact upload): completes with zero deprecation annotations — https://github.com/dariuscorvus/iqualize/actions/runs/30223585396