### PR TITLE
Refresh the tap in place instead of restarting it on new processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.51.2] - 2026-07-27
+
+### Fixed
+- Launching an app while the EQ ran splices ~100 ms of silence into playback — the momentary lag when Discord starts. The new-process watcher added for #87 restarted the tap on *any* new Core Audio process object, and a restart is a full teardown of the capture helper, tap, aggregate, ring buffer and audio graph. The capture helper now refreshes the live tap in place instead, by re-setting its description on the 1 s timer it already runs for call exclusions, and the restart path is gone. New processes that never play audio no longer cost anything either — 5 of 7 did not over a 30 s sample (#140)
+
 ## [0.51.1] - 2026-07-27
 
 ### Changed

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -130,8 +130,6 @@ final class AudioEngine {
     nonisolated(unsafe) private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
     @ObservationIgnored
     private var configChangeObserver: NSObjectProtocol?
-    private var knownProcessObjectIDs: Set<AudioObjectID> = []
-    private var processListPollWorkItem: DispatchWorkItem?
     var onStateChange: (() -> Void)?
     /// Resolves a pinned preset for a device UID, if any. Wired by the caller that owns
     /// both AudioEngine and PresetStore — kept as a closure so AudioEngine stays decoupled
@@ -216,7 +214,6 @@ final class AudioEngine {
             outputDeviceName = "Unknown"
         }
         installDeviceChangeListener()
-        knownProcessObjectIDs = (try? getProcessObjectList()).map(Set.init) ?? []
     }
 
     deinit {
@@ -386,17 +383,11 @@ final class AudioEngine {
         }
 
         isRunning = true
-        knownProcessObjectIDs = (try? getProcessObjectList()).map(Set.init) ?? knownProcessObjectIDs
-        if processListPollWorkItem == nil {
-            scheduleProcessListPoll()
-        }
     }
 
     func stop() {
         guard isRunning else { return }
         isRunning = false
-        processListPollWorkItem?.cancel()
-        processListPollWorkItem = nil
 
         if let configChangeObserver {
             NotificationCenter.default.removeObserver(configChangeObserver)
@@ -593,42 +584,15 @@ final class AudioEngine {
 
     // MARK: - New-process tap coverage
     //
-    // The global process tap is supposed to dynamically pick up processes that start
-    // after it was created, but in practice a newly-launched app can end up muted
-    // without its audio actually flowing through the tap — i.e. silently dropped
-    // (see #87, e.g. Discord launched while iQualize is running). Restarting the tap
-    // once a new Core Audio process appears reliably picks it up (confirmed: manually
-    // switching output devices, which restarts the tap as a side effect, fixes Discord's
-    // audio without quitting iQualize).
+    // Used to live here: a 2 s poll of kAudioHardwarePropertyProcessObjectList that
+    // called restartTap() whenever the list grew, so a late-launched app that the tap
+    // had silently dropped (#87) would get picked up. It worked, but the restart is a
+    // full stop() + start() — helper, tap, aggregate, ring and AVAudioEngine graph all
+    // torn down — and spliced ~100 ms of silence into playback every time any app
+    // started making noise (#140).
     //
-    // kAudioHardwarePropertyProcessObjectList is *supposed* to notify listeners of this,
-    // but verified experimentally that it goes silent for a process that itself holds an
-    // active CATap — the exact situation we're in. So instead of listening, poll the
-    // process list on an interval while running and restart the tap when it grows.
-    // Processes disappearing (e.g. quitting an app) never needs a tap restart.
-
-    private static let processListPollInterval: TimeInterval = 2.0
-
-    private func scheduleProcessListPoll() {
-        let workItem = DispatchWorkItem { [weak self] in
-            self?.pollProcessList()
-        }
-        processListPollWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.processListPollInterval, execute: workItem)
-    }
-
-    private func pollProcessList() {
-        guard isRunning else { return }
-        let current = (try? getProcessObjectList()).map(Set.init) ?? knownProcessObjectIDs
-        let grew = !current.subtracting(knownProcessObjectIDs).isEmpty
-        knownProcessObjectIDs = current
-        if grew {
-            // restartTap() calls stop() then start(), and start() already reschedules
-            // the next poll cycle — scheduling again here would run two poll loops.
-            restartTap()
-            onStateChange?()
-            return
-        }
-        scheduleProcessListPoll()
-    }
+    // The capture helper now refreshes the live tap in place instead, by re-setting
+    // kAudioTapPropertyDescription (see pollNewOutputProcesses in iQualizeCapture).
+    // It already polls every second for the #131 mic exclusions, so this costs no new
+    // timer, no new IPC, and no dropout.
 }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.51.1</string>
+	<string>0.51.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.51.1</string>
+	<string>0.51.2</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualizeCapture/main.swift
+++ b/Sources/iQualizeCapture/main.swift
@@ -51,6 +51,12 @@ nonisolated(unsafe) var tapDescription: AnyObject?
 nonisolated(unsafe) var baseExcludedObjects: [AudioObjectID] = []
 nonisolated(unsafe) var excludedMicUsers: Set<AudioObjectID> = []
 nonisolated(unsafe) var micPollTimer: DispatchSourceTimer?
+/// Process objects seen at the last poll, for spotting newly-launched apps (#140).
+nonisolated(unsafe) var knownProcessObjects: Set<AudioObjectID> = []
+/// Newly-appeared processes still being watched for output, and the polls each has
+/// left. A process registers with the HAL before it starts playing, so checking
+/// once at appearance would miss nearly everyone.
+nonisolated(unsafe) var pendingNewProcesses: [AudioObjectID: Int] = [:]
 
 // MARK: - Helpers
 
@@ -200,6 +206,55 @@ func applyTapExclusions() {
         os_log(.error, log: capLog, "tap description update failed: OSStatus %{public}d", err)
     }
 }
