### PR TITLE
Fix Info.plist permissions and EQ theme switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.51.3] - 2026-07-29
+
+### Fixed
+- `install.sh` could ship `Info.plist` mode `0600` inside the DMG: the temp file used for build-commit stamping is created by `mktemp` (`0600`), and `cp` onto a not-yet-existing destination inherits the source mode — the case on a fresh CI runner building a release. Root-run install scripts that copy the app straight out of the DMG got an unreadable plist, which silenced the system audio recording permission prompt and left iQualize running with no audio output. `install.sh` now `chmod`s the installed plist to `644` after copying it in. Reported by @json20 (#142)
+
 ## [0.51.2] - 2026-07-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.51.4] - 2026-07-29
+
+### Fixed
+- The EQ window didn't fully restyle when its theme (Settings → Theme) disagreed with the system-wide appearance: text and accents switched immediately, but the window background and axis labels stayed on the old appearance, sometimes leaving light text on a light background or vice versa. `DreamRootView` looked up the window to restyle via `NSApp.windows.first(where: title contains "iQualize" or empty)`, which could silently match the Help window or a status-item window instead of the EQ window itself — it now uses a direct reference set by `DreamHostingView` when the window is created. Applying that override also moved from an `.onChange`/`.onAppear` side effect into the view's `body`, since the old timing applied the appearance one render after SwiftUI had already resolved that render's system colors against the previous one. Reported by Gary (@nordicdata, #144)
+
+### Added
+- README now documents the GUI path (System Settings → Privacy & Security → Security → Open Anyway) for allowing iQualize's unsigned build, for anyone not comfortable running the `xattr` command. Suggested by Gary (@nordicdata, #144)
+
 ## [0.51.3] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ xattr -dr com.apple.quarantine /Applications/iQualize.app
 
 Then open it normally. If the `.dmg` itself won't mount, clear the flag on the download first: `xattr -c ~/Downloads/iQualize-*.dmg`.
 
+Not comfortable with Terminal? On macOS Sequoia and Tahoe there's a GUI path: try opening iQualize once (you'll get the "damaged"/blocked dialog), then go to **System Settings → Privacy & Security → Security** and click **Open Anyway** next to the message about iQualize, confirming with your admin password. Older macOS versions expose the same option under **System Preferences → Security & Privacy → General** instead.
+
 ### Build from source
 
 ```bash

--- a/Sources/iQualize/DreamUI/DreamHostingView.swift
+++ b/Sources/iQualize/DreamUI/DreamHostingView.swift
@@ -23,6 +23,7 @@ enum DreamHostingView {
 
         // Wire window's UndoManager into the view model
         viewModel.undoManager = window.undoManager
+        viewModel.window = window
 
         let host = NSHostingView(rootView: DreamRootView(vm: viewModel))
         host.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/iQualize/DreamUI/DreamRootView.swift
+++ b/Sources/iQualize/DreamUI/DreamRootView.swift
@@ -8,6 +8,14 @@ struct DreamRootView: View {
 
     var body: some View {
         let resolvedScheme: ColorScheme = vm.theme.colorScheme ?? systemScheme
+        // Must run before `theme` below: DreamTheme.bgWindow/bgToolbar/bgCanvas resolve
+        // via Color(nsColor:), which reads the *window's* actual NSAppearance at draw
+        // time, not this view's `scheme`/environment. Applying the override inside a
+        // .onChange/.onAppear side effect fires one render late — SwiftUI had already
+        // resolved this render's NSColors against the *old* appearance by the time the
+        // side effect landed, so those surfaces stayed on the previous appearance while
+        // the scheme-driven (hardcoded RGB) colors below switched immediately (#144).
+        let _ = applyWindowAppearance()
         let theme = DreamTheme(scheme: resolvedScheme)
 
         VStack(spacing: 0) {
@@ -26,19 +34,18 @@ struct DreamRootView: View {
         .background(theme.bgWindow)
         .environment(\.dreamTheme, theme)
         .preferredColorScheme(vm.theme.colorScheme)
-        .onAppear { applyWindowAppearance(scheme: resolvedScheme) }
-        .onChange(of: vm.theme) { _, _ in applyWindowAppearance(scheme: vm.theme.colorScheme ?? systemScheme) }
-        .onChange(of: systemScheme) { _, _ in
-            if vm.theme == .auto { applyWindowAppearance(scheme: systemScheme) }
-        }
         .background(
             KeyEventHandler(vm: vm)
         )
     }
 
-    private func applyWindowAppearance(scheme: ColorScheme) {
-        // Force the NSWindow's traffic-light/chrome appearance to match.
-        guard let window = NSApp.windows.first(where: { $0.title.isEmpty || $0.title.contains("iQualize") }) else { return }
+    // Force the NSWindow's traffic-light/chrome/system-color appearance to match the
+    // chosen theme. Uses the window set directly by DreamHostingView rather than
+    // searching NSApp.windows — that search matched any window titled "iQualize ..."
+    // (e.g. Help) or with an empty title (e.g. a status-item window), and could
+    // silently restyle the wrong one (#144).
+    private func applyWindowAppearance() {
+        guard let window = vm.window else { return }
         switch vm.theme {
         case .auto:
             window.appearance = nil

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -17,6 +17,12 @@ final class DreamViewModel {
     @ObservationIgnored
     weak var undoManager: UndoManager?
 
+    /// The EQ window itself — set by DreamHostingView once the window exists, so
+    /// DreamRootView can apply the theme override to the right window directly
+    /// instead of guessing at it via NSApp.windows.
+    @ObservationIgnored
+    weak var window: NSWindow?
+
     /// Callback fired when the toolbar's Settings gear is tapped.
     @ObservationIgnored
     var onOpenSettings: (() -> Void)?

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.51.3</string>
+	<string>0.51.4</string>
 	<key>CFBundleVersion</key>
-	<string>0.51.3</string>
+	<string>0.51.4</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.51.2</string>
+	<string>0.51.3</string>
 	<key>CFBundleVersion</key>
-	<string>0.51.2</string>
+	<string>0.51.3</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,11 @@ if ! cmp -s "$STAMPED_PLIST" "$APP/Contents/Info.plist"; then
 fi
 cp -f "$STAMPED_PLIST" "$APP/Contents/Info.plist"
 rm -f "$STAMPED_PLIST"
+# mktemp creates STAMPED_PLIST 0600, and cp inherits that mode when the
+# destination doesn't already exist (first install on a fresh machine/CI
+# runner) — this shipped in the v0.51.0 DMG and broke the system audio
+# recording permission prompt for root-run installers (issue #142).
+chmod 644 "$APP/Contents/Info.plist"
 
 if [ "$NEEDS_RESIGN" = "1" ]; then
     # Record the pre-sign product hashes first so the sidecar is covered by


### PR DESCRIPTION
## Summary
- `mktemp` creates the temp plist used for build-commit stamping as `0600`. `cp` inherits that mode when the destination `Info.plist` doesn't already exist — the case on a fresh CI runner building a release DMG. Any install script that copies the app straight out of the DMG (root-run installers, in particular) ended up with an unreadable plist, which silenced the system audio recording permission prompt entirely. `install.sh` now `chmod`s the installed plist to `644` unconditionally after the copy. (#142)
- The EQ window didn't fully restyle when its theme (Settings → Theme) disagreed with the system-wide appearance: text and accents switched immediately, but the window background and axis labels stayed on the old appearance. Two bugs stacked: `DreamRootView` looked up the window to restyle via `NSApp.windows.first` matching titles containing "iQualize" or empty titles, which could silently match the Help window or a status-item window instead — now `DreamHostingView` hands it a direct reference. And the appearance override applied from an `.onChange`/`.onAppear` side effect, which ran one render after SwiftUI had already resolved that render's system colors against the old appearance — moved inline into `body`, before those colors are computed. (#144)
- README documents the GUI path (System Settings → Privacy & Security → Security → Open Anyway) for allowing the unsigned build, for anyone not comfortable running `xattr`. (#144)

Fixes #142
Fixes #144

## Scope
Two patch bumps (0.51.2 → 0.51.4) and `CHANGELOG.md` entries, both bug fixes plus one doc addition — no other changes.

## Test plan
- [x] Fresh install (`rm -rf` the app bundle first, matching the actual Info.plist failure mode) → lands at `644`
- [x] Normal re-install over an existing bundle → stays `644`
- [x] Theme set to Dark, Light, and Auto against a Dark system appearance — verified live in the running app that window background, axis labels, and text all switch together in one render for each
- [x] App builds and launches successfully post-fix