### PR TITLE
Compensate capture ring clock drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.51.2] - 2026-07-27
+
+### Fixed
+- The capture ring buffer had no drift handling (#133): the helper fills it on the tap aggregate's clock, the app drains it on the output device's clock, and when those clocks differ (USB or Bluetooth output) the fill level walks until the ring slips a sub-millisecond chunk. The reader now holds the ring at a fixed fill level with a micro-resampler (fill-level P-controller, Catmull-Rom interpolation, correction clamped to ±500 ppm ≈ 0.87 cent — inaudible; bit-exact passthrough at zero drift). Verified against ±100 ppm synthetic drift: fill converges, zero slips, a coherent 4 s tone measurement reads within 0.1 dB
+- Capture latency is now pinned at ~43 ms (2048 frames at 48 kHz). Previously it was whatever the startup race left in the ring — anywhere from 0 to 341 ms
+- The ring's head indices are now published with release/acquire ordering (new `IQRingAtomics` C shim). The plain stores let the reader observe an advanced write head before the sample data behind it on arm64
+- Investigating #133's evidence found the measured coherence loss (1-5 dB, run to run) came mostly from a different bug pair: the e2e script's own `afplay` and `sox` are new Core Audio processes, so the app restarted its tap (#87 poll) inside the 4 s measurement window, splicing ~100 ms of silence per restart. `e2e-tap-test.sh` now measures the last 4 s of a 12 s capture, past the restarts. On host-clocked device pairs (BlackHole) the pre-fix ring measures clean with the fixed window — real clock drift needs independent hardware clocks
+
+### Changed
+- `Spikes/TapAttenuationE2E`: `goertzel.py` gained a `--coherent` mode (whole-window integration, degraded by any phase discontinuity) and `e2e-tap-test.sh` uses it as a phase-coherence gate (block vs coherent ≤ 0.5 dB); the unity tolerance tightened from 3 dB back to 1 dB. Measured: 6 consecutive runs at +0.00 dB on both checks (16ch and 2ch)
+
+### Added
+- `iqualize status` reports capture-ring drift telemetry: `Capture: fill 2048 frames, drift +0.0 ppm, underruns 0, resyncs 0`. Counters reset on every capture (re)start (device switch, sleep/wake)
+
 ## [0.51.1] - 2026-07-27
 
 ### Changed

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,15 @@ let package = Package(
             name: "IQControlProtocol",
             path: "Sources/IQControlProtocol"
         ),
+        // C shim for the capture ring's cross-process head publication
+        // (#133): release-store / acquire-load on the shared header's 64-bit
+        // head fields. C because the macOS 14 floor rules out
+        // Synchronization.Atomic and swift-atomics is a heavy dependency for
+        // four functions.
+        .target(
+            name: "IQRingAtomics",
+            path: "Sources/IQRingAtomics"
+        ),
         // Named "iqualize-cli", not "iqualize" — a same-named target would collide with
         // the "iQualize" app target's binary on macOS's default case-insensitive filesystem.
         // install.sh renames the built binary to "iqualize" when it copies it into place.
@@ -30,6 +39,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Markdown", package: "swift-markdown"),
                 "IQControlProtocol",
+                "IQRingAtomics",
             ],
             path: "Sources/iQualize",
             exclude: ["Info.plist"],