+
+/// Refresh the live tap when a newly-launched app starts playing.
+///
+/// A global tap is supposed to cover processes that start after it was created, but
+/// #87 saw a late-launched app end up muted with its audio silently dropped rather
+/// than routed. The main app used to fix that by restarting the whole tap, which
+/// tore down this helper and spliced ~100 ms of silence into playback (#140). Setting
+/// kAudioTapPropertyDescription on the live tap re-resolves it in place instead —
+/// verified returning noErr here in the helper, with the IOProc running.
+///
+/// Only newly-appeared processes that actually start playing trigger a refresh.
+/// Most process objects never play — measured 5 of 7 over a 30 s window — and every
+/// description update churns the live tap, so refreshing on bare list growth would
+/// trade a rare dropout for constant churn.
+@available(macOS 14.2, *)
+func pollNewOutputProcesses() {
+    let current = Set(processObjectList())
+    let firstPass = knownProcessObjects.isEmpty
+    for appeared in current.subtracting(knownProcessObjects) {
+        pendingNewProcesses[appeared] = newProcessWatchPolls
+    }
+    knownProcessObjects = current
+    // run() seeds the tap against the processes alive at creation, so the first
+    // poll's "new" processes are just that baseline.
+    if firstPass { pendingNewProcesses.removeAll(); return }
+
+    var startedOutput: [AudioObjectID] = []
+    for (obj, pollsLeft) in pendingNewProcesses {
+        guard current.contains(obj) else { pendingNewProcesses[obj] = nil; continue }
+        if processFlag(obj, kAudioProcessPropertyIsRunningOutput) {
+            pendingNewProcesses[obj] = nil
+            startedOutput.append(obj)
+        } else if pollsLeft <= 1 {
+            pendingNewProcesses[obj] = nil
+        } else {
+            pendingNewProcesses[obj] = pollsLeft - 1
+        }
+    }
+    guard !startedOutput.isEmpty else { return }
+
+    applyTapExclusions()
+    for obj in startedOutput {
+        os_log(.default, log: capLog,
+               "new output process %{public}@ — tap refreshed in place", processLogName(obj))
+    }
+}
+
+/// How long a new process stays under observation, in poll ticks (1 s each).
+let newProcessWatchPolls = 8
 
 @available(macOS 14.2, *)
 func pollMicUsers() {
@@ -449,12 +504,17 @@ func run() {
     }
     stdinThread.start()
 
-    // 8. Watch for processes starting/stopping mic use (calls) and update
-    //    the tap's exclusion list live (#131). dispatchMain() below services
-    //    the main queue.
+    // 8. Watch for processes starting/stopping mic use (calls) and update the tap's
+    //    exclusion list live (#131), and for newly-launched apps starting playback,
+    //    refreshing the tap in place rather than restarting it (#140).
+    //    dispatchMain() below services the main queue.
+    knownProcessObjects = Set(processObjectList())
     let timer = DispatchSource.makeTimerSource(queue: .main)
     timer.schedule(deadline: .now() + 1.0, repeating: 1.0)
-    timer.setEventHandler { pollMicUsers() }
+    timer.setEventHandler {
+        pollMicUsers()
+        pollNewOutputProcesses()
+    }
     timer.resume()
     micPollTimer = timer
 }

