### PR TITLE
Remove fixed 31-band EQ limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.53.0] - 2026-07-30
+
+### Changed
+- Removed the fixed 31-band EQ limit (#114). AVAudioUnitEQ (Apple's AUNBandEQ) has a real, OS-defined ceiling on how many bands it can natively process — not just an app-chosen constant — so growing its allocation on demand was never going to get to "CPU-bound only." Bands beyond that native capacity now run through the app's own biquad chain (`BiquadFilterChain`), cascaded ahead of AVAudioUnitEQ in the render callback; split-channel mode already used this chain exclusively and was unaffected. The CLI's add-band cap and the AutoEQ/OPRA import truncation are both gone — only the GraphicEQ import's fixed 31-point ISO resampling grid remains, since that's a property of the format, not the engine.
+
 ## [0.52.0] - 2026-07-30
 
 ### Added

--- a/EQ_BAND_CAPACITY.md
+++ b/EQ_BAND_CAPACITY.md
@@ -1,0 +1,89 @@
+# EQ Band Capacity
+
+Tracks: [#114](https://github.com/dariuscorvus/iqualize/issues/114)
+
+## Why this document exists
+
+iQualize used to cap presets at 31 EQ bands (`EQPresetData.maxBandCount`). The fix looks like a one-line constant removal, but the actual constraint is a real Core Audio ceiling, not just an app-chosen number, so the fix is a genuine architecture change (a second DSP path spliced into the render callback) rather than a config bump. This file is the in-repo record of *why* 31 was there, why it couldn't just be raised, and what runs in its place — so a future "why does `AudioEngine` still have a `31` in it, didn't we remove the limit?" doesn't require re-deriving all of this from the diff.
+
+## Why 31 wasn't just an app-chosen number
+
+`AudioEngine` did (and still does) all linked-channel-mode EQ processing through `AVAudioUnitEQ`, the system's N-band parametric EQ Audio Unit (backed by Apple's `AUNBandEQ`). It's constructed with a fixed band count up front:
+
+```swift
+AVAudioUnitEQ(numberOfBands: EQPresetData.maxBandCount) // was 31
+```
+
+`AVAudioUnitEQ.bands` is a fixed-size array allocated at that call — there's no API to grow it afterward. The natural-looking fix ("raise the constant, or grow the node when the user adds more bands") runs into the fact that the underlying `AUNBandEQ` unit has its own hardware/OS-defined ceiling, independent of the app. From Apple's `AudioUnitProperties.h`:
+
+```c
+/*!
+    @constant       kAUNBandEQProperty_NumberOfBands
+    @discussion         ... If more than kAUNBandEQProperty_MaxNumberOfBands
+                        are specified, an error is returned.
+
+    @constant       kAUNBandEQProperty_MaxNumberOfBands
+    @discussion         Returns the maximum number of equalizer bands.
+*/
+```
+
+So "just ask for more bands" was never going to produce an unbounded engine — it would only move the wall from 31 to wherever `kAUNBandEQProperty_MaxNumberOfBands` reports on a given system, still an AU-imposed ceiling, still not "CPU-bound only" as the issue asked for.
+
+## What already worked: split-channel mode
+
+Split-channel mode (independent L/R EQ curves) never used `AVAudioUnitEQ` at all. It runs `BiquadFilterChain` (`Sources/iQualize/BiquadFilter.swift`) — a hand-rolled, real-time-safe Direct-Form-II-Transposed biquad chain — directly inside the `AVAudioSourceNode` render callback, with `AVAudioUnitEQ` fully bypassed. `BiquadFilterChain` resizes its internal coefficient/state arrays to whatever `bands.count` it's given; it has no capacity ceiling of its own. This path was already exactly what the issue asked for, just only reachable via split-channel mode.
+
+## The fix: cascade an overflow chain in linked mode
+
+Rather than replace `AVAudioUnitEQ` outright (see "Alternative considered" below), linked mode now splits a preset's bands into two groups:
+
+- **Bands `0..<31`** — processed by `AVAudioUnitEQ`, unchanged from before.
+- **Bands `31...`** (if any) — processed by `BiquadFilterChain`, cascaded ahead of `AVAudioUnitEQ` in the render callback, exactly the way split-channel mode already ran its chains, just carrying only the overflow bands instead of the full preset.
+
+`AudioEngine.applyBands()` (previously duplicated between `start()` and `applyBands()`, now a single code path called from both) is where this split happens:
+
+```swift
+private static let avEQNativeBandCount = 31   // AVAudioUnitEQ's native capacity
+```
+
+The render callback's `rtBiquadChainActive` flag (renamed from `rtSplitChannelActive`, since it's no longer split-mode-specific) now means "run whatever's in `rtBiquadChainL`/`R`" — the content differs by mode, but the callback doesn't need to know which:
+
+- **Split-channel mode**: chains carry the *entire* per-channel band list; `AVAudioUnitEQ` is bypassed. Unchanged from before this fix.
+- **Linked mode, ≤31 bands**: chains are `nil`, flag is `false`. Byte-identical code path to before this fix — zero behavior change for the overwhelming majority of presets.
+- **Linked mode, >31 bands**: chains carry only bands `31...`, both L and R identical (linked mode shares one band list across channels). `AVAudioUnitEQ` still handles bands `0..<31` and is *not* bypassed.
+
+Because the render callback biquad step runs unconditionally ahead of `AVAudioUnitEQ` in the signal path (it's inside the `AVAudioSourceNode`'s own render block, which returns before the graph ever reaches the `AVAudioUnitEQ` node), the two DSP engines compose correctly: the source node hands `AVAudioUnitEQ` audio that already has the overflow bands applied, and `AVAudioUnitEQ` applies bands `0..<31` on top. Cascaded biquads commute for magnitude response, so band order between the two engines doesn't matter acoustically.
+
+## Alternative considered: replace `AVAudioUnitEQ` entirely
+
+The architecturally "purer" option — always route linked-mode EQ through `BiquadFilterChain` too, dropping `AVAudioUnitEQ` from the graph altogether — was considered and rejected for this pass.
+
+The blocker: the pre-EQ/post-EQ spectrum analyzer overlay (`preEqAnalyzer`/`postEqAnalyzer`, user-toggleable in Settings) gets its data via `AVAudioEngine.installTap` on `sourceNode` (pre) and `eqNode` (post) — see `AudioEngine.swift` `start()`. That only works because `AVAudioUnitEQ` is a real node downstream of the source node in the graph; tapping it is how "post-EQ" is captured today. If EQ moved entirely into the render callback, the source node's own tap would already contain the fully-EQ'd signal, collapsing the pre/post distinction for every user, not just those with >31 bands. Fixing that properly would mean feeding both analyzers manually from inside the render callback (a raw-pointer path into `SpectrumAnalyzer`, since wrapping raw render-callback buffers in `AVAudioPCMBuffer` there would allocate on the audio thread) — a materially bigger, riskier change to the most carefully-guarded code in the app.
+
+The hybrid approach keeps `AVAudioUnitEQ` and its tap points completely untouched for every preset at or under 31 bands (the common case), and only introduces the overflow chain for presets that actually exceed it.
+
+## Known trade-off
+
+For a preset with more than 31 bands, the pre-EQ spectrum view is not perfectly "pre" anymore: the overflow chain (bands 31+) has already been applied by the time `sourceNode`'s tap fires, so `preEqAnalyzer` shows a partially-EQ'd signal in that case. `postEqAnalyzer` (tapping after `AVAudioUnitEQ`) is unaffected and remains fully accurate. This only affects users who exceed the AU's native capacity — the vast majority of presets (10–20 bands is typical; even the AutoEQ/OPRA catalog rarely exceeds it) see no change at all.
+
+## What was removed alongside the AU/engine change
+
+The 31-band ceiling was enforced in more than just `AudioEngine`:
+
+- **CLI**: `MenuBarController.addBand` rejected a 32nd band with an explicit error. Removed — the underlying crash risk it existed to prevent (`eq.bands[i]` out of bounds) no longer exists, because `applyBands` now bounds every AU-array access to `min(count, avEQNativeBandCount)`.
+- **Import truncation**: `PresetImporter.parseParametricEQ` (AutoEQ) and `parseOPRA` both truncated to 31 bands after parsing. Removed — imports now keep every band the source file provides.
+- **Not removed**: `PresetImporter`'s GraphicEQ import still resamples onto a fixed 31-point ISO 1/3-octave grid (`iso31BandFrequencies`). That's unrelated to the AU capacity — GraphicEQ.txt is a dense continuous curve, not a list of parametric bands, so importing it always means resampling onto *some* fixed grid; 31 is simply how many ISO 1/3-octave centers exist between 20 Hz and 20 kHz. Higher-resolution GraphicEQ import (e.g. 1/6- or 1/12-octave) would be a deliberate, separate change to the importer, out of scope here.
+- **Latent GUI bug closed as a side effect**: `DreamViewModel.addBand` (the GUI's "+" buttons and "Add Suggested Band") never had its own band-count guard — only the CLI did. Past 31 bands added via the GUI, the old `eq.bands[i]` indexing in `applyBands` would have been out of bounds. `applyBands`'s new bounded loop (`0..<min(count, avEQNativeBandCount)`) closes this regardless of which client (GUI or CLI) is adding bands.
+
+## Verification
+
+- `Tests/iQualizeTests/BiquadFilterChainTests.swift` exercises `BiquadFilterChain` directly with 40 bands and with a chain grown from 1 to 35 bands, confirming the DSP layer has no built-in ceiling.
+- Manually verified against the running app via the CLI: added 105 bands to a live preset (`iqualize band add` in a loop), confirmed `iqualize status` reported zero underruns/resyncs throughout, and confirmed the EQ window rendered the resulting curve and all 105 per-band readout rows without lag or crash.
+
+## Files involved
+
+- `Sources/iQualize/AudioEngine.swift` — `avEQNativeBandCount`, `applyBands`, the render callback's `rtBiquadChainActive`/`rtBiquadChainL`/`rtBiquadChainR`.
+- `Sources/iQualize/BiquadFilter.swift` — `BiquadFilterChain`, unchanged; now serves two roles (full split-channel processing, or linked-mode overflow) instead of one.
+- `Sources/iQualize/MenuBarController.swift` — CLI `addBand`, cap removed.
+- `Sources/iQualize/PresetImporter.swift` — AutoEQ/OPRA import truncation removed; GraphicEQ's ISO grid untouched.
+- `Sources/iQualize/EQModels.swift` — `EQPresetData.maxBandCount` removed (kept `minBandCount`).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ open /Applications/iQualize.app
 
 ### Parametric EQ
 
-- Up to 31 bands with editable frequency (20 Hz – 20 kHz), gain, and bandwidth
+- No arbitrary limit on the number of EQ bands — the practical limit depends on your Mac's available processing resources. Editable frequency (20 Hz – 20 kHz), gain, and bandwidth per band
 - Q / Octave display toggle — switch between Q factor and octave bandwidth globally (Q is the default, octaves for musicians who think in bandwidth)
 - 7 filter types per band: Bell (parametric), Low Shelf, High Shelf, Low Pass, High Pass, Band Pass, and Notch
 - Biquad frequency response curve using Audio EQ Cookbook formulas, rendered as a translucent backdrop behind EQ sliders
@@ -76,7 +76,7 @@ open /Applications/iQualize.app
 - Add bands with + buttons on either side of the EQ — new band copies the leftmost or rightmost band
 - Right-click context menu: Add Suggested Band finds the largest frequency gap and inserts a new band at the geometric midpoint
 - Delete, or reorder via the right-click context menu (Move Left/Right)
-- Minimum 1 band, maximum 31
+- Minimum 1 band, no maximum
 
 ### Presets
 

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -120,7 +120,8 @@ func deinterleaveChannel(
 @MainActor
 final class AudioEngine {
     /// AVAudioUnitEQ's own native band capacity — an AudioEngine implementation
-    /// detail, not a user-facing limit. See the comment at its allocation in start().
+    /// detail, not a user-facing limit. See the comment at its allocation in start(),
+    /// and EQ_BAND_CAPACITY.md for why this can't just be raised.
     private static let avEQNativeBandCount = 31
 
     private(set) var isRunning = false

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -32,13 +32,17 @@ nonisolated(unsafe) private var rtInputGain: Float = 1.0
 /// (see GainPolicy.tapHeadroomCompensation). Applied unconditionally — the tap
 /// attenuates in Bypass too, so Bypass must compensate to sound like app-off.
 nonisolated(unsafe) private var rtVolumeCompensation: Float = 1.0
-/// Per-channel biquad filter chains for split channel mode.
-/// Only active when rtSplitChannelActive is true.
+/// Per-channel biquad filter chains, run in this callback ahead of AVAudioUnitEQ.
+/// Only active when rtBiquadChainActive is true. Two roles, depending on mode:
+/// in split channel mode they carry the full band lists (AVAudioUnitEQ is bypassed
+/// entirely); in linked mode they carry only the bands beyond AVAudioUnitEQ's fixed
+/// native capacity (see AudioEngine.avEQNativeBandCount), so there's no hard cap on
+/// band count in either mode.
 /// Channels 2+ (e.g. 5.1/7.1 surround) pass through unprocessed — per-channel
 /// EQ for >2 channels is a separate feature.
 nonisolated(unsafe) private var rtBiquadChainL: BiquadFilterChain?
 nonisolated(unsafe) private var rtBiquadChainR: BiquadFilterChain?
-nonisolated(unsafe) private var rtSplitChannelActive: Bool = false
+nonisolated(unsafe) private var rtBiquadChainActive: Bool = false
 
 /// AVAudioSourceNode render block: pulls interleaved audio from the capture
 /// client's shared ring buffer, deinterleaves into separate channel buffers
@@ -77,9 +81,11 @@ private func renderCallback(
                             frames: frames, gain: rtInputGain * balance * rtVolumeCompensation)
     }
 
-    // Apply per-channel biquad EQ when split channel mode is active.
-    // This runs INSTEAD of AVAudioUnitEQ (which is bypassed in split mode).
-    if rtSplitChannelActive {
+    // Apply per-channel biquad EQ when a chain is configured — either the whole
+    // preset in split channel mode (AVAudioUnitEQ bypassed), or the overflow
+    // bands beyond AVAudioUnitEQ's native capacity in linked mode (runs ahead
+    // of it in the graph, feeding it already-partially-EQ'd audio).
+    if rtBiquadChainActive {
         if bufferList.count > 0, let outL = bufferList[0].mData?.assumingMemoryBound(to: Float.self) {
             rtBiquadChainL?.process(outL, frameCount: frames)
         }
@@ -113,6 +119,10 @@ func deinterleaveChannel(
 @Observable
 @MainActor
 final class AudioEngine {
+    /// AVAudioUnitEQ's own native band capacity — an AudioEngine implementation
+    /// detail, not a user-facing limit. See the comment at its allocation in start().
+    private static let avEQNativeBandCount = 31
+
     private(set) var isRunning = false
     private(set) var outputDeviceName = "Unknown"
     private(set) var outputDeviceUID: String?
@@ -176,10 +186,7 @@ final class AudioEngine {
     }
 
     var splitChannelActive: Bool = false {
-        didSet {
-            rtSplitChannelActive = splitChannelActive
-            applyBands()
-        }
+        didSet { applyBands() }
     }
 
     var inputGainDB: Float = 0.0 {
@@ -300,30 +307,16 @@ final class AudioEngine {
         let sourceNode = AVAudioSourceNode(format: format, renderBlock: renderCallback)
         self.sourceNode = sourceNode
 
-        let eqNode = AVAudioUnitEQ(numberOfBands: EQPresetData.maxBandCount)
-        for (i, eqBand) in eqNode.bands.enumerated() {
-            if i < activePreset.bands.count {
-                let band = activePreset.bands[i]
-                eqBand.filterType = band.filterType.avType
-                eqBand.frequency = band.frequency
-                eqBand.bandwidth = band.bandwidth
-                eqBand.gain = band.gain
-                eqBand.bypass = false
-            } else {
-                eqBand.bypass = true
-            }
-        }
-        eqNode.globalGain = 0
-        if splitChannelActive && !bypassed {
-            // Split channel mode: bypass AVAudioUnitEQ, set up biquad chains
-            eqNode.bypass = true
-            rtBiquadChainL = BiquadFilterChain(bands: activePreset.bands, sampleRate: sampleRate)
-            rtBiquadChainR = BiquadFilterChain(bands: activePreset.rightBands ?? activePreset.bands, sampleRate: sampleRate)
-            rtSplitChannelActive = true
-        } else {
-            eqNode.bypass = bypassed || activePreset.isFlat
-        }
+        // AVAudioUnitEQ (Apple's AUNBandEQ) natively processes up to
+        // Self.avEQNativeBandCount bands — it's allocated at a fixed size and,
+        // per Apple's own kAUNBandEQProperty_MaxNumberOfBands, can't grow past
+        // its own hardware/OS-defined ceiling regardless of what's requested
+        // here. Any bands beyond that run through rtBiquadChainL/R instead
+        // (see applyBands and the render callback above), so there's no
+        // app-imposed cap on band count — only CPU.
+        let eqNode = AVAudioUnitEQ(numberOfBands: Self.avEQNativeBandCount)
         self.eq = eqNode
+        applyBands()
 
         // Peak limiter: dynamic limiting at 0 dBFS (replaces static preamp hack)
         let limiterDesc = AudioComponentDescription(
@@ -416,6 +409,7 @@ final class AudioEngine {
         rtCaptureClient = nil
         rtBiquadChainL = nil
         rtBiquadChainR = nil
+        rtBiquadChainActive = false
         rtVolumeCompensation = 1.0
 
         // Remove spectrum taps before stopping engine
@@ -461,6 +455,7 @@ final class AudioEngine {
         rtCaptureClient = nil
         rtBiquadChainL = nil
         rtBiquadChainR = nil
+        rtBiquadChainActive = false
         rtVolumeCompensation = 1.0
         sourceNode?.removeTap(onBus: 0)
         eq?.removeTap(onBus: 0)
@@ -482,42 +477,48 @@ final class AudioEngine {
         band.muted ? 0 : band.gain
     }
 
+    private func withEffectiveGain(_ bands: [EQBand]) -> [EQBand] {
+        bands.map { band -> EQBand in
+            var b = band; b.gain = effectiveGain(band); return b
+        }
+    }
+
+    /// Push `bands` into `rtBiquadChainL`/`R`, creating the chains on first use.
+    private func updateBiquadChains(leftBands: [EQBand], rightBands: [EQBand], sampleRate: Double) {
+        if let chainL = rtBiquadChainL {
+            chainL.updateCoefficients(bands: leftBands, sampleRate: sampleRate)
+        } else {
+            rtBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sampleRate)
+        }
+        if let chainR = rtBiquadChainR {
+            chainR.updateCoefficients(bands: rightBands, sampleRate: sampleRate)
+        } else {
+            rtBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sampleRate)
+        }
+    }
+
     private func applyBands(from old: EQPresetData? = nil) {
         guard let eq else { return }
 
         if splitChannelActive && !bypassed {
             // Split channel mode: bypass AVAudioUnitEQ, use custom biquad chains
+            // for the full band lists — already unbounded, no AU capacity involved.
             eq.bypass = true
-            let sr = outputSampleRate
-
-            let leftBands = activePreset.bands.map { band -> EQBand in
-                var b = band; b.gain = effectiveGain(band); return b
-            }
-            let rightSource = activePreset.rightBands ?? activePreset.bands
-            let rightBands = rightSource.map { band -> EQBand in
-                var b = band; b.gain = effectiveGain(band); return b
-            }
-
-            if let chainL = rtBiquadChainL {
-                chainL.updateCoefficients(bands: leftBands, sampleRate: sr)
-            } else {
-                rtBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sr)
-            }
-
-            if let chainR = rtBiquadChainR {
-                chainR.updateCoefficients(bands: rightBands, sampleRate: sr)
-            } else {
-                rtBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sr)
-            }
+            let leftBands = withEffectiveGain(activePreset.bands)
+            let rightBands = withEffectiveGain(activePreset.rightBands ?? activePreset.bands)
+            updateBiquadChains(leftBands: leftBands, rightBands: rightBands, sampleRate: outputSampleRate)
+            rtBiquadChainActive = true
         } else {
-            // Linked mode: use AVAudioUnitEQ, disable biquad chains
-            rtBiquadChainL = nil
-            rtBiquadChainR = nil
+            // Linked mode: AVAudioUnitEQ natively processes the first
+            // Self.avEQNativeBandCount bands; any remaining bands run through
+            // the biquad chains instead, cascaded ahead of it in the render
+            // callback — so band count here is CPU-bound, not AU-bound.
+            let allBands = activePreset.bands
+            let newCount = min(allBands.count, Self.avEQNativeBandCount)
+            let oldCount = min(old?.bands.count ?? 0, Self.avEQNativeBandCount)
 
-            let newCount = activePreset.bands.count
-            let oldCount = old?.bands.count ?? 0
-
-            for (i, band) in activePreset.bands.enumerated() {
+            for i in 0..<newCount {
+                let band = allBands[i]
                 let eqBand = eq.bands[i]
                 if i >= oldCount {
                     // New band — configure fully
@@ -532,20 +533,26 @@ final class AudioEngine {
                     if band.frequency != oldBand.frequency { eqBand.frequency = band.frequency }
                     if effectiveGain(band) != effectiveGain(oldBand) { eqBand.gain = effectiveGain(band) }
                     if band.bandwidth != oldBand.bandwidth { eqBand.bandwidth = band.bandwidth }
-                } else {
-                    // No old data — write everything
-                    eqBand.filterType = band.filterType.avType
-                    eqBand.frequency = band.frequency
-                    eqBand.gain = effectiveGain(band)
-                    eqBand.bandwidth = band.bandwidth
                 }
             }
 
-            // Bypass bands that are no longer active
-            if newCount < oldCount {
-                for i in newCount..<oldCount {
+            // Bypass AU slots not currently in use (covers both a preset shrinking
+            // and the very first call, where oldCount is 0 and eq.bands defaults
+            // to un-bypassed).
+            if newCount < eq.bands.count {
+                for i in newCount..<eq.bands.count {
                     eq.bands[i].bypass = true
                 }
+            }
+
+            if allBands.count > Self.avEQNativeBandCount {
+                let overflowBands = withEffectiveGain(Array(allBands[Self.avEQNativeBandCount...]))
+                updateBiquadChains(leftBands: overflowBands, rightBands: overflowBands, sampleRate: outputSampleRate)
+                rtBiquadChainActive = true
+            } else {
+                rtBiquadChainL = nil
+                rtBiquadChainR = nil
+                rtBiquadChainActive = false
             }
 
             eq.globalGain = 0

--- a/Sources/iQualize/EQModels.swift
+++ b/Sources/iQualize/EQModels.swift
@@ -142,7 +142,6 @@ struct EQPresetData: Codable, Equatable, Sendable, Identifiable {
 extension EQPresetData {
     static let defaultFrequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
 
-    static let maxBandCount = 31
     static let minBandCount = 1
 }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.52.0</string>
+	<string>0.53.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.52.0</string>
+	<string>0.53.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -506,15 +506,8 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         return preset.bands.sorted { $0.frequency < $1.frequency }.map { bandSummary(for: $0, in: preset) }
     }
 
-    /// The 31-band cap is enforced here — AudioEngine.swift creates its AVAudioUnitEQ node
-    /// with a fixed numberOfBands: EQPresetData.maxBandCount (31) and indexes into it with no
-    /// bounds check, so a 32nd band would crash the audio engine. That gap is pre-existing and
-    /// not fixed here — this new code path simply never reaches it.
     func addBand(frequency: Float?, gain: Float?, bandwidth: Float?, filterType: String?) throws -> CLIBandSummary {
         var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
-        guard preset.bands.count < EQPresetData.maxBandCount else {
-            throw CLIHandlerError(message: "preset already has the maximum of \(EQPresetData.maxBandCount) bands")
-        }
         let type: FilterType
         if let filterType {
             guard let parsed = FilterType(rawValue: filterType) else {

--- a/Sources/iQualize/PresetImporter.swift
+++ b/Sources/iQualize/PresetImporter.swift
@@ -114,9 +114,6 @@ enum PresetImporter {
         }
 
         guard !bands.isEmpty else { throw PresetImportError.noBandsFound }
-        if bands.count > EQPresetData.maxBandCount {
-            bands = Array(bands.prefix(EQPresetData.maxBandCount))
-        }
 
         return ParsedPreset(name: nil, bands: bands, rightBands: nil, inputGainDB: preamp, outputGainDB: nil)
     }
@@ -142,7 +139,8 @@ enum PresetImporter {
     // MARK: AutoEQ GraphicEQ.txt
 
     /// Standard 31-band ISO 1/3-octave center frequencies (20 Hz - 20 kHz).
-    /// Conveniently exactly `EQPresetData.maxBandCount`.
+    /// This is the resampling grid GraphicEQ imports are always converted onto,
+    /// independent of how many bands the app itself can process.
     private static let iso31BandFrequencies: [Float] = [
         20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
         1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000, 12500, 16000, 20000
@@ -184,17 +182,13 @@ enum PresetImporter {
     private static func parseOPRA(_ opra: OPRAEqInfo) throws -> ParsedPreset {
         guard opra.type == "parametric_eq" else { throw PresetImportError.unrecognizedFormat }
 
-        var bands = opra.parameters.bands.compactMap { band -> EQBand? in
+        let bands = opra.parameters.bands.compactMap { band -> EQBand? in
             guard let filterType = opraFilterType(band.type) else { return nil }
             let bandwidth = band.q.map { EQBand.qToOctaves($0) } ?? 1.0
             return EQBand(frequency: band.frequency, gain: band.gain_db ?? 0, bandwidth: bandwidth, filterType: filterType)
         }
 
         guard !bands.isEmpty else { throw PresetImportError.noBandsFound }
-        // Schema states bands are "sorted by priority" and software with fewer bands should truncate.
-        if bands.count > EQPresetData.maxBandCount {
-            bands = Array(bands.prefix(EQPresetData.maxBandCount))
-        }
 
         return ParsedPreset(name: nil, bands: bands, rightBands: nil, inputGainDB: opra.parameters.gain_db, outputGainDB: nil)
     }

--- a/Tests/iQualizeTests/BiquadFilterChainTests.swift
+++ b/Tests/iQualizeTests/BiquadFilterChainTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import iQualize
+
+/// Exercises BiquadFilterChain directly — the DSP path AudioEngine uses for
+/// split-channel EQ, and for any bands beyond AVAudioUnitEQ's native capacity
+/// in linked mode (see #114: there's no app-imposed band count limit).
+final class BiquadFilterChainTests: XCTestCase {
+
+    private func band(_ frequency: Float, gain: Float = 3.0) -> EQBand {
+        EQBand(frequency: frequency, gain: gain, bandwidth: 1.0, filterType: .parametric)
+    }
+
+    /// AVAudioUnitEQ's native capacity is 31 bands; a chain well beyond that
+    /// must still process a full buffer without crashing or producing
+    /// non-finite output — this is the DSP layer's half of "no fixed limit."
+    func testProcessesMoreBandsThanAVAudioUnitEQNativeCapacity() {
+        let bandCount = 40
+        let bands = (0..<bandCount).map { band(Float(40 + $0 * 400)) }
+        let chain = BiquadFilterChain(bands: bands, sampleRate: 48000)
+
+        var buffer = [Float](repeating: 0, count: 512)
+        buffer[0] = 1.0 // impulse
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            chain.process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+
+        XCTAssertTrue(buffer.allSatisfy { $0.isFinite })
+        XCTAssertTrue(buffer.contains { $0 != 0 })
+    }
+
+    /// updateCoefficients must resize its internal state when band count grows
+    /// past the previous count, not just when it shrinks.
+    func testUpdateCoefficientsGrowsPastPreviousCount() {
+        let chain = BiquadFilterChain(bands: [band(1000)], sampleRate: 48000)
+        let grown = (0..<35).map { band(Float(50 + $0 * 500)) }
+        chain.updateCoefficients(bands: grown, sampleRate: 48000)
+
+        var buffer = [Float](repeating: 0, count: 256)
+        buffer[0] = 1.0
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            chain.process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+
+        XCTAssertTrue(buffer.allSatisfy { $0.isFinite })
+    }
+}

--- a/Tests/iQualizeTests/EQPresetTests.swift
+++ b/Tests/iQualizeTests/EQPresetTests.swift
@@ -47,13 +47,12 @@ final class EQPresetDataTests: XCTestCase {
 
     func testBuiltInPresetBandCountsWithinLimits() {
         // The classic 10-band presets keep 10 bands; the newer ones vary
-        // (Luzifer's Void 16, 0xDEADBEEF 20) but must fit the engine's cap.
+        // (Luzifer's Void 16, 0xDEADBEEF 20) — there's no upper cap to fit.
         XCTAssertEqual(EQPresetData.flat.bands.count, 10)
         XCTAssertEqual(EQPresetData.bassBoost.bands.count, 10)
         XCTAssertEqual(EQPresetData.vocalClarity.bands.count, 10)
         for preset in EQPresetData.builtInPresets {
             XCTAssertGreaterThanOrEqual(preset.bands.count, EQPresetData.minBandCount)
-            XCTAssertLessThanOrEqual(preset.bands.count, EQPresetData.maxBandCount)
         }
     }
 


### PR DESCRIPTION
## Summary

`AVAudioUnitEQ` (Apple's AUNBandEQ) has a real, OS-defined ceiling on how many bands it can natively process, exposed via `kAUNBandEQProperty_MaxNumberOfBands`. The app's own `maxBandCount = 31` mirrored that, but it was still an app-imposed wall stacked on top of a framework one — growing the AU's allocation on demand would only have moved the wall, not removed it.

`AudioEngine` now caps `AVAudioUnitEQ` at its native 31-band capacity and cascades any bands beyond that through `BiquadFilterChain` in the render callback — the same software biquad path split-channel mode already used exclusively and unbounded. `applyBands` is now a single code path for both linked and split-channel modes, replacing the duplicated band-setup logic that used to live in both `start()` and `applyBands()`.

Removed the cap everywhere it was enforced: the CLI's `addBand` guard, and AutoEQ/OPRA import truncation. GraphicEQ's fixed 31-point ISO resampling grid stays, since that's a property of the format, not the engine.

This also closes a latent GUI crash risk — `DreamViewModel.addBand` had no band-count guard of its own and would have indexed `eq.bands[i]` out of bounds past 31.

## Scope

- Bumped to 0.53.0 and updated `CHANGELOG.md` per repo convention (new capability, minor bump).
- Updated `README.md`'s band-count claims.
- Left the GraphicEQ import's fixed 31-point ISO grid untouched — it's a resampling grid inherent to the format, not the removed cap.

## Test plan

- [x] `swift test` — 60 existing tests pass, plus new `BiquadFilterChainTests` covering a 40-band chain and growing a chain from 1 to 35 bands
- [x] Built, installed, and launched the app (`install.sh` + launch verification)
- [x] Added 105 bands to a live preset via the CLI (`iqualize band add`) — `iqualize status` showed zero underruns/resyncs throughout
- [x] Opened the EQ window with all 105 bands active — curve, anchor dots, and readout grid rendered correctly; window stayed responsive to interaction
- [x] Deleted the test preset via CLI to leave the running app clean

Fixes #114