@@ -54,6 +64,7 @@ let package = Package(
         // Continuity (just like Spotify). See CONTINUITY.md.
         .executableTarget(
             name: "iQualizeCapture",
+            dependencies: ["IQRingAtomics"],
             path: "Sources/iQualizeCapture",
             linkerSettings: [
                 .linkedFramework("CoreAudio"),

--- a/Sources/IQControlProtocol/CLIControlMessages.swift
+++ b/Sources/IQControlProtocol/CLIControlMessages.swift
@@ -70,8 +70,18 @@ public struct CLIStatusPayload: Codable, Sendable {
     /// Git commit the app was built from (IQGitCommit, stamped by install.sh).
     /// nil for unstamped builds (e.g. plain `swift build` outside a git checkout).
     public var gitCommit: String?
+    /// Capture-ring drift telemetry (#133). All nil when the engine is
+    /// stopped or the app predates the fields. The counters reset on every
+    /// capture (re)start — device switches, sleep/wake, and config changes
+    /// each build a fresh capture client.
+    public var captureFillFrames: Int?
+    /// Applied drift correction in ppm (positive = reader consuming faster
+    /// than nominal).
+    public var captureDriftPpm: Double?
+    public var captureUnderruns: UInt64?
+    public var captureOverrunResyncs: UInt64?
 
-    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool, appVersion: String? = nil, gitCommit: String? = nil) {
+    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool, appVersion: String? = nil, gitCommit: String? = nil, captureFillFrames: Int? = nil, captureDriftPpm: Double? = nil, captureUnderruns: UInt64? = nil, captureOverrunResyncs: UInt64? = nil) {
         self.bypassed = bypassed
         self.activePresetID = activePresetID
         self.activePresetName = activePresetName
@@ -83,6 +93,10 @@ public struct CLIStatusPayload: Codable, Sendable {
         self.isRunning = isRunning
         self.appVersion = appVersion
         self.gitCommit = gitCommit
+        self.captureFillFrames = captureFillFrames
+        self.captureDriftPpm = captureDriftPpm
+        self.captureUnderruns = captureUnderruns
+        self.captureOverrunResyncs = captureOverrunResyncs
     }
 }
 

--- a/Sources/IQRingAtomics/include/iq_ring_atomics.h
+++ b/Sources/IQRingAtomics/include/iq_ring_atomics.h
@@ -1,0 +1,35 @@
+#ifndef IQ_RING_ATOMICS_H
+#define IQ_RING_ATOMICS_H
+
+#include <stdint.h>
+
+// 64-bit acquire/release pair for the capture ring's head fields, shared
+// between the iQualizeCapture helper (writer) and the app (reader) across a
+// MAP_SHARED mapping. The writer's release-store of writeHead pairs with the
+// reader's acquire-load so sample data written before the store is visible
+// after the load — plain loads/stores give no such guarantee on arm64.
+//
+// Clang __atomic builtins on plain uint64_t* (not _Atomic types): valid on
+// any naturally aligned 64-bit field, importable into Swift as ordinary
+// functions, and dependency-free. Both head fields sit at offsets 0 and 8 of
+// a page-aligned mapping, so alignment always holds.
+
+static inline uint64_t iq_load_acquire_u64(const uint64_t *p) {
+    return __atomic_load_n(p, __ATOMIC_ACQUIRE);
+}
+
+static inline void iq_store_release_u64(uint64_t *p, uint64_t v) {
+    __atomic_store_n(p, v, __ATOMIC_RELEASE);
+}
+
+// Relaxed variants for single-writer telemetry counters: torn-free, no
+// ordering — readers only need eventually-consistent whole values.
+static inline uint64_t iq_load_relaxed_u64(const uint64_t *p) {
+    return __atomic_load_n(p, __ATOMIC_RELAXED);
+}
+
+static inline void iq_store_relaxed_u64(uint64_t *p, uint64_t v) {
+    __atomic_store_n(p, v, __ATOMIC_RELAXED);
+}
+
+#endif /* IQ_RING_ATOMICS_H */

--- a/Sources/IQRingAtomics/iq_ring_atomics.c
+++ b/Sources/IQRingAtomics/iq_ring_atomics.c
@@ -1,0 +1,3 @@
+// SPM requires at least one compilable source in a C target; everything
+// lives as static inline functions in the umbrella header.
+#include "include/iq_ring_atomics.h"

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -55,6 +55,8 @@ private func renderCallback(
     let interleavedCount = frames * ch
     let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
 
+    // Preallocated in start() for the AU's maximumFramesPerSlice default;
+    // growing here on the audio thread is a never-expected fallback.
     if rtScratchCapacity < interleavedCount {
         rtScratchBuffer?.deallocate()
         rtScratchBuffer = .allocate(capacity: interleavedCount)
@@ -62,9 +64,10 @@ private func renderCallback(
     }
     guard let scratch = rtScratchBuffer else { return noErr }
 
-    let read = client.read(scratch, count: interleavedCount)
-    if read < interleavedCount {
-        scratch.advanced(by: read).initialize(repeating: 0.0, count: interleavedCount - read)
+    // All-or-nothing: a full drift-compensated block (#133), or silence
+    // while the ring seeds / after an underrun.
+    if client.readResampled(scratch, frames: frames) == 0 {
+        scratch.initialize(repeating: 0.0, count: interleavedCount)
     }
 
     for i in 0..<bufferList.count {
@@ -207,6 +210,13 @@ final class AudioEngine {
     var maxGainDB: Float = 12
     private(set) var outputSampleRate: Double = 48000
 
+    /// Capture-ring drift telemetry (#133) for the CLI status surface.
+    /// nil while the engine is stopped. Counters reset on every capture
+    /// (re)start — each start() builds a fresh CaptureClient.
+    func captureTelemetry() -> CaptureClient.Telemetry? {
+        captureClient?.telemetrySnapshot()
+    }
+
     init() {
         do {
             let deviceID = try getDefaultOutputDeviceID()
@@ -263,6 +273,15 @@ final class AudioEngine {
         self.outputSampleRate = sampleRate
         rtCaptureClient = client
         rtChannelCount = channels
+
+        // Preallocate the render scratch for the AU maximumFramesPerSlice
+        // default (4096) so the render callback never allocates in practice.
+        let scratchFloats = 4096 * Int(channels)
+        if rtScratchCapacity < scratchFloats {
+            rtScratchBuffer?.deallocate()
+            rtScratchBuffer = .allocate(capacity: scratchFloats)
+            rtScratchCapacity = scratchFloats
+        }
 
         os_log(.default, log: appLog,
                "capture helper sr: %{public}.0f  ch: %{public}u  output: %{public}@",

--- a/Sources/iQualize/CaptureClient.swift
+++ b/Sources/iQualize/CaptureClient.swift
@@ -8,12 +8,14 @@
 
 import Foundation
 import Darwin
+import IQRingAtomics
 import os.log
 
 private let clientLog = OSLog(subsystem: "com.iqualize", category: "capture-client")
 
 // Must match Sources/iQualizeCapture/main.swift exactly.
-private struct SharedHeader {
+// Internal (not private) so the resampler tests can build a synthetic ring.
+struct SharedHeader {
     var writeHead: UInt64
     var readHead: UInt64
     var sampleRate: Float64
@@ -39,6 +41,67 @@ final class CaptureClient: @unchecked Sendable {
     private var dataPtr: UnsafeMutablePointer<Float>?
     private var mask: UInt64 = 0
     private var intentionallyStopping: Bool = false
+
+    // Cached field pointers into the shared header, so every cross-process
+    // atomic access goes through one audited pointer per field.
+    private var writeHeadPtr: UnsafeMutablePointer<UInt64>?
+    private var readHeadPtr: UnsafeMutablePointer<UInt64>?
+    private var capacityFrames: Int = 0
+    private var baseTargetFill: Int = 0
+
+    // Drift-compensator state (#133). Render-thread-only, same single-consumer
+    // contract as the old read(): no synchronization needed.
+    private enum DriftState { case seeding, running }
+    private var driftState: DriftState = .seeding
+    /// Absolute source read position: integer frames + fraction in [0, 1).
+    /// Kept split (not one Double) so precision never degrades with uptime.
+    private var srcFrame: UInt64 = 0
+    private var srcFrac: Double = 0
+    private var fillEMA: Double = 0
+    /// Head position when we entered .seeding. Re-seeding waits until the
+    /// writer has produced a full target *beyond* this, so recovery always
+    /// lands on fresh audio — gating on the absolute head would re-seed
+    /// instantly against a stalled writer and loop-replay the last ~2 s.
+    private var seedFloorFrames: UInt64 = 0
+    /// High-water mark of callback sizes. The effective target is at least
+    /// 2× this, so a pathologically large slice (e.g. 4096 frames) re-seeds
+    /// once at a workable fill instead of latching into permanent underrun.
+    private var maxCallbackFrames: Int = 0
+
+    // Telemetry, published from the render thread with relaxed stores and
+    // read by telemetrySnapshot() on any thread. Counters reset whenever a
+    // new CaptureClient is built — i.e. on every capture (re)start.
+    private let telemetrySlots: UnsafeMutablePointer<UInt64> = {
+        let p = UnsafeMutablePointer<UInt64>.allocate(capacity: 4)
+        p.initialize(repeating: 0, count: 4)
+        return p
+    }()
+    private enum TelemetrySlot {
+        static let fillFrames = 0
+        static let driftPpmBits = 1
+        static let underruns = 2
+        static let overrunResyncs = 3
+    }
+
+    struct Telemetry: Sendable {
+        var fillFrames: Int
+        var driftPpm: Double
+        var underruns: UInt64
+        var overrunResyncs: UInt64
+    }
+
+    func telemetrySnapshot() -> Telemetry {
+        Telemetry(
+            fillFrames: Int(truncatingIfNeeded: iq_load_relaxed_u64(telemetrySlots + TelemetrySlot.fillFrames)),
+            driftPpm: Double(bitPattern: iq_load_relaxed_u64(telemetrySlots + TelemetrySlot.driftPpmBits)),
+            underruns: iq_load_relaxed_u64(telemetrySlots + TelemetrySlot.underruns),
+            overrunResyncs: iq_load_relaxed_u64(telemetrySlots + TelemetrySlot.overrunResyncs)
+        )
+    }
+
+    deinit {
+        telemetrySlots.deallocate()
+    }
 
     /// Launches the helper, reads the handshake, maps its shared memory.
     /// Throws if anything fails — caller should treat as a hard error.
@@ -136,18 +199,42 @@ final class CaptureClient: @unchecked Sendable {
         // a predictable, world-writable path in /tmp is reachable by name.
         _ = shmPath.withCString { unlink($0) }
 
-        headerPtr = mapped.bindMemory(to: SharedHeader.self, capacity: 1)
-        dataPtr = mapped.advanced(by: headerSize)
-            .bindMemory(to: Float.self, capacity: capFloats)
-
-        sampleRate = sr
-        channels = UInt32(ch)
-        capacityFloats = UInt32(capFloats)
-        mask = UInt64(capFloats - 1)
+        attach(region: mapped, headerSize: headerSize,
+               capacityFloats: capFloats, sampleRate: sr, channels: UInt32(ch))
 
         os_log(.default, log: clientLog,
-               "capture helper ready: pid=%{public}d sr=%{public}.0f ch=%{public}u cap=%{public}d",
-               proc.processIdentifier, sr, UInt32(ch), capFloats)
+               "capture helper ready: pid=%{public}d sr=%{public}.0f ch=%{public}u cap=%{public}d target=%{public}d",
+               proc.processIdentifier, sr, UInt32(ch), capFloats, baseTargetFill)
+    }
+
+    /// Binds an already-mapped ring region and derives the drift-compensator
+    /// parameters. Split out of start() so the resampler tests can drive a
+    /// synthetic ring they allocate themselves — no helper process, no mmap.
+    func attach(region: UnsafeMutableRawPointer, headerSize: Int,
+                capacityFloats capFloats: Int, sampleRate sr: Float64, channels ch: UInt32) {
+        headerPtr = region.bindMemory(to: SharedHeader.self, capacity: 1)
+        dataPtr = region.advanced(by: headerSize)
+            .bindMemory(to: Float.self, capacity: capFloats)
+        writeHeadPtr = region
+            .advanced(by: MemoryLayout<SharedHeader>.offset(of: \.writeHead)!)
+            .assumingMemoryBound(to: UInt64.self)
+        readHeadPtr = region
+            .advanced(by: MemoryLayout<SharedHeader>.offset(of: \.readHead)!)
+            .assumingMemoryBound(to: UInt64.self)
+
+        sampleRate = sr
+        channels = ch
+        capacityFloats = UInt32(capFloats)
+        mask = UInt64(capFloats - 1)
+        capacityFrames = capFloats / Int(ch)
+        baseTargetFill = DriftPolicy.targetFillFrames(sampleRate: sr, capacityFrames: capacityFrames)
+
+        driftState = .seeding
+        seedFloorFrames = 0
+        srcFrame = 0
+        srcFrac = 0
+        fillEMA = 0
+        maxCallbackFrames = 0
     }
 
     func stop() {
@@ -170,30 +257,121 @@ final class CaptureClient: @unchecked Sendable {
         }
         headerPtr = nil
         dataPtr = nil
+        writeHeadPtr = nil
+        readHeadPtr = nil
     }
 
-    /// Read up to `count` interleaved Float32 samples. Returns the actual
-    /// count read (less than `count` on underrun). Safe to call from the
-    /// AVAudioEngine render thread — only touches mmap'd memory, no syscalls.
-    func read(_ dest: UnsafeMutablePointer<Float>, count: Int) -> Int {
-        guard let header = headerPtr, let data = dataPtr else { return 0 }
-        let writeHead = header.pointee.writeHead
-        var readHead = header.pointee.readHead
-        let capacity = UInt64(capacityFloats)
-        // If the reader fell more than `capacity` samples behind the writer,
-        // the writer has wrapped over data we never read. Skip forward so we
-        // start at recent audio instead of returning corrupted (wrapped) data.
-        if writeHead &- readHead > capacity {
-            readHead = writeHead &- capacity
+    /// Drift-compensated read for the render callback (#133): pulls `frames`
+    /// interleaved frames from the ring, resampling by a ratio a hair off 1.0
+    /// (Catmull-Rom, fill-level P-controller — see DriftPolicy) so the two
+    /// unlocked device clocks never walk the ring into an edge.
+    ///
+    /// All-or-nothing: returns `frames` with `dest` fully written, or 0 while
+    /// seeding / after an underrun (caller outputs silence). Render thread
+    /// only. Only touches mapped memory — no syscalls, no allocation.
+    func readResampled(_ dest: UnsafeMutablePointer<Float>, frames: Int) -> Int {
+        guard let data = dataPtr, let writeHeadField = writeHeadPtr,
+              let readHeadField = readHeadPtr, frames > 0 else { return 0 }
+        let ch = Int(channels)
+        let chU = UInt64(channels)
+
+        // One acquire-load snapshot per callback, paired with the helper's
+        // release-store: every sample behind this head is visible. Floor to
+        // whole frames; a torn partial frame at the head is treated as
+        // unwritten.
+        let writeFrames = iq_load_acquire_u64(writeHeadField) / chU
+
+        if frames > maxCallbackFrames { maxCallbackFrames = frames }
+        let effTarget = max(baseTargetFill, 2 * maxCallbackFrames)
+
+        if driftState == .seeding {
+            // Wait for a full target of audio past the seed floor (+1 so the
+            // interpolator's left neighbor exists), then start exactly
+            // `effTarget` behind the writer — the operating point is chosen,
+            // not startup-race-determined.
+            guard writeFrames >= seedFloorFrames &+ UInt64(effTarget) &+ 1 else {
+                iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.fillFrames, 0)
+                iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.driftPpmBits, Double(0).bitPattern)
+                return 0
+            }
+            srcFrame = DriftPolicy.seedPosition(writeFrames: writeFrames, targetFill: effTarget)
+            srcFrac = 0
+            fillEMA = Double(effTarget)
+            driftState = .running
         }
-        let avail = Int(writeHead &- readHead)
-        let toRead = min(count, avail)
+
+        var fill = Double(writeFrames &- srcFrame) - srcFrac
+
+        // Reader stalled long enough for the backlog to exceed the overrun
+        // threshold: jump back to target rather than splicing out minutes of
+        // backlog at 500 ppm. Instantaneous check — a stall is a step, not
+        // drift, so the EMA must not see it.
+        let overrunThreshold = DriftPolicy.overrunThresholdFrames(
+            targetFill: effTarget, capacityFrames: capacityFrames)
+        if fill > Double(overrunThreshold) {
+            iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.overrunResyncs,
+                                 iq_load_relaxed_u64(telemetrySlots + TelemetrySlot.overrunResyncs) &+ 1)
+            srcFrame = DriftPolicy.seedPosition(writeFrames: writeFrames, targetFill: effTarget)
+            srcFrac = 0
+            fillEMA = Double(effTarget)
+            fill = Double(effTarget)
+        }
+
+        // The fill this callback measured (post-reseed if one happened) — the
+        // quantity the controller regulates, and what telemetry reports.
+        let measuredFill = fill
+
+        let alpha = DriftPolicy.emaAlpha(frames: frames, sampleRate: sampleRate)
+        fillEMA += alpha * (fill - fillEMA)
+        let ratio = DriftPolicy.resampleRatio(fillEMA: fillEMA, targetFill: Double(effTarget),
+                                              sampleRate: sampleRate)
+
+        // Source span this callback will touch, including the interpolator's
+        // +2 lookahead. Not enough data means the writer stalled — the target
+        // is ~4× a normal callback, so this is never tight timing. Zero-fill,
+        // count once, and wait in .seeding for fresh post-stall audio.
+        let span = UInt64(Double(frames) * ratio + srcFrac) &+ UInt64(DriftPolicy.windowMarginFrames)
+        if srcFrame &+ span >= writeFrames {
+            iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.underruns,
+                                 iq_load_relaxed_u64(telemetrySlots + TelemetrySlot.underruns) &+ 1)
+            driftState = .seeding
+            seedFloorFrames = writeFrames
+            iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.fillFrames, 0)
+            return 0
+        }
+
+        // Interpolating copy. No separate history buffer: the ring behind the
+        // read position stays valid for capacity − fill ≈ 300 ms, so x[-1] is
+        // always resident, and the span check above bounds x[+2].
+        var idx = srcFrame
+        var frac = srcFrac
         let m = mask
-        for i in 0..<toRead {
-            dest[i] = data[Int(readHead & m)]
-            readHead &+= 1
+        for f in 0..<frames {
+            let t = Float(frac)
+            let base = (idx &- 1) &* chU
+            for c in 0..<ch {
+                let cU = UInt64(c)
+                let xm1 = data[Int((base &+ cU) & m)]
+                let x0 = data[Int((base &+ chU &+ cU) & m)]
+                let x1 = data[Int((base &+ 2 &* chU &+ cU) & m)]
+                let x2 = data[Int((base &+ 3 &* chU &+ cU) & m)]
+                dest[f * ch + c] = DriftPolicy.catmullRom(xm1, x0, x1, x2, t)
+            }
+            frac += ratio
+            let carry = Int(frac)   // 0 or 1: ratio ≤ 1 + 500 ppm
+            idx &+= UInt64(carry)
+            frac -= Double(carry)
         }
-        header.pointee.readHead = readHead
-        return toRead
+        srcFrame = idx
+        srcFrac = frac
+
+        // Floor of the fractional position, release-published for symmetry
+        // and tooling — the writer never reads it.
+        iq_store_release_u64(readHeadField, srcFrame &* chU)
+        iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.fillFrames,
+                             UInt64(max(0, measuredFill.rounded())))
+        iq_store_relaxed_u64(telemetrySlots + TelemetrySlot.driftPpmBits,
+                             ((ratio - 1) * 1e6).bitPattern)
+        return frames
     }
 }

--- a/Sources/iQualize/DriftPolicy.swift
+++ b/Sources/iQualize/DriftPolicy.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Pure math for the capture-ring drift compensator (#133). The capture
+/// helper fills the ring on the tap aggregate's clock; the render callback
+/// drains it on the output device's clock. The clocks are unlocked, so the
+/// reader resamples by a ratio a hair off 1.0 to hold the ring's fill level
+/// at a fixed target — CaptureClient owns the state (positions, EMA,
+/// counters); everything computable lives here so the unit tests exercise
+/// the exact production math without an audio device.
+enum DriftPolicy {
+
+    /// Fill-smoothing time constant. Instantaneous fill sawtooths by a full
+    /// writer IO block (≤1024 frames) at the IO cycle rate; 0.5 s attenuates
+    /// that ripple by >30 dB so the controller sees the mean, while real
+    /// drift (which changes over minutes) passes through.
+    static let emaTauSeconds: Double = 0.5
+
+    /// Fill-error decay time constant of the P-controller. With
+    /// ratio − 1 = error/(τ·sr), fill error decays exponentially with τ = 3 s
+    /// — at least 6× the EMA τ, so the cascaded loop cannot oscillate. Pure P
+    /// leaves a steady-state error of drift·τ·sr (14 frames at 100 ppm):
+    /// acceptable, and an integrator would add windup for nothing.
+    static let controllerTauSeconds: Double = 3.0
+
+    /// Resample-ratio clamp. ±500 ppm is 0.87 cent of pitch — far below
+    /// audibility — and covers real consumer clock mismatch (typically
+    /// <200 ppm) 2.5× over. Large fill errors are removed by re-seeding, not
+    /// by the ratio, so the clamp only ever handles genuine drift.
+    static let maxCorrection: Double = 500e-6
+
+    /// Source frames the interpolator needs beyond the integer read position:
+    /// Catmull-Rom takes one frame behind and two ahead.
+    static let windowMarginFrames = 3
+
+    /// Fill target the controller holds, and therefore the capture path's
+    /// pinned latency: ~40 ms, floored at 2048 frames, capped at a quarter of
+    /// the ring. 2048 at 48 kHz clears the writer's block (≤1024) plus the
+    /// reader's slice (512) plus scheduling jitter with ~4× margin — so an
+    /// underrun means the writer actually stalled, never tight timing — and
+    /// leaves ~300 ms of overrun headroom. Before #133 the operating point
+    /// was wherever the start() race left it, anywhere in 0–341 ms.
+    static func targetFillFrames(sampleRate: Double, capacityFrames: Int) -> Int {
+        min(capacityFrames / 4, max(2048, Int(sampleRate * 0.04)))
+    }
+
+    /// Fill level that triggers a re-seed instead of resampling. Instantaneous
+    /// fill legitimately spikes one writer block above target; 3× target is
+    /// unreachable except by a real reader stall, and splicing out that much
+    /// backlog at 500 ppm would take minutes — jumping is the right recovery.
+    /// Capped clear of capacity so the re-seed lands well before writer wrap.
+    static func overrunThresholdFrames(targetFill: Int, capacityFrames: Int) -> Int {
+        min(3 * targetFill, capacityFrames - capacityFrames / 8)
+    }
+
+    /// EMA coefficient for a callback of `frames` frames: 1 − exp(−n/(τ·sr)),
+    /// so the time constant stays emaTauSeconds regardless of slice size.
+    static func emaAlpha(frames: Int, sampleRate: Double) -> Double {
+        1.0 - exp(-Double(frames) / (emaTauSeconds * sampleRate))
+    }
+
+    /// Resample ratio (source frames consumed per output frame):
+    /// 1 + clamp((fillEMA − target)/(τ·sr), ±maxCorrection). Above target →
+    /// ratio > 1, consume faster, fill falls.
+    static func resampleRatio(fillEMA: Double, targetFill: Double, sampleRate: Double) -> Double {
+        let correction = (fillEMA - targetFill) / (controllerTauSeconds * sampleRate)
+        return 1.0 + min(max(correction, -maxCorrection), maxCorrection)
+    }
+
+    /// Absolute source frame to (re)seed the read position at: exactly
+    /// targetFill behind the writer.
+    static func seedPosition(writeFrames: UInt64, targetFill: Int) -> UInt64 {
+        writeFrames &- UInt64(targetFill)
+    }
+
+    /// 4-point Catmull-Rom interpolation at fraction t ∈ [0, 1) between x0
+    /// and x1, Horner form. Bit-exact passthrough at t = 0. Chosen over
+    /// linear interpolation because linear dips up to −12 dB at 20 kHz at
+    /// t = 0.5, which the cycling fraction would turn into audible HF
+    /// flutter; Catmull-Rom stays within ~1 dB below 12 kHz.
+    @inline(__always)
+    static func catmullRom(_ xm1: Float, _ x0: Float, _ x1: Float, _ x2: Float, _ t: Float) -> Float {
+        let c1 = 0.5 * (x1 - xm1)
+        let c2 = xm1 - 2.5 * x0 + 2 * x1 - 0.5 * x2
+        let c3 = 0.5 * (x2 - xm1) + 1.5 * (x0 - x1)
+        return x0 + t * (c1 + t * (c2 + t * c3))
+    }
+}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.51.1</string>
+	<string>0.51.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.51.1</string>
+	<string>0.51.2</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -385,7 +385,8 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     }
 
     func statusSnapshot() -> CLIStatusPayload {
-        CLIStatusPayload(
+        let capture = audioEngine.captureTelemetry()
+        return CLIStatusPayload(
             bypassed: audioEngine.bypassed,
             activePresetID: audioEngine.activePreset.id,
             activePresetName: audioEngine.activePreset.name,
@@ -396,7 +397,11 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             outputDeviceName: audioEngine.outputDeviceName,
             isRunning: audioEngine.isRunning,
             appVersion: appVersion,
-            gitCommit: appGitCommit
+            gitCommit: appGitCommit,
+            captureFillFrames: capture?.fillFrames,
+            captureDriftPpm: capture?.driftPpm,
+            captureUnderruns: capture?.underruns,
+            captureOverrunResyncs: capture?.overrunResyncs
         )
     }
 

--- a/Sources/iQualizeCapture/main.swift
+++ b/Sources/iQualizeCapture/main.swift
@@ -17,6 +17,7 @@ import CoreAudio
 import AudioToolbox
 import Darwin
 import Foundation
+import IQRingAtomics
 import os.log
 
 private let capLog = OSLog(subsystem: "com.iqualize", category: "capture-helper")
@@ -42,6 +43,9 @@ nonisolated(unsafe) var shmPath: String = "/tmp/iqualize-cap-\(getpid()).bin"
 nonisolated(unsafe) var shmFD: Int32 = -1
 nonisolated(unsafe) var shmTotalSize: size_t = 0
 nonisolated(unsafe) var headerPtr: UnsafeMutablePointer<SharedHeader>? = nil
+/// Points at headerPtr.pointee.writeHead — the one field published across
+/// processes with release semantics (see iq_ring_atomics.h).
+nonisolated(unsafe) var writeHeadFieldPtr: UnsafeMutablePointer<UInt64>? = nil
 nonisolated(unsafe) var dataPtr: UnsafeMutablePointer<Float>? = nil
 nonisolated(unsafe) var dataMask: UInt64 = 0
 nonisolated(unsafe) var tapID = AudioObjectID(kAudioObjectUnknown)
@@ -327,6 +331,9 @@ func run() {
         channels: channels,
         capacityFloats: UInt32(dataFloatsPow2)
     )
+    writeHeadFieldPtr = mapped
+        .advanced(by: MemoryLayout<SharedHeader>.offset(of: \.writeHead)!)
+        .assumingMemoryBound(to: UInt64.self)
     dataPtr = mapped.advanced(by: headerSize).bindMemory(to: Float.self, capacity: dataFloatsPow2)
     memset(dataPtr, 0, dataBytes)
 
@@ -365,10 +372,12 @@ func run() {
     }
 
     let ioBlock: AudioDeviceIOBlock = { _, inInputData, _, outOutputData, _ in
-        guard let header = headerPtr, let data = dataPtr else { return }
+        guard let header = headerPtr, let data = dataPtr,
+              let writeHeadField = writeHeadFieldPtr else { return }
         let mask = dataMask
 
         let inBufList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inInputData))
+        // Plain load: this IOProc thread is the only writer of writeHead.
         var writeHead = header.pointee.writeHead
 
         for i in 0..<inBufList.count {
@@ -380,7 +389,9 @@ func run() {
                 writeHead &+= 1
             }
         }
-        header.pointee.writeHead = writeHead
+        // Release-store pairs with the reader's acquire-load: the sample
+        // stores above must be visible before the advanced head is.
+        iq_store_release_u64(writeHeadField, writeHead)
 
         let outBufList = UnsafeMutableAudioBufferListPointer(outOutputData)
         for i in 0..<outBufList.count {

--- a/Sources/iqualize-cli/CLIOutput.swift
+++ b/Sources/iqualize-cli/CLIOutput.swift
@@ -42,7 +42,7 @@ func formatVersion(_ status: CLIStatusPayload) -> String {
 
 func formatStatus(_ status: CLIStatusPayload) -> String {
     let mode = status.gainIsGlobal ? "shared" : "per-preset"
-    return """
+    var lines = """
     Version: \(formatVersion(status))
     Bypass: \(status.bypassed ? "on" : "off")
     Preset: \(status.activePresetName)
@@ -50,4 +50,14 @@ func formatStatus(_ status: CLIStatusPayload) -> String {
     Balance: \(formatBalance(status.balance))
     Output device: \(status.outputDeviceName)
     """
+    // Drift telemetry (#133); absent while the engine is stopped or from
+    // older apps. Counters reset on every capture (re)start.
+    if let fill = status.captureFillFrames,
+       let ppm = status.captureDriftPpm,
+       let underruns = status.captureUnderruns,
+       let resyncs = status.captureOverrunResyncs {
+        lines += "\n" + String(format: "Capture: fill %d frames, drift %+.1f ppm, underruns %d, resyncs %d",
+                               fill, ppm, underruns, resyncs)
+    }
+    return lines
 }

--- a/Spikes/TapAttenuationE2E/.gitignore
+++ b/Spikes/TapAttenuationE2E/.gitignore
@@ -1,4 +1,5 @@
 setoutput
 vpio_tone
 sine997.wav
+sine997-16s.wav
 .*.wav

--- a/Spikes/TapAttenuationE2E/e2e-tap-test.sh
+++ b/Spikes/TapAttenuationE2E/e2e-tap-test.sh
@@ -22,25 +22,33 @@
 # Needs: brew install sox blackhole-16ch (blackhole-2ch for the stereo
 # control run: ./e2e-tap-test.sh "BlackHole 2ch"). First run triggers a
 # macOS microphone-permission prompt — deny it and the capture is silent.
-# Takes over the default output for ~20 s and restarts iQualize; restores
+# Takes over the default output for ~40 s and restarts iQualize; restores
 # both on exit.
 set -u
 DIR="$(cd "$(dirname "$0")" && pwd)"
 DEVICE="${1:-BlackHole 16ch}"
-SINE="$DIR/sine997.wav"
+# 16 s tone: the measurement window is the LAST 4 s of a 12 s capture. afplay
+# and sox are themselves new Core Audio processes, and iQualize restarts its
+# tap when the process list grows (#87, 2 s poll) — so the first ~4 s of every
+# through-iQualize capture contain up to two full tap restarts, each splicing
+# ~100 ms of silence. Block averaging shrugged that off; the #133 coherence
+# check cannot. Measuring the tail keeps the tooling's own restarts out of
+# the window.
+SINE="$DIR/sine997-16s.wav"
 APP=/Applications/iQualize.app
 
 command -v sox >/dev/null || { echo "FAIL: sox not installed (brew install sox)"; exit 1; }
 [ -x "$DIR/setoutput" ] && [ "$DIR/setoutput" -nt "$DIR/setoutput.swift" ] \
     || swiftc -O -framework CoreAudio -o "$DIR/setoutput" "$DIR/setoutput.swift" || exit 1
-[ -f "$SINE" ] || python3 "$DIR/gen_sine.py" "$SINE" || exit 1
+[ -f "$SINE" ] || python3 "$DIR/gen_sine.py" "$SINE" 16 || exit 1
 "$DIR/setoutput" 2>/dev/null | grep -qi "${DEVICE}" \
     || { echo "FAIL: output device \"$DEVICE\" not found (brew install --cask blackhole-16ch)"; exit 1; }
 
-rms() { # capture 4s from $DEVICE (ch 1+2), measure the 997 Hz test tone via
-        # a Goertzel bin — sub-Hz selectivity, so background playback on the
-        # machine can't skew the reading
-    sox -q -t coreaudio "$DEVICE" -b 16 "$DIR/.cap.wav" trim 0 4 remix 1,2 2>/dev/null
+rms() { # capture 12 s from $DEVICE (ch 1+2), keep the last 4 s (see the SINE
+        # comment above), measure the 997 Hz test tone via a Goertzel bin —
+        # sub-Hz selectivity, so background playback can't skew the reading
+    sox -q -t coreaudio "$DEVICE" -b 16 "$DIR/.cap-full.wav" trim 0 12 remix 1,2 2>/dev/null
+    sox -q "$DIR/.cap-full.wav" "$DIR/.cap.wav" trim -4 2>/dev/null
     python3 "$DIR/goertzel.py" "$DIR/.cap.wav" 997
 }
 
@@ -84,14 +92,25 @@ sleep 1.5
 THROUGH=$(play_and_measure)
 echo "iQualize RMS (bypass on):   ${THROUGH} dB"
 
-# Tolerance 3 dB: the capture pipeline's ring buffer occasionally slips a
-# sub-ms chunk (clock drift between the tap aggregate and the render device),
-# which adds up to ~±2 dB of run-to-run jitter on this measurement — verified
-# present on builds before and after #131. Every real failure mode this test
-# guards against (missed stereo-pair step, lost compensation, call ducking)
-# is 6 dB or more.
+# Tolerance 1 dB. It was 3 dB to absorb ~±2 dB of run-to-run jitter that
+# turned out to be mid-window tap restarts (see the SINE comment) — with the
+# measurement window past the restarts and the ring drift-compensated (#133)
+# the reading is stable, and every real failure mode this test guards against
+# (missed stereo-pair step, lost compensation, call ducking) is 6 dB or more.
 DELTA=$(echo "$THROUGH $BASELINE" | awk '{printf "%+.2f", $1 - $2}')
 echo "delta:                      ${DELTA} dB"
-echo "$DELTA" | awk '{d=$1; if (d<0) d=-d; exit !(d<=3.0)}' \
-    && echo "PASS: unity within 3 dB — OS attenuation exists and is fully compensated" \
+echo "$DELTA" | awk '{d=$1; if (d<0) d=-d; exit !(d<=1.0)}' \
+    && echo "PASS: unity within 1 dB — OS attenuation exists and is fully compensated" \
     || echo "FAIL: not unity — see delta (positive = over-boost, negative = under-compensation)"
+
+# --- phase coherence through the capture ring (#133) ---
+# .cap.wav still holds the iQualize-path capture. Coherent whole-window
+# integration must agree with the block-averaged reading: any phase break in
+# the window — a ring slip under clock drift, a tap restart — drags the
+# coherent number down while barely moving the block average.
+COHERENT=$(python3 "$DIR/goertzel.py" "$DIR/.cap.wav" 997 --coherent)
+CDELTA=$(echo "$THROUGH $COHERENT" | awk '{printf "%+.2f", $1 - $2}')
+echo "coherent RMS (same capture): ${COHERENT} dB (block - coherent = ${CDELTA} dB)"
+echo "$CDELTA" | awk '{d=$1; if (d<0) d=-d; exit !(d<=0.5)}' \
+    && echo "PASS: phase-coherent — no ring slips in the capture path" \
+    || echo "FAIL: coherent reading diverges — the capture ring is slipping (#133 regression)"

--- a/Spikes/TapAttenuationE2E/gen_sine.py
+++ b/Spikes/TapAttenuationE2E/gen_sine.py
@@ -21,6 +21,8 @@ AMP_DB = -30.0
 
 amp = 10 ** (AMP_DB / 20)
 path = sys.argv[1] if len(sys.argv) > 1 else "sine.wav"
+if len(sys.argv) > 2:
+    SECONDS = int(sys.argv[2])
 
 w = wave.open(path, "w")
 w.setnchannels(2)
@@ -32,4 +34,4 @@ for i in range(SR * SECONDS):
     frames += struct.pack("<hh", s, s)
 w.writeframes(bytes(frames))
 w.close()
-print(f"{path}: {SECONDS}s 440 Hz sine at {AMP_DB} dBFS, {SR} Hz stereo")
+print(f"{path}: {SECONDS}s {FREQ:.0f} Hz sine at {AMP_DB} dBFS, {SR} Hz stereo")

--- a/Spikes/TapAttenuationE2E/goertzel.py
+++ b/Spikes/TapAttenuationE2E/goertzel.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
 """Measure the RMS level (dBFS) of a single test tone in a 16-bit mono WAV.
 
-Goertzel per 1-second block, power-averaged across blocks. Two deliberate
-properties:
+Default mode: Goertzel per 1-second block, power-averaged across blocks. Two
+deliberate properties:
 - 1 s blocks put an integer-Hz tone exactly on a bin (no scalloping), and
-  incoherent (power) averaging keeps occasional sub-ms ring-buffer slips in
-  the capture path from reading as level loss — a phase jump only degrades
-  the one block it lands in. Coherent integration over the whole file would
-  punish a single slip by several dB.
+  incoherent (power) averaging is robust to phase discontinuities — a phase
+  jump only degrades the one block it lands in.
 - The ~1 Hz-wide detector means background music, speech, or noise on the
   capture doesn't move the reading the way wideband RMS does.
 
-Usage: goertzel.py capture.wav 997
+--coherent mode: a single Goertzel over the largest whole-second prefix.
+Any phase discontinuity in the window — a ring slip under clock drift
+(#133), a tap restart, a dropped capture buffer — drags this reading down
+while leaving block mode nearly untouched. The difference between the two
+modes is therefore a direct phase-coherence check on the capture path.
+
+Usage: goertzel.py capture.wav 997 [--coherent]
 """
 import math
 import struct
@@ -19,6 +23,7 @@ import sys
 import wave
 
 path, freq = sys.argv[1], float(sys.argv[2])
+coherent = "--coherent" in sys.argv[3:]
 w = wave.open(path)
 if w.getsampwidth() != 2 or w.getnchannels() != 1:
     sys.exit("expected 16-bit mono WAV")
@@ -38,13 +43,20 @@ def block_rms(block, k):
     amp = 2.0 * math.sqrt(max(power, 1e-30)) / m
     return amp / math.sqrt(2.0)
 
-blocks = max(1, n // sr)
-powers = []
-for b in range(blocks):
-    block = x[b * sr:(b + 1) * sr]
+def measure(block):
     k0 = round(freq * len(block) / sr)
-    rms = max(block_rms(block, k) for k in range(k0 - 1, k0 + 2))
-    powers.append(rms * rms)
+    return max(block_rms(block, k) for k in range(k0 - 1, k0 + 2))
 
-mean_rms = math.sqrt(sum(powers) / len(powers))
+if coherent:
+    # Whole-second prefix keeps the integer-Hz tone bin-exact.
+    prefix = max(1, n // sr) * sr
+    mean_rms = measure(x[:min(prefix, n)])
+else:
+    blocks = max(1, n // sr)
+    powers = []
+    for b in range(blocks):
+        rms = measure(x[b * sr:(b + 1) * sr])
+        powers.append(rms * rms)
+    mean_rms = math.sqrt(sum(powers) / len(powers))
+
 print(f"{20 * math.log10(max(mean_rms, 1e-15)):.2f}")

--- a/Tests/iQualizeTests/CaptureClientResampleTests.swift
+++ b/Tests/iQualizeTests/CaptureClientResampleTests.swift
@@ -1,0 +1,276 @@
+import XCTest
+@testable import iQualize
+
+/// End-to-end tests of CaptureClient.readResampled (#133) against a synthetic
+/// ring the test owns — no helper process, no mmap, no audio device. The
+/// writer produces interleaved sines at 48 kHz × (1 ± drift) relative to the
+/// reader's consumption, exactly the unlocked-clock situation the drift
+/// compensator exists for.
+final class CaptureClientResampleTests: XCTestCase {
+
+    private static let headerSize = 64          // matches the helper's (stride+63)&~63
+    private static let capacityFloats = 32768   // 16384 stereo frames, power of two
+    private static let sampleRate = 48000.0
+    private static let callbackFrames = 512
+    private static let amplitude = 0.5
+    private static let toneL = 997.0
+    private static let toneR = 1499.0
+
+    /// Owns the ring region and writes drifting interleaved stereo sines the
+    /// way the capture helper does: sample stores, then the head.
+    private final class SyntheticWriter {
+        let region: UnsafeMutableRawPointer
+        let data: UnsafeMutablePointer<Float>
+        let writeHeadPtr: UnsafeMutablePointer<UInt64>
+        let mask: UInt64
+        var head: UInt64 = 0                    // in floats
+        var phaseL = 0.0
+        var phaseR = 0.0
+        var pendingFrames = 0.0
+
+        init() {
+            region = UnsafeMutableRawPointer.allocate(
+                byteCount: headerSize + capacityFloats * MemoryLayout<Float>.size,
+                alignment: 4096)
+            let header = region.bindMemory(to: SharedHeader.self, capacity: 1)
+            header.pointee = SharedHeader(
+                writeHead: 0, readHead: 0,
+                sampleRate: sampleRate, channels: 2,
+                capacityFloats: UInt32(capacityFloats),
+                _pad: (0, 0, 0))
+            data = region.advanced(by: headerSize)
+                .bindMemory(to: Float.self, capacity: capacityFloats)
+            data.initialize(repeating: 0, count: capacityFloats)
+            writeHeadPtr = region
+                .advanced(by: MemoryLayout<SharedHeader>.offset(of: \.writeHead)!)
+                .assumingMemoryBound(to: UInt64.self)
+            mask = UInt64(capacityFloats - 1)
+        }
+
+        deinit { region.deallocate() }
+
+        /// One reader-callback's worth of wall-clock production at the
+        /// writer's (drifting) rate, whole frames with remainder carry.
+        func produce(rateFactor: Double) {
+            pendingFrames += Double(callbackFrames) * rateFactor
+            let whole = Int(pendingFrames)
+            pendingFrames -= Double(whole)
+            write(frames: whole)
+        }
+
+        func write(frames: Int) {
+            let incL = 2 * Double.pi * toneL / sampleRate
+            let incR = 2 * Double.pi * toneR / sampleRate
+            for _ in 0..<frames {
+                data[Int(head & mask)] = Float(amplitude * sin(phaseL))
+                data[Int((head &+ 1) & mask)] = Float(amplitude * sin(phaseR))
+                head &+= 2
+                phaseL = (phaseL + incL).truncatingRemainder(dividingBy: 2 * .pi)
+                phaseR = (phaseR + incR).truncatingRemainder(dividingBy: 2 * .pi)
+            }
+            writeHeadPtr.pointee = head
+        }
+    }
+
+    private func makeClient(_ writer: SyntheticWriter) -> CaptureClient {
+        let client = CaptureClient()
+        client.attach(region: writer.region, headerSize: Self.headerSize,
+                      capacityFloats: Self.capacityFloats,
+                      sampleRate: Self.sampleRate, channels: 2)
+        return client
+    }
+
+    /// Coherent single-window tone amplitude via complex correlation — the
+    /// measurement that reads 1-5 dB low on the pre-#133 pipeline.
+    private func coherentAmplitude(_ samples: ArraySlice<Float>, frequency: Double) -> Double {
+        var re = 0.0, im = 0.0
+        var phase = 0.0
+        let inc = 2 * Double.pi * frequency / Self.sampleRate
+        for s in samples {
+            re += Double(s) * cos(phase)
+            im -= Double(s) * sin(phase)
+            phase += inc
+        }
+        let n = Double(samples.count)
+        return 2 * (re * re + im * im).squareRoot() / n
+    }
+
+    private func channel(_ interleaved: [Float], _ ch: Int) -> [Float] {
+        stride(from: ch, to: interleaved.count, by: 2).map { interleaved[$0] }
+    }
+
+    /// Runs `seconds` of lockstep writer/reader simulation, returning the
+    /// interleaved reader output.
+    private func run(client: CaptureClient, writer: SyntheticWriter,
+                     seconds: Double, rateFactor: Double) -> [Float] {
+        let callbacks = Int(seconds * Self.sampleRate / Double(Self.callbackFrames))
+        let dest = UnsafeMutablePointer<Float>.allocate(capacity: Self.callbackFrames * 2)
+        defer { dest.deallocate() }
+        var output: [Float] = []
+        output.reserveCapacity(callbacks * Self.callbackFrames * 2)
+        for _ in 0..<callbacks {
+            writer.produce(rateFactor: rateFactor)
+            let got = client.readResampled(dest, frames: Self.callbackFrames)
+            if got == 0 {
+                output.append(contentsOf: [Float](repeating: 0, count: Self.callbackFrames * 2))
+            } else {
+                output.append(contentsOf: UnsafeBufferPointer(start: dest, count: Self.callbackFrames * 2))
+            }
+        }
+        return output
+    }
+
+    // MARK: - Steady drift
+
+    func testDriftedWriterProducesCoherentOutputAndConvergedFill() {
+        for drift in [100e-6, 0.0, -100e-6] {
+            let writer = SyntheticWriter()
+            let client = makeClient(writer)
+            let output = run(client: client, writer: writer, seconds: 30, rateFactor: 1 + drift)
+
+            let telemetry = client.telemetrySnapshot()
+            XCTAssertEqual(telemetry.underruns, 0, "drift \(drift): no underruns in steady state")
+            XCTAssertEqual(telemetry.overrunResyncs, 0, "drift \(drift): no resyncs in steady state")
+            // Converged fill: target + drift·τ·sr residual, ± ripple.
+            let expectedFill = 2048.0 + drift * DriftPolicy.controllerTauSeconds * Self.sampleRate
+            XCTAssertEqual(Double(telemetry.fillFrames), expectedFill, accuracy: 20,
+                           "drift \(drift): fill converges near target")
+            XCTAssertEqual(telemetry.driftPpm, drift * 1e6, accuracy: 5,
+                           "drift \(drift): reported correction matches the injected drift")
+
+            // Analysis window: the last 4 s, long after convergence.
+            let left = channel(output, 0)
+            let right = channel(output, 1)
+            let window = Int(4 * Self.sampleRate)
+            let tailL = left[(left.count - window)...]
+            let tailR = right[(right.count - window)...]
+
+            // The resampler consumes `1+drift` source frames per output frame,
+            // so the tone lands at f·(1+drift) in the reader's domain — the
+            // physically correct result for unlocked clocks. Coherent
+            // integration at that frequency must read the full source level:
+            // this is exactly the measurement that reads 1-5 dB low on the
+            // slipping pre-#133 pipeline.
+            let ampL = coherentAmplitude(tailL, frequency: Self.toneL * (1 + drift))
+            let dbErrorL = 20 * log10(ampL / Self.amplitude)
+            XCTAssertEqual(dbErrorL, 0, accuracy: 0.1,
+                           "drift \(drift): coherent 4 s tone level within 0.1 dB")
+
+            let ampR = coherentAmplitude(tailR, frequency: Self.toneR * (1 + drift))
+            XCTAssertEqual(20 * log10(ampR / Self.amplitude), 0, accuracy: 0.1,
+                           "drift \(drift): right channel intact")
+
+            // No splice: a dropped/repeated/silenced chunk steps the waveform
+            // harder than a continuous 997 Hz sine ever can.
+            let maxSlope = Float(1.05 * Self.amplitude * 2 * Double.pi * Self.toneL * (1 + drift) / Self.sampleRate)
+            var maxDelta: Float = 0
+            var prev = tailL.first!
+            for s in tailL.dropFirst() {
+                maxDelta = max(maxDelta, abs(s - prev))
+                prev = s
+            }
+            XCTAssertLessThanOrEqual(maxDelta, maxSlope,
+                                     "drift \(drift): no phase discontinuity in the output")
+
+            // Channel separation: the right tone must not appear on the left.
+            // Frame-based positions make L/R misalignment structural nonsense;
+            // rectangular-window leakage of the 1499 Hz tone sits near -76 dB,
+            // an actual swap at 0 dB.
+            let bleed = coherentAmplitude(tailL, frequency: Self.toneR * (1 + drift))
+            XCTAssertLessThan(20 * log10(max(bleed, 1e-12) / Self.amplitude), -60,
+                              "drift \(drift): no L/R bleed")
+        }
+    }
+
+    // MARK: - Seeding
+
+    func testReadsBeforeTargetFillReturnSilenceWithoutCounting() {
+        let writer = SyntheticWriter()
+        let client = makeClient(writer)
+        let dest = UnsafeMutablePointer<Float>.allocate(capacity: Self.callbackFrames * 2)
+        defer { dest.deallocate() }
+
+        // 3 callbacks of production = 1536 frames < 2048 target.
+        for _ in 0..<3 {
+            writer.produce(rateFactor: 1.0)
+            XCTAssertEqual(client.readResampled(dest, frames: Self.callbackFrames), 0)
+        }
+        let telemetry = client.telemetrySnapshot()
+        XCTAssertEqual(telemetry.underruns, 0, "seeding is not an underrun")
+        XCTAssertEqual(telemetry.fillFrames, 0)
+
+        // Two more callbacks cross target+1; the seed lands and reads flow.
+        writer.produce(rateFactor: 1.0)
+        writer.produce(rateFactor: 1.0)
+        XCTAssertEqual(client.readResampled(dest, frames: Self.callbackFrames), Self.callbackFrames)
+    }
+
+    // MARK: - Writer stall (underrun)
+
+    func testWriterStallCountsOneUnderrunAndResumesCleanly() {
+        let writer = SyntheticWriter()
+        let client = makeClient(writer)
+
+        var output = run(client: client, writer: writer, seconds: 10, rateFactor: 1.0)
+        XCTAssertEqual(client.telemetrySnapshot().underruns, 0)
+
+        // Writer stalls ~200 ms: reader callbacks continue with no production.
+        let dest = UnsafeMutablePointer<Float>.allocate(capacity: Self.callbackFrames * 2)
+        defer { dest.deallocate() }
+        for _ in 0..<19 {
+            let got = client.readResampled(dest, frames: Self.callbackFrames)
+            if got == 0 {
+                output.append(contentsOf: [Float](repeating: 0, count: Self.callbackFrames * 2))
+            } else {
+                output.append(contentsOf: UnsafeBufferPointer(start: dest, count: Self.callbackFrames * 2))
+            }
+        }
+        XCTAssertEqual(client.telemetrySnapshot().underruns, 1,
+                       "a stall counts once, not once per starved callback")
+
+        // Writer resumes; the reader re-seeds on fresh audio and runs clean.
+        let resumed = run(client: client, writer: writer, seconds: 10, rateFactor: 1.0)
+        output.append(contentsOf: resumed)
+
+        let telemetry = client.telemetrySnapshot()
+        XCTAssertEqual(telemetry.underruns, 1, "no further underruns after resume")
+        XCTAssertEqual(telemetry.overrunResyncs, 0)
+        XCTAssertEqual(Double(telemetry.fillFrames), 2048, accuracy: 20, "fill re-converges")
+
+        // Post-resume tail is a clean, full-level, correctly-routed tone.
+        let left = channel(resumed, 0)
+        let window = Int(4 * Self.sampleRate)
+        let tailL = left[(left.count - window)...]
+        let ampL = coherentAmplitude(tailL, frequency: Self.toneL)
+        XCTAssertEqual(20 * log10(ampL / Self.amplitude), 0, accuracy: 0.1)
+        let bleed = coherentAmplitude(tailL, frequency: Self.toneR)
+        XCTAssertLessThan(20 * log10(max(bleed, 1e-12) / Self.amplitude), -60,
+                          "channels stay aligned across an underrun re-seed")
+    }
+
+    // MARK: - Reader stall (overrun)
+
+    func testReaderStallCountsOneResyncAndReturnsToTarget() {
+        let writer = SyntheticWriter()
+        let client = makeClient(writer)
+        _ = run(client: client, writer: writer, seconds: 10, rateFactor: 1.0)
+
+        // Reader stalls while the writer keeps going: fill must pass
+        // 3×target = 6144 before the next read (10 callbacks — 9 lands the
+        // integer arithmetic exactly on the threshold, which doesn't trip).
+        for _ in 0..<10 {
+            writer.produce(rateFactor: 1.0)
+        }
+
+        let dest = UnsafeMutablePointer<Float>.allocate(capacity: Self.callbackFrames * 2)
+        defer { dest.deallocate() }
+        XCTAssertEqual(client.readResampled(dest, frames: Self.callbackFrames), Self.callbackFrames,
+                       "recovery read succeeds immediately — the data exists")
+
+        let telemetry = client.telemetrySnapshot()
+        XCTAssertEqual(telemetry.overrunResyncs, 1)
+        XCTAssertEqual(telemetry.underruns, 0)
+        XCTAssertEqual(Double(telemetry.fillFrames), 2048, accuracy: 20,
+                       "resync jumps straight back to target")
+    }
+}

--- a/Tests/iQualizeTests/DriftPolicyTests.swift
+++ b/Tests/iQualizeTests/DriftPolicyTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import iQualize
+
+final class DriftPolicyTests: XCTestCase {
+
+    // MARK: - Target fill / overrun threshold (#133)
+
+    func testTargetFillAtCommonRates() {
+        // 48 kHz stereo ring: 16384 frames capacity. 0.04 s = 1920, floored
+        // to 2048.
+        XCTAssertEqual(DriftPolicy.targetFillFrames(sampleRate: 48000, capacityFrames: 16384), 2048)
+        XCTAssertEqual(DriftPolicy.targetFillFrames(sampleRate: 44100, capacityFrames: 16384), 2048)
+        // 96 kHz: 0.04 s = 3840 wins over the floor.
+        XCTAssertEqual(DriftPolicy.targetFillFrames(sampleRate: 96000, capacityFrames: 16384), 3840)
+    }
+
+    func testTargetFillCappedAtQuarterCapacity() {
+        XCTAssertEqual(DriftPolicy.targetFillFrames(sampleRate: 48000, capacityFrames: 4096), 1024)
+    }
+
+    func testOverrunThresholdIsTripleTargetCappedClearOfCapacity() {
+        XCTAssertEqual(DriftPolicy.overrunThresholdFrames(targetFill: 2048, capacityFrames: 16384), 6144)
+        // Cap: never closer to capacity than an eighth of the ring.
+        XCTAssertEqual(DriftPolicy.overrunThresholdFrames(targetFill: 6000, capacityFrames: 16384), 14336)
+    }
+
+    // MARK: - EMA
+
+    func testEmaAlphaIsFrameCountAware() {
+        // Two 512-frame callbacks must smooth exactly as much as one
+        // 1024-frame callback: 1-a1024 == (1-a512)^2.
+        let a512 = DriftPolicy.emaAlpha(frames: 512, sampleRate: 48000)
+        let a1024 = DriftPolicy.emaAlpha(frames: 1024, sampleRate: 48000)
+        XCTAssertEqual(1 - a1024, (1 - a512) * (1 - a512), accuracy: 1e-12)
+    }
+
+    func testEmaAlphaBounded() {
+        let a = DriftPolicy.emaAlpha(frames: 512, sampleRate: 48000)
+        XCTAssertGreaterThan(a, 0)
+        XCTAssertLessThan(a, 1)
+        // τ = 0.5 s at 48 kHz, 512-frame slice → ~0.021 per callback.
+        XCTAssertEqual(a, 0.0211, accuracy: 0.001)
+    }
+
+    // MARK: - Resample ratio
+
+    func testRatioIsUnityAtTarget() {
+        XCTAssertEqual(DriftPolicy.resampleRatio(fillEMA: 2048, targetFill: 2048, sampleRate: 48000), 1.0)
+    }
+
+    func testRatioSign() {
+        // Fill above target → consume faster than nominal → ratio > 1.
+        XCTAssertGreaterThan(DriftPolicy.resampleRatio(fillEMA: 2148, targetFill: 2048, sampleRate: 48000), 1.0)
+        XCTAssertLessThan(DriftPolicy.resampleRatio(fillEMA: 1948, targetFill: 2048, sampleRate: 48000), 1.0)
+    }
+
+    func testRatioClampsAtMaxCorrection() {
+        XCTAssertEqual(DriftPolicy.resampleRatio(fillEMA: 16000, targetFill: 2048, sampleRate: 48000),
+                       1.0 + DriftPolicy.maxCorrection)
+        XCTAssertEqual(DriftPolicy.resampleRatio(fillEMA: 0, targetFill: 2048, sampleRate: 48000),
+                       1.0 - DriftPolicy.maxCorrection)
+    }
+
+    func testSteadyStateResidualPrediction() {
+        // Pure P: holding 100 ppm of drift needs ratio 1 + 1e-4, which the
+        // controller produces at error = drift·τ·sr = 14.4 frames.
+        let residual = 100e-6 * DriftPolicy.controllerTauSeconds * 48000
+        let ratio = DriftPolicy.resampleRatio(fillEMA: 2048 + residual, targetFill: 2048, sampleRate: 48000)
+        XCTAssertEqual(ratio, 1.0 + 100e-6, accuracy: 1e-9)
+    }
+
+    // MARK: - Seed position
+
+    func testSeedPositionLandsTargetBehindWriter() {
+        XCTAssertEqual(DriftPolicy.seedPosition(writeFrames: 10000, targetFill: 2048), 7952)
+    }
+
+    // MARK: - Catmull-Rom
+
+    func testCatmullRomEndpoints() {
+        // t = 0 must be bit-exact passthrough of x0.
+        XCTAssertEqual(DriftPolicy.catmullRom(0.3, 0.7, -0.2, 0.9, 0), 0.7)
+        // t → 1 converges to x1.
+        XCTAssertEqual(DriftPolicy.catmullRom(0.3, 0.7, -0.2, 0.9, 1), -0.2, accuracy: 1e-6)
+    }
+
+    func testCatmullRomReproducesLinearRamp() {
+        // On collinear points the spline is the line itself.
+        XCTAssertEqual(DriftPolicy.catmullRom(1, 2, 3, 4, 0.25), 2.25, accuracy: 1e-6)
+        XCTAssertEqual(DriftPolicy.catmullRom(-3, -1, 1, 3, 0.5), 0, accuracy: 1e-6)
+    }
+
+    func testCatmullRomMidpointWeights() {
+        // At t = 0.5 the kernel is (-1/16, 9/16, 9/16, -1/16).
+        let v = DriftPolicy.catmullRom(1, 0, 0, 0, 0.5)
+        XCTAssertEqual(v, -1.0 / 16.0, accuracy: 1e-6)
+        let w = DriftPolicy.catmullRom(0, 1, 0, 0, 0.5)
+        XCTAssertEqual(w, 9.0 / 16.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Closed loop
+
+    /// Difference-equation simulation of the whole loop: a writer drifting
+    /// ±100 ppm against a reader in 512-frame callbacks. Verifies the fill
+    /// converges to target + drift·τ·sr with no oscillation and no clamping —
+    /// the same math CaptureClient.readResampled runs per callback.
+    func testClosedLoopConvergesToPredictedResidual() {
+        let sr = 48000.0
+        let target = 2048.0
+        let callbackFrames = 512
+
+        for drift in [100e-6, -100e-6] {
+            // The controller regulates fill as measured at callback start —
+            // after the writer's production, before this callback consumes.
+            // Track that quantity, exactly as readResampled sees it.
+            var fill = target        // seed puts the measured fill at target
+            var fillEMA = target
+            var producedRemainder = 0.0
+            var maxRatioDeviation = 0.0
+            var measuredFill = target
+
+            // 60 s: the sim starts with an artificial +512-frame disturbance
+            // (production lands before the first measurement), and its decay
+            // through the EMA lag needs ~40 s to drop under the assert
+            // accuracy. Verified against a longer run: the fixed point is
+            // exact from ~45 s on.
+            let seconds = 60.0
+            let callbacks = Int(seconds * sr / Double(callbackFrames))
+            var lastAbsError = Double.infinity
+            var errorGrewAfterSettling = false
+            let residual = drift * DriftPolicy.controllerTauSeconds * sr
+
+            for i in 0..<callbacks {
+                // Writer produces at sr·(1+drift) while the reader consumes
+                // one callback's worth of source frames.
+                let produced = Double(callbackFrames) * (1 + drift) + producedRemainder
+                let wholeProduced = floor(produced)
+                producedRemainder = produced - wholeProduced
+                fill += wholeProduced
+                measuredFill = fill
+
+                let alpha = DriftPolicy.emaAlpha(frames: callbackFrames, sampleRate: sr)
+                fillEMA += alpha * (measuredFill - fillEMA)
+                let ratio = DriftPolicy.resampleRatio(fillEMA: fillEMA, targetFill: target, sampleRate: sr)
+                maxRatioDeviation = max(maxRatioDeviation, abs(ratio - 1))
+                fill -= Double(callbackFrames) * ratio
+
+                // After the EMA has settled (~5 s), the approach to the
+                // residual must be monotone in the smoothed view — any
+                // overshoot/oscillation grows the error between samples.
+                let absError = abs(fillEMA - (target + residual))
+                if i % 100 == 0 {
+                    if Double(i) * Double(callbackFrames) / sr > 5, absError > lastAbsError + 0.5 {
+                        errorGrewAfterSettling = true
+                    }
+                    lastAbsError = absError
+                }
+            }
+
+            XCTAssertEqual(measuredFill, target + residual, accuracy: 2.0,
+                           "measured fill must converge to target + drift·τ·sr for drift \(drift)")
+            XCTAssertFalse(errorGrewAfterSettling, "no oscillation after EMA settling")
+            XCTAssertLessThan(maxRatioDeviation, DriftPolicy.maxCorrection,
+                              "±100 ppm drift must never hit the ratio clamp")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The capture helper fills the shared ring on the tap aggregate's clock; the app drains it from the render callback on the output device's clock. Nothing handled the difference between them — no fill target, no prefill, no drift tracking. The fill level walks until it hits an edge and slips a sub-millisecond chunk: silence spliced in on underrun, a chunk dropped by the `>capacity` clamp on overrun.

The reader now seeds exactly 2048 frames behind the writer and holds it there: a P-controller on smoothed fill (τ = 3 s, EMA τ = 0.5 s) drives a Catmull-Rom fractional resampler. Correction clamps at ±500 ppm — 0.87 cent, inaudible — and `t = 0` is bit-exact passthrough, so a locked clock pair costs nothing. Underrun and overrun became counted exceptional events rather than the normal operating mode.

Two things ride along because the fix rewrites this exact code:

- **Frame-based positions.** The old reader counted floats and stayed L/R-aligned only by luck — any short read at a non-channel multiple would have swapped the channels permanently.
- **Release/acquire ordering** on the ring heads, via a ~25-line C shim (`Sources/IQRingAtomics`). The plain stores let the reader observe an advanced write head before the sample data behind it on arm64. C rather than `Synchronization.Atomic` (macOS 15+, we target 14) or swift-atomics (heavy for four functions).

Capture latency is now pinned at ~43 ms. It used to be whatever the `start()` race left in the ring — anywhere from 0 to 341 ms.

**The issue's measured evidence turned out to be mostly a different bug.** A/B against `13aca49` with a fixed measurement window shows the pre-fix ring reading perfectly coherent on BlackHole. The cause of the 1–5 dB coherence loss: the e2e script's own `afplay` and `sox` are new Core Audio processes, so the #87 process-list poll restarted the tap *inside* the 4 s measurement window, splicing ~100 ms of silence per restart. `e2e-tap-test.sh` now measures the last 4 s of a 12 s capture, past the restarts. BlackHole is host-clocked, so it can't exhibit real drift at all — that needs independent hardware clocks (USB/Bluetooth DAC), where the new `drift ppm` telemetry will show it directly.

The drift compensation is still the right fix — it's just verified against synthetic ±100 ppm drift and hardware-clock reasoning rather than against this rig. The restart glitch is worth its own issue; I did not fix it here.

## Scope

| Area | Change |
|---|---|
| `Sources/iQualize/DriftPolicy.swift` (new) | Pure math: target fill, overrun threshold, EMA α, resample ratio, seed position, Catmull-Rom. `GainPolicy` pattern — unit-testable without an audio device |
| `Sources/iQualize/CaptureClient.swift` | `readResampled` replaces `read`; `attach()` split out of `start()` for testability; telemetry counters |
| `Sources/IQRingAtomics/` (new) | C shim: acquire/release/relaxed u64 |
| `Sources/iQualizeCapture/main.swift` | Release-store of `writeHead` |
| `Sources/iQualize/AudioEngine.swift` | All-or-nothing read in the render callback; scratch preallocated in `start()` for `maximumFramesPerSlice` so the audio thread never allocates |
| CLI status | `Capture: fill 2048 frames, drift +0.0 ppm, underruns 0, resyncs 0` — optional payload fields, same versioning pattern as `appVersion` (#136) |
| `Spikes/TapAttenuationE2E` | `goertzel.py --coherent`; coherence gate in `e2e-tap-test.sh`; tail-window measurement; tolerance 3 → 1 dB |

Deliberately out of scope: deduplicating the hand-mirrored `SharedHeader` structs; writer-side vectorization; the writer's latent multi-buffer channel-blocking assumption; the tap-restart glitch the e2e work uncovered.

## Test plan

- [x] `swift test` — 47/47, including a closed-loop convergence simulation at ±100 ppm and a synthetic drifted-writer suite driving the real `readResampled`: coherent tone within 0.1 dB, zero slips, no L/R bleed across a re-seed, exact underrun/resync counting, no sample-delta exceeding the analytic sine slope
- [x] `bash install.sh` + launch verification; app runs, `iqualize status` reports 0.51.2
- [x] Playback soaks: fill pins at exactly 2048, drift +0.0 ppm, counters stay 0
- [x] 7 e2e runs (6× BlackHole 16ch, 1× 2ch): every one **+0.00 dB** on both the unity check and the new coherence check, at the tightened 1 dB tolerance
- [x] A/B against pre-fix `13aca49` with the corrected measurement window — the finding described above
- [ ] **Not verified:** a genuinely drifting device pair (USB/Bluetooth DAC). No such hardware in this session. BlackHole shares the host clock, so it cannot exercise the drift path; the `drift ppm` field is the way to check it

Fill reads 0 while the system is silent — the tap produces no frames, so the reader waits and seeds within ~50 ms of audio starting.

Fixes #133