--- a/Spikes/TapProcessRefresh/Package.swift
+++ b/Spikes/TapProcessRefresh/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TapProcessRefresh",
+    // 14.2, not 14.0 — CATap (AudioHardwareCreateProcessTap) landed in 14.2.
+    platforms: [.macOS("14.2")],
+    targets: [
+        .executableTarget(
+            name: "TapProcessRefresh",
+            linkerSettings: [
+                .linkedFramework("CoreAudio"),
+                .linkedFramework("AudioToolbox"),
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/TapProcessRefresh/Info.plist",
+                ]),
+            ]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Spikes/TapProcessRefresh/Sources/TapProcessRefresh/Info.plist
+++ b/Spikes/TapProcessRefresh/Sources/TapProcessRefresh/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.iqualize.TapProcessRefresh</string>
+    <key>CFBundleName</key>
+    <string>TapProcessRefresh</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>iQualize needs to capture system audio to apply equalizer effects.</string>
+</dict>
+</plist>

--- a/Spikes/TapProcessRefresh/Sources/TapProcessRefresh/main.swift
+++ b/Spikes/TapProcessRefresh/Sources/TapProcessRefresh/main.swift
@@ -1,0 +1,534 @@
+// TapProcessRefresh — does a live CATap pick up a process that launched after it?
+//
+// Answers the blocking question in issue #140: AudioEngine currently does a full
+// stop()+start() whenever a new Core Audio process appears (#87), splicing ~100 ms
+// of silence into playback. The capture helper already updates the live tap's
+// description in place for mic exclusions (#131, main.swift:185-202), but that only
+// proves *exclusion* changes take effect — not that a refresh makes the tap
+// re-resolve membership and pick up a newly-launched app.
+//
+// Method: create a global tap, then start a tone process AFTER the tap exists and
+// measure RMS through the tap across four phases.
+//
+//   A  baseline        nothing playing              expect silence
+//   B  late process    tone started after the tap   silence here = #87 reproduced
+//   C  description     re-set kAudioTapPropertyDescription, list unchanged
+//   D  tap list        re-set the aggregate's kAudioAggregateDeviceTapListKey
+//   E  full rebuild    tear down and recreate tap + aggregate  (CONTROL)
+//
+// Phase E is the control and is what makes a negative result meaningful: it is the
+// thing production does today, so it must show the tone. If E is silent too, the
+// tone never reached the tap and the run says nothing about C or D.
+//
+// Usage: swift run TapProcessRefresh
+// Needs audio-capture TCC permission; run it from a terminal that has it.
+//
+// READ THIS BEFORE TRUSTING A NEGATIVE RESULT.
+//
+// This spike runs as a bare terminal binary, which is NOT the context the capture
+// helper runs in. The helper is signed, bundled, and carries the app's TCC grant.
+// That difference already produced one wrong conclusion: setting
+// kAudioTapPropertyDescription returns '!hog' (kAudioDevicePermissionsError) here at
+// every point in a tap's life, and it was briefly taken as proof that live tap
+// updates are impossible. Probed inside the real helper the same call returns noErr.
+// The tap-refresh path in iQualizeCapture is built on that, and works.
+//
+// Creating a tap and capturing audio both succeed here, which is exactly what makes
+// the permissions error misleading — the rig looks fully functional. So: a POSITIVE
+// result from this spike is trustworthy, a NEGATIVE one is a hypothesis that needs
+// re-testing inside the helper before anyone acts on it.
+
+import AudioToolbox
+import CoreAudio
+import Foundation
+
+// MARK: - State (nonisolated for the IOProc)
+
+nonisolated(unsafe) var tapID = AudioObjectID(kAudioObjectUnknown)
+nonisolated(unsafe) var aggID = AudioObjectID(kAudioObjectUnknown)
+nonisolated(unsafe) var ioProcID: AudioDeviceIOProcID?
+nonisolated(unsafe) var tapDesc: CATapDescription?
+nonisolated(unsafe) var tapUUID = UUID()
+
+// Level accumulator, written by the IOProc and drained on the main thread.
+nonisolated(unsafe) var sumSquares: Double = 0
+nonisolated(unsafe) var sampleCount: Int = 0
+nonisolated(unsafe) var peak: Float = 0
+let levelLock = NSLock()
+
+func check(_ status: OSStatus, _ message: String) {
+    guard status != noErr else { return }
+    FileHandle.standardError.write("FATAL \(message): OSStatus \(status)\n".data(using: .utf8)!)
+    teardown()
+    exit(1)
+}
+
+// MARK: - Level measurement
+
+func resetLevel() {
+    levelLock.lock()
+    sumSquares = 0
+    sampleCount = 0
+    peak = 0
+    levelLock.unlock()
+}
+
+/// Returns (rms dBFS, peak dBFS, frames seen). -inf is reported as -120.
+func readLevel() -> (rms: Double, peak: Double, frames: Int) {
+    levelLock.lock()
+    let s = sumSquares, n = sampleCount, p = peak
+    levelLock.unlock()
+    guard n > 0 else { return (-120, -120, 0) }
+    let rms = (s / Double(n)).squareRoot()
+    let toDB = { (x: Double) in x > 1e-9 ? 20 * log10(x) : -120 }
+    return (toDB(rms), toDB(Double(p)), n)
+}
+
+// MARK: - Tap + aggregate lifecycle
+
+func selfProcessObject() -> AudioObjectID {
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyTranslatePIDToProcessObject,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var pid = getpid()
+    var obj = AudioObjectID(kAudioObjectUnknown)
+    var sz = UInt32(MemoryLayout<AudioObjectID>.size)
+    AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr,
+                               UInt32(MemoryLayout<pid_t>.size), &pid, &sz, &obj)
+    return obj
+}
+
+func processObjectList() -> [AudioObjectID] {
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyProcessObjectList,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let systemObject = AudioObjectID(kAudioObjectSystemObject)
+    var size: UInt32 = 0
+    guard AudioObjectGetPropertyDataSize(systemObject, &addr, 0, nil, &size) == noErr else { return [] }
+    let count = Int(size) / MemoryLayout<AudioObjectID>.size
+    guard count > 0 else { return [] }
+    var ids = [AudioObjectID](repeating: AudioObjectID(kAudioObjectUnknown), count: count)
+    guard AudioObjectGetPropertyData(systemObject, &addr, 0, nil, &size, &ids) == noErr else { return [] }
+    return ids
+}
+
+/// Mirrors iQualizeCapture: global tap excluding ourselves, muted, fed into a
+/// private tap-only aggregate device with an IOProc.
+func buildTap() {
+    var excluded: [AudioObjectID] = []
+    let selfObj = selfProcessObject()
+    if selfObj != kAudioObjectUnknown { excluded.append(selfObj) }
+
+    let desc = CATapDescription(stereoGlobalTapButExcludeProcesses: excluded)
+    tapUUID = UUID()
+    desc.uuid = tapUUID
+    desc.muteBehavior = .unmuted   // unmuted: we only measure, we don't re-render
+    desc.name = "TapProcessRefresh"
+    check(AudioHardwareCreateProcessTap(desc, &tapID), "create tap")
+    tapDesc = desc
+
+    let aggUID = UUID().uuidString
+    let aggDesc: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "TapProcessRefresh-Aggregate",
+        kAudioAggregateDeviceUIDKey: aggUID,
+        kAudioAggregateDeviceIsPrivateKey: true,
+        kAudioAggregateDeviceIsStackedKey: false,
+        kAudioAggregateDeviceTapAutoStartKey: true,
+        kAudioAggregateDeviceTapListKey: [
+            [
+                kAudioSubTapDriftCompensationKey: true,
+                kAudioSubTapUIDKey: tapUUID.uuidString,
+            ]
+        ],
+    ]
+    check(AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggID), "create aggregate")
+
+    var aliveAddr = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyDeviceIsAlive,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    for _ in 1...30 {
+        var alive: UInt32 = 0
+        var sz = UInt32(MemoryLayout<UInt32>.size)
+        AudioObjectGetPropertyData(aggID, &aliveAddr, 0, nil, &sz, &alive)
+        if alive != 0 { break }
+        Thread.sleep(forTimeInterval: 0.1)
+    }
+
+    let ioBlock: AudioDeviceIOBlock = { _, inInputData, _, _, _ in
+        let bufList = UnsafeMutableAudioBufferListPointer(UnsafeMutablePointer(mutating: inInputData))
+        var localSum = 0.0
+        var localPeak: Float = 0
+        var localCount = 0
+        for i in 0..<bufList.count {
+            guard let buf = bufList[i].mData else { continue }
+            let n = Int(bufList[i].mDataByteSize) / MemoryLayout<Float>.size
+            let src = buf.assumingMemoryBound(to: Float.self)
+            for j in 0..<n {
+                let v = src[j]
+                localSum += Double(v) * Double(v)
+                let a = abs(v)
+                if a > localPeak { localPeak = a }
+            }
+            localCount += n
+        }
+        levelLock.lock()
+        sumSquares += localSum
+        sampleCount += localCount
+        if localPeak > peak { peak = localPeak }
+        levelLock.unlock()
+    }
+    check(AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggID, nil, ioBlock), "create IOProc")
+    check(AudioDeviceStart(aggID, ioProcID), "start IOProc")
+}
+
+func teardown() {
+    if let proc = ioProcID, aggID != kAudioObjectUnknown {
+        AudioDeviceStop(aggID, proc)
+        AudioDeviceDestroyIOProcID(aggID, proc)
+        ioProcID = nil
+    }
+    if aggID != kAudioObjectUnknown {
+        AudioHardwareDestroyAggregateDevice(aggID)
+        aggID = AudioObjectID(kAudioObjectUnknown)
+    }
+    if tapID != kAudioObjectUnknown {
+        AudioHardwareDestroyProcessTap(tapID)
+        tapID = AudioObjectID(kAudioObjectUnknown)
+    }
+    tapDesc = nil
+}
+
+// MARK: - The two refresh strategies under test
+
+/// Phase C: re-set kAudioTapPropertyDescription on the live tap with an unchanged
+/// process list. This is exactly what applyTapExclusions() does for #131, minus
+/// the exclusion-list change.
+func refreshTapDescription() -> OSStatus {
+    guard let desc = tapDesc, tapID != kAudioObjectUnknown else { return -1 }
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioTapPropertyDescription,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var ref: CATapDescription? = desc
+    return withUnsafeMutablePointer(to: &ref) { ptr in
+        AudioObjectSetPropertyData(tapID, &addr, 0, nil,
+                                   UInt32(MemoryLayout<CATapDescription?>.stride), ptr)
+    }
+}
+
+/// Phase D: re-set the aggregate's tap list, nudging the aggregate to re-resolve
+/// the tap without destroying either object.
+func refreshAggregateTapList() -> OSStatus {
+    guard aggID != kAudioObjectUnknown else { return -1 }
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioAggregateDevicePropertyTapList,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var list = [[
+        kAudioSubTapDriftCompensationKey: true,
+        kAudioSubTapUIDKey: tapUUID.uuidString,
+    ]] as CFArray
+    return withUnsafeMutablePointer(to: &list) { ptr in
+        AudioObjectSetPropertyData(aggID, &addr, 0, nil,
+                                   UInt32(MemoryLayout<CFArray?>.stride), ptr)
+    }
+}
+
+// MARK: - Tone process
+
+/// Starts a tone in a process that did not exist when the tap was created.
+func startTone() -> Process {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/sox")
+    // -n null input, synth a 60 s 997 Hz sine at -12 dBFS out the default device
+    p.arguments = ["-n", "-d", "synth", "60", "sine", "997", "gain", "-12"]
+    p.standardOutput = FileHandle.nullDevice
+    p.standardError = FileHandle.nullDevice
+    do {
+        try p.run()
+    } catch {
+        FileHandle.standardError.write("could not start sox: \(error)\n".data(using: .utf8)!)
+        teardown()
+        exit(1)
+    }
+    return p
+}
+
+// MARK: - Description-set probe (`swift run TapProcessRefresh descset`)
+//
+// Phase C came back '!hog' (kAudioDevicePermissionsError), so this walks the same
+// call through every point in a tap's life to see whether it ever succeeds.
+//
+// Resolved: it fails at all four points HERE and succeeds in the capture helper.
+// The variable is the process, not the tap state — see the header. Keep this mode
+// around as the control for that difference, not as evidence about the API.
+
+func setDescription(_ desc: CATapDescription) -> OSStatus {
+    var addr = AudioObjectPropertyAddress(
+        mSelector: kAudioTapPropertyDescription,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var ref: CATapDescription? = desc
+    return withUnsafeMutablePointer(to: &ref) { ptr in
+        AudioObjectSetPropertyData(tapID, &addr, 0, nil,
+                                   UInt32(MemoryLayout<CATapDescription?>.stride), ptr)
+    }
+}
+
+func fourCC(_ s: OSStatus) -> String {
+    guard s != 0 else { return "ok" }
+    let b = withUnsafeBytes(of: s.bigEndian) { Array($0) }
+    let ascii = b.allSatisfy { $0 >= 32 && $0 < 127 }
+    return ascii ? "'\(String(bytes: b, encoding: .ascii) ?? "?")'  (\(s))" : "\(s)"
+}
+
+func runDescriptionSetProbe() {
+    print("TapProcessRefresh — description-set probe (issue #140)\n")
+
+    // Production parity: muted global tap, excluding self.
+    var excluded: [AudioObjectID] = []
+    let selfObj = selfProcessObject()
+    if selfObj != kAudioObjectUnknown { excluded.append(selfObj) }
+    let desc = CATapDescription(stereoGlobalTapButExcludeProcesses: excluded)
+    tapUUID = UUID()
+    desc.uuid = tapUUID
+    desc.muteBehavior = .muted
+    desc.name = "TapProcessRefresh-descset"
+    check(AudioHardwareCreateProcessTap(desc, &tapID), "create tap")
+    tapDesc = desc
+    print("tap \(tapID) created (muted, global, excluding self)")
+
+    // A victim to actually add to the exclusion list, so this is a real change
+    // and not a no-op set. Any other audio process will do.
+    let victim = processObjectList().first { $0 != selfObj && $0 != kAudioObjectUnknown }
+    print("victim process object to exclude: \(victim.map(String.init) ?? "none found")\n")
+
+    print("1  bare tap, no aggregate yet")
+    desc.processes = excluded
+    print("   no-op set            \(fourCC(setDescription(desc)))")
+    if let victim {
+        desc.processes = excluded + [victim]
+        print("   real exclusion set   \(fourCC(setDescription(desc)))")
+        desc.processes = excluded
+        print("   revert set           \(fourCC(setDescription(desc)))")
+    }
+
+    // Now attach the aggregate + IOProc, exactly as the helper does.
+    let aggUID = UUID().uuidString
+    let aggDesc: [String: Any] = [
+        kAudioAggregateDeviceNameKey: "TapProcessRefresh-Aggregate",
+        kAudioAggregateDeviceUIDKey: aggUID,
+        kAudioAggregateDeviceIsPrivateKey: true,
+        kAudioAggregateDeviceIsStackedKey: false,
+        kAudioAggregateDeviceTapAutoStartKey: true,
+        kAudioAggregateDeviceTapListKey: [
+            [kAudioSubTapDriftCompensationKey: true, kAudioSubTapUIDKey: tapUUID.uuidString]
+        ],
+    ]
+    check(AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggID), "create aggregate")
+    Thread.sleep(forTimeInterval: 0.5)
+
+    print("\n2  aggregate attached, IOProc NOT started")
+    if let victim {
+        desc.processes = excluded + [victim]
+        print("   real exclusion set   \(fourCC(setDescription(desc)))")
+    }
+
+    let ioBlock: AudioDeviceIOBlock = { _, _, _, _, _ in }
+    check(AudioDeviceCreateIOProcIDWithBlock(&ioProcID, aggID, nil, ioBlock), "create IOProc")
+    check(AudioDeviceStart(aggID, ioProcID), "start IOProc")
+    Thread.sleep(forTimeInterval: 0.5)
+
+    print("\n3  IOProc running  <- what applyTapExclusions() does in production")
+    if let victim {
+        desc.processes = excluded + [victim]
+        print("   real exclusion set   \(fourCC(setDescription(desc)))")
+        desc.processes = excluded
+        print("   revert set           \(fourCC(setDescription(desc)))")
+    }
+
+    AudioDeviceStop(aggID, ioProcID)
+    Thread.sleep(forTimeInterval: 0.3)
+    print("\n4  IOProc stopped again")
+    if let victim {
+        desc.processes = excluded + [victim]
+        print("   real exclusion set   \(fourCC(setDescription(desc)))")
+    }
+
+    teardown()
+    print("\n'!hog' is kAudioDevicePermissionsError.")
+}
+
+// MARK: - Process-list watch (`swift run TapProcessRefresh watch [seconds]`)
+//
+// Does the filter in pollProcessList() actually buy anything? It only helps if new
+// process objects routinely appear WITHOUT playing audio. This mirrors production's
+// 2 s poll and reports, for each newly-appeared object, whether it was already
+// running output and whether it ever starts within the watch window.
+
+func processName(_ obj: AudioObjectID) -> String {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioProcessPropertyBundleID,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var bundleID: CFString = "" as CFString
+    var size = UInt32(MemoryLayout<CFString>.size)
+    let err = withUnsafeMutablePointer(to: &bundleID) { ptr in
+        AudioObjectGetPropertyData(obj, &address, 0, nil, &size, ptr)
+    }
+    let bid = err == noErr ? (bundleID as String) : ""
+    return bid.isEmpty ? "obj \(obj)" : bid
+}
+
+func isRunningOutput(_ obj: AudioObjectID) -> Bool {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioProcessPropertyIsRunningOutput,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var running: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    guard AudioObjectGetPropertyData(obj, &address, 0, nil, &size, &running) == noErr
+    else { return false }
+    return running != 0
+}
+
+func runWatch(seconds: Int) {
+    print("watching the process list for \(seconds)s at production's 2 s cadence")
+    print("launch some audio apps now\n")
+    var known = Set(processObjectList())
+    print("starting with \(known.count) process objects")
+    var watching: [AudioObjectID: Int] = [:]      // object -> cycles observed
+    var everPlayed = Set<AudioObjectID>()
+    var appearedPlaying = 0, appearedSilent = 0
+
+    let cycles = seconds / 2
+    for _ in 0..<cycles {
+        Thread.sleep(forTimeInterval: 2.0)
+        let current = Set(processObjectList())
+        for obj in current.subtracting(known) {
+            let playing = isRunningOutput(obj)
+            if playing { appearedPlaying += 1; everPlayed.insert(obj) }
+            else { appearedSilent += 1 }
+            watching[obj] = 0
+            print(String(format: "  + %-42@ appeared %@",
+                         processName(obj) as NSString,
+                         playing ? "PLAYING" : "silent"))
+        }
+        // Follow the ones that appeared silent to see if they ever start.
+        for (obj, seen) in watching {
+            guard current.contains(obj) else { watching[obj] = nil; continue }
+            if !everPlayed.contains(obj), isRunningOutput(obj) {
+                everPlayed.insert(obj)
+                print("    -> \(processName(obj)) started output after \((seen + 1) * 2)s")
+            }
+            if seen >= 5 { watching[obj] = nil } else { watching[obj] = seen + 1 }
+        }
+        known = current
+    }
+
+    print("\n--- summary ---")
+    print("  new process objects:        \(appearedPlaying + appearedSilent)")
+    print("  already playing on arrival: \(appearedPlaying)")
+    print("  arrived silent:             \(appearedSilent)")
+    print("  ever played during watch:   \(everPlayed.count)")
+    let neverPlayed = (appearedPlaying + appearedSilent) - everPlayed.count
+    print("  never played at all:        \(neverPlayed)   <- restarts the filter avoids")
+}
+
+let mode = CommandLine.arguments.dropFirst().first
+if mode == "descset" {
+    runDescriptionSetProbe()
+    exit(0)
+}
+if mode == "watch" {
+    let secs = CommandLine.arguments.dropFirst(2).first.flatMap { Int($0) } ?? 30
+    runWatch(seconds: secs)
+    exit(0)
+}
+
+// MARK: - Run
+
+func measure(_ label: String, settle: TimeInterval = 2.0, window: TimeInterval = 3.0) -> Double {
+    Thread.sleep(forTimeInterval: settle)   // let the change take effect
+    resetLevel()
+    Thread.sleep(forTimeInterval: window)
+    let (rms, pk, frames) = readLevel()
+    print(String(format: "  %-22@  rms %7.1f dBFS   peak %7.1f dBFS   frames %d",
+                 label as NSString, rms, pk, frames))
+    return rms
+}
+
+print("TapProcessRefresh — issue #140 phase 0 spike")
+print("pid \(getpid())")
+
+let before = Set(processObjectList())
+buildTap()
+print("tap \(tapID)  aggregate \(aggID)  processes visible at creation: \(before.count)\n")
+
+print("A  baseline (nothing playing)")
+let baseline = measure("baseline")
+
+print("\nB  tone process started AFTER the tap exists")
+let tone = startTone()
+let after = Set(processObjectList())
+print("   new process objects: \(after.subtracting(before).count)")
+let late = measure("late process")
+
+print("\nC  re-set kAudioTapPropertyDescription (list unchanged)")
+let cErr = refreshTapDescription()
+print("   set returned OSStatus \(cErr)")
+let afterDesc = measure("after description")
+
+print("\nD  re-set aggregate kAudioAggregateDevicePropertyTapList")
+let dErr = refreshAggregateTapList()
+print("   set returned OSStatus \(dErr)")
+let afterList = measure("after tap list")
+
+print("\nE  full rebuild (CONTROL — this is what production does today)")
+teardown()
+buildTap()
+let afterRebuild = measure("after rebuild")
+
+tone.terminate()
+teardown()
+
+// MARK: - Verdict
+
+/// A phase "hears" the tone if it sits well above the silent baseline.
+let threshold = max(baseline + 20, -80.0)
+func verdict(_ v: Double) -> String { v > threshold ? "TONE" : "silent" }
+
+print("\n--- summary (tone threshold \(String(format: "%.1f", threshold)) dBFS) ---")
+print("  A baseline           \(verdict(baseline))")
+print("  B late process       \(verdict(late))")
+print("  C description reset  \(verdict(afterDesc))")
+print("  D tap list reset     \(verdict(afterList))")
+print("  E full rebuild       \(verdict(afterRebuild))  <- control")
+
+if late > threshold {
+    print("\nNO REPRO: the late process was already captured without any refresh.")
+    print("The restart in pollProcessList() may not be needed at all for this app.")
+} else if afterRebuild <= threshold {
+    print("\nINVALID: the control never heard the tone, so C and D prove nothing.")
+    print("Check that sox is audible on the default output device and rerun.")
+} else if afterDesc > threshold {
+    print("\nPOSITIVE (C): re-setting the tap description picks up the new process.")
+    print("Phase 2 is buildable in the helper with no restart.")
+} else if afterList > threshold {
+    print("\nPOSITIVE (D): the aggregate tap list needs the nudge, the tap alone is not enough.")
+    print("Phase 2 is buildable, but against the aggregate rather than the tap.")
+} else {
+    print("\nNEGATIVE: only a full rebuild picks up the new process.")
+    print("Fall back to Phase 1 (filter) + Phase 3 (debounce); Phase 2 is not viable.")
+}


### PR DESCRIPTION
## Summary

Launching an app while the EQ ran restarted the tap and spliced ~100 ms of silence into playback — the momentary lag when Discord starts.

The new-process watcher added for #87 called `restartTap()` whenever a new Core Audio process object appeared, and a restart is a full `stop()` + `start()`: capture helper, CATap, aggregate device, ring buffer and audio graph all torn down and rebuilt. #87 called this risk out when it proposed the watcher — "needs debouncing and/or filtering" — and shipped with neither.

The capture helper now re-sets `kAudioTapPropertyDescription` on the live tap instead, re-resolving it with no teardown. It rides the 1 s timer the helper already runs for the #131 mic exclusions, so there is no new timer and no new IPC, and `AudioEngine` loses the poll and restart path entirely.

#87 no longer reproduces. A late-launched process is picked up by the tap unaided, and Discord launched under the EQ has sound, so the restart was pure cost. The refresh is kept as the corrective nudge rather than dropping the mechanism outright.

Fixes #140.

## Scope

Only newly-appeared processes that actually start playing trigger a refresh, and they are watched for up to 8 polls first — a process registers with the HAL before it plays, so a single check at appearance misses nearly all of them. Refreshing on bare list growth would churn the live tap constantly: 5 of 7 new process objects never played audio over a 30 s sample.

`Spikes/TapProcessRefresh` carries the measurements, with three modes (level run, `descset`, `watch`). Its header documents a trap worth knowing before anyone reuses it: run as a bare terminal binary it gets `kAudioDevicePermissionsError` setting the tap description, which reads as "live tap updates are impossible" and is wrong — the same call returns `noErr` inside the signed, TCC-granted helper. Creating a tap and capturing audio both succeed there, which is what makes the error convincing. Drop the directory if you'd rather not carry it.

Deliberately out of scope:

- **Audio quality dropping while the mic is in use.** The AirPods switch to the hands-free profile — 48 kHz on A2DP against 24 kHz input on the headset profile. Reproduces with iQualize quit.
- **Short lag when Discord closes.** The profile switch back to 48 kHz changes the output format and fires `.AVAudioEngineConfigurationChange`, rebuilding the graph (`Sources/iQualize/AudioEngine.swift:367`). A different trigger from the one removed here, and a legitimate rebuild — the format really did change.
- **`AudioObjectID` recycling.** A genuinely new process can reuse a retired ID and slip past the known-set comparison. Pre-existing and untouched; it now costs a missed refresh rather than a missed restart.
- **`os_log` output from the app and helper does not surface through `log show`** on the test machine under any predicate tried. Not investigated, but it is why verification here went through files.

## Test plan

Verified on a real device (AirPods Pro), by @dariuscorvus unless noted:

- [x] Discord launched under the EQ: no lag on start, and it has sound
- [x] Apple Continuity still migrates output correctly
- [x] Mic quality drop traced to the AirPods profile switch, not this code
- [x] Refresh actually fires per launching app, with the helper PID unchanged — instrumented temporarily, removed before commit
- [x] Three apps launched in sequence: 0 tap restarts, was 1 each
- [x] Non-playing Core Audio process: no refresh, no restart
- [x] Late-launched `sox` captured by the live tap unaided — -15.8 dBFS against a -120 dBFS baseline
- [x] 5 of 7 new process objects never play audio over 30 s (`TapProcessRefresh watch`)
- [x] Engine healthy after: capture running, preset intact
- [x] 29 unit tests pass; builds, installs, launches

Not verified:

- [ ] Any app other than Discord that historically reproduced #87
- [ ] `kAudioAggregateDevicePropertyTapList` reset inside the helper — measured only in the spike, where it returned `noErr` but stopped the IOProc delivering
