### PR TITLE
Make built-in presets directly overwritable, remove fork/copy mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.54.0] - 2026-07-31
+
+### Changed
+- Built-in presets are now edited and saved in place instead of forking into a "(Custom)" copy on first edit (#101). `PresetStore` gained a `builtInOverrides` table keyed by the built-in's own id — `allPresets`/`hiddenBuiltInPresets` resolve through it, so identity, `isBuiltIn`, and picker position never change, only content. `forkIfBuiltIn` is gone from both the GUI (`DreamViewModel`) and CLI (`MenuBarController`, `SettingsWindowController`) mutation paths, and Save on a built-in no longer redirects to Save As. The Preset Browser's iQualize tab gained an "Edited" section (alongside the existing hidden/"Restore" one) with its own "Reset to Original" action, mirrored inline in the EQ window's Save menu when the active preset has a saved override. Existing forks from the old model are left alone as regular custom presets — no migration, since a fork can't be reliably distinguished from an independently-created custom preset with a coincidental name.
+
+### Fixed
+- `DreamViewModel.savePreset()` never refreshed the window title, so the "●" unsaved-changes dot lingered after a successful save. Pre-existing for custom presets, but only became visible once built-ins started saving through the same path instead of always redirecting to Save As.
+- The Preset Browser's "Reset to Original" called `PresetStore` directly, bypassing the EQ window's view model — if the reset preset was also the one currently loaded there, the window kept showing (and could re-save) the stale override instead of syncing to the reverted original.
+
 ## [0.53.0] - 2026-07-30
 
 ### Changed

--- a/Sources/iQualize/DreamUI/DreamToolbar.swift
+++ b/Sources/iQualize/DreamUI/DreamToolbar.swift
@@ -55,12 +55,13 @@ struct DreamToolbar: View {
         Button("New") { vm.newPreset() }
 
         Menu {
-            Button("Save") {
-                if vm.isBuiltIn { vm.presentSaveAsDialog() } else { vm.savePreset() }
-            }
-            .keyboardShortcut("s", modifiers: .command)
+            Button("Save") { vm.savePreset() }
+                .keyboardShortcut("s", modifiers: .command)
             Button("Save As…") { vm.presentSaveAsDialog() }
                 .keyboardShortcut("s", modifiers: [.command, .shift])
+            if vm.isBuiltIn && vm.presetStore.hasOverride(vm.activePresetID) {
+                Button("Reset to Original") { vm.resetActiveBuiltInToOriginal() }
+            }
             Divider()
             Button("Import Preset…") { vm.importPresets() }
             Button("Preset Browser…") { vm.showPresetBrowser() }
@@ -68,7 +69,7 @@ struct DreamToolbar: View {
         } label: {
             Text("Save")
         } primaryAction: {
-            if vm.isBuiltIn { vm.presentSaveAsDialog() } else { vm.savePreset() }
+            vm.savePreset()
         }
         .menuStyle(.button)
         .controlSize(.regular)

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -89,8 +89,8 @@ final class DreamViewModel {
     }
 
     /// Unpins if the active preset is already the one pinned here, otherwise pins it.
-    /// No-ops while there are unsaved changes — pinning an unsaved fork would point at an
-    /// id that isn't in `PresetStore`, silently dangling the pin.
+    /// No-ops while there are unsaved changes — the pin stores only the id, so pinning now
+    /// would later resolve to whatever's on disk, not the edit currently on screen.
     func toggleDevicePin() {
         guard let uid = audioEngine.outputDeviceUID else { return }
         if isCurrentDevicePinnedToActivePreset {
@@ -237,9 +237,8 @@ final class DreamViewModel {
     }
 
     /// The dirty flag tracks whether the EQ *content* (band curves) differs from the saved
-    /// baseline — not the preset's identity (id / name / built-in flag). Comparing identity is
-    /// wrong across a built-in→"(Custom)" fork: undoing the fork restores the same curve under a
-    /// different identity and would otherwise leave a phantom dirty dot.
+    /// baseline, not the preset's identity — a built-in and a custom preset are edited and
+    /// saved the same way, in place.
     private func contentMatchesSaved(_ preset: EQPresetData) -> Bool {
         guard let saved = savedSnapshot else { return false }
         return preset.bands == saved.bands
@@ -253,7 +252,6 @@ final class DreamViewModel {
     /// Snapshot before mutation, mutate, then register undo. `actionName` is shown in Edit > Undo.
     private func mutate(_ actionName: String, _ transform: () -> Void) {
         let oldPreset = audioEngine.activePreset
-        forkIfBuiltIn()
         transform()
         pushBandsToEngine()
         registerUndo(actionName: actionName, oldPreset: oldPreset)
@@ -262,7 +260,6 @@ final class DreamViewModel {
     /// Same as `mutate` but does not register undo — for in-progress drag operations
     /// where undo registers on drag end via `commitDrag`.
     private func liveMutate(_ transform: () -> Void) {
-        forkIfBuiltIn()
         transform()
         pushBandsToEngine()
     }
@@ -387,16 +384,6 @@ final class DreamViewModel {
         }
     }
 
-    private func forkIfBuiltIn() {
-        guard audioEngine.activePreset.isBuiltIn else { return }
-        let newPreset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
-        audioEngine.activePreset = newPreset
-        savedSnapshot = newPreset
-        presetName = newPreset.name
-        activePresetID = newPreset.id
-        isBuiltIn = false
-    }
-
     private func registerUndo(actionName: String, oldPreset: EQPresetData) {
         guard let undoManager else { return }
         let currentPreset = audioEngine.activePreset
@@ -437,8 +424,8 @@ final class DreamViewModel {
         let newGain = gain.map      { max(-gainClamp, min(gainClamp, $0)) }
         let newBW   = bandwidth.map { $0.clamped(to: EQBand.bandwidthRange) }
         // No-op guard: if nothing actually changes, don't mutate. This keeps re-selecting a band's
-        // current filter type (or nudging a value that's already at its clamp) from forking a
-        // built-in preset to "(Custom)" or pushing a redundant undo step.
+        // current filter type (or nudging a value that's already at its clamp) from dirtying a
+        // built-in preset or pushing a redundant undo step.
         let changes =
             (newFreq.map     { $0 != cur.frequency }  ?? false) ||
             (newGain.map     { $0 != cur.gain }       ?? false) ||
@@ -606,20 +593,35 @@ final class DreamViewModel {
     }
 
     func savePreset() {
-        if isBuiltIn {
-            // Save-As required for built-in
-            saveAsPreset(name: nil)
-            return
-        }
         var preset = audioEngine.activePreset
         preset.bands = bands
         preset.rightBands = rightBands
-        presetStore.saveCustomPreset(preset)
+        if isBuiltIn {
+            presetStore.saveBuiltInOverride(preset)
+        } else {
+            presetStore.saveCustomPreset(preset)
+        }
         savedSnapshot = preset
         isModified = false
+        onTitleShouldUpdate?()
         var s = iQualizeState.load()
         s.selectedPresetID = preset.id
         s.save()
+    }
+
+    /// Reverts the active built-in preset to its shipped original — undoes not just the
+    /// current session's edits but any previously-saved override. No-op unless the active
+    /// preset is a built-in with a saved override.
+    func resetActiveBuiltInToOriginal() {
+        guard isBuiltIn, presetStore.hasOverride(activePresetID),
+              let original = EQPresetData.builtInPresets.first(where: { $0.id == activePresetID }) else { return }
+        let old = audioEngine.activePreset
+        audioEngine.activePreset = original
+        presetStore.resetBuiltInToOriginal(id: activePresetID)
+        savedSnapshot = original
+        isModified = false
+        syncFromAudioEngine()
+        registerUndo(actionName: "Reset to Original", oldPreset: old)
     }
 
     func saveAsPreset(name: String?) {
@@ -699,9 +701,7 @@ final class DreamViewModel {
     // MARK: - Native dialogs
 
     /// If there are unsaved changes, asks Save / Cancel / Don't Save before running `then`.
-    /// Proceeds straight to `then` when there's nothing to lose. "Save" reuses the same
-    /// built-in-redirects-to-Save-As rule as the toolbar's Save button; if that dialog gets
-    /// cancelled, the whole action is treated as cancelled too.
+    /// Proceeds straight to `then` when there's nothing to lose.
     func confirmDiscardIfNeeded(then: @escaping () -> Void) {
         guard isModified else { then(); return }
         let alert = NSAlert()
@@ -712,12 +712,7 @@ final class DreamViewModel {
         alert.addButton(withTitle: "Don't Save")
         switch alert.runModal() {
         case .alertFirstButtonReturn:
-            if isBuiltIn {
-                presentSaveAsDialog()
-                if isModified { return } // the Save As name prompt was itself cancelled
-            } else {
-                savePreset()
-            }
+            savePreset()
             then()
         case .alertThirdButtonReturn:
             then()
@@ -878,12 +873,26 @@ final class DreamViewModel {
     /// Opens (or refocuses) the Preset Browser window (OPRA tab + iQualize tab).
     func showPresetBrowser() {
         if presetBrowserWindowController == nil {
-            presetBrowserWindowController = PresetBrowserWindowController(presetStore: presetStore) { [weak self] product, curve in
-                self?.importOPRACurve(product: product, curve: curve)
-            }
+            presetBrowserWindowController = PresetBrowserWindowController(
+                presetStore: presetStore,
+                onImportOPRA: { [weak self] product, curve in self?.importOPRACurve(product: product, curve: curve) },
+                onResetBuiltIn: { [weak self] id in self?.resetBuiltIn(id: id) }
+            )
         }
         presetBrowserWindowController?.showWindow(nil)
         presetBrowserWindowController?.window?.makeKeyAndOrderFront(nil)
+    }
+
+    /// Resets a built-in's saved override from outside the EQ window (the Preset Browser).
+    /// Routes through `resetActiveBuiltInToOriginal()` when `id` is the preset currently loaded
+    /// here, so the live bands/curve/dirty-state stay in sync with the store — otherwise the
+    /// window would keep showing the stale override and could re-save it on the next Save.
+    private func resetBuiltIn(id: UUID) {
+        if id == activePresetID {
+            resetActiveBuiltInToOriginal()
+        } else {
+            presetStore.resetBuiltInToOriginal(id: id)
+        }
     }
 
     private func importOPRACurve(product: OPRAProductEntry, curve: OPRACurveEntry) {
@@ -954,12 +963,11 @@ final class DreamViewModel {
         }
     }
 
-    /// Per-preset gain edit: forks a built-in in-memory only (matches `mutate()`'s band-edit
-    /// behavior) — no `PresetStore.saveCustomPreset` call, so the fork stays out of the picker
-    /// and out of persisted state until an explicit Save.
+    /// Per-preset gain edit: mutates in-memory only (matches `mutate()`'s band-edit behavior) —
+    /// no store-persist call here, so the edit stays out of the picker and out of persisted
+    /// state until an explicit Save.
     private func mutateGain(_ actionName: String, _ apply: (inout EQPresetData) -> Void) {
         let oldPreset = audioEngine.activePreset
-        forkIfBuiltIn()
         var preset = audioEngine.activePreset
         apply(&preset)
         audioEngine.activePreset = preset

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Top-level Preset Browser: a `NavigationSplitView` whose sidebar stacks a search field on
 /// top, the scrolling catalog list in the middle, and the OPRA/iQualize catalog picker pinned
 /// at the bottom. The picker switches between OPRA's community database and iQualize's own
-/// built-in presets the user has hidden from their picker. The detail pane shows the selected
-/// OPRA product's community EQ curves.
+/// built-in presets the user has hidden from their picker or edited and saved in place. The
+/// detail pane shows the selected OPRA product's community EQ curves.
 ///
 /// The search field is a plain `VStack` sibling above the `List`, not `.searchable`. A
 /// `.searchable(placement: .sidebar)` field renders as a transparent overlay inside the
@@ -14,6 +14,12 @@ import SwiftUI
 struct PresetBrowserView: View {
     let presetStore: PresetStore
     let onImportOPRA: (OPRAProductEntry, OPRACurveEntry) -> Void
+    /// Routes through the EQ window's view model rather than calling
+    /// `presetStore.resetBuiltInToOriginal` directly — if the preset being reset is also the
+    /// one currently loaded in the EQ window, the view model needs to sync its in-memory bands
+    /// back to the original too, or the window keeps showing (and could re-save) the stale
+    /// override.
+    let onResetBuiltIn: (UUID) -> Void
 
     private enum Catalog: String, CaseIterable {
         case opra = "OPRA"
@@ -41,6 +47,12 @@ struct PresetBrowserView: View {
         let hidden = presetStore.hiddenBuiltInPresets
         guard !searchText.isEmpty else { return hidden }
         return hidden.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var filteredOverriddenPresets: [EQPresetData] {
+        let overridden = presetStore.overriddenBuiltInPresets
+        guard !searchText.isEmpty else { return overridden }
+        return overridden.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
     var body: some View {
@@ -141,20 +153,38 @@ struct PresetBrowserView: View {
     @ViewBuilder
     private var iqualizeSidebar: some View {
         let hidden = filteredHiddenPresets
-        if hidden.isEmpty {
+        let overridden = filteredOverriddenPresets
+        if hidden.isEmpty && overridden.isEmpty {
             Text(searchText.isEmpty
-                 ? "All built-in presets are already in your list"
+                 ? "All built-in presets are in your list, unedited"
                  : "No matching presets")
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            List(hidden) { preset in
-                HStack {
-                    Text(preset.name)
-                    Spacer()
-                    Button("Restore") { presetStore.restoreBuiltInPreset(id: preset.id) }
+            List {
+                if !overridden.isEmpty {
+                    Section("Edited") {
+                        ForEach(overridden) { preset in
+                            HStack {
+                                Text(preset.name)
+                                Spacer()
+                                Button("Reset to Original") { onResetBuiltIn(preset.id) }
+                            }
+                        }
+                    }
+                }
+                if !hidden.isEmpty {
+                    Section("Hidden") {
+                        ForEach(hidden) { preset in
+                            HStack {
+                                Text(preset.name)
+                                Spacer()
+                                Button("Restore") { presetStore.restoreBuiltInPreset(id: preset.id) }
+                            }
+                        }
+                    }
                 }
             }
             .listStyle(.sidebar)
@@ -223,7 +253,7 @@ struct PresetBrowserView: View {
                 placeholder("Select a headphone to see available EQ profiles")
             }
         case .iqualize:
-            placeholder("Restore a built-in preset to add it back to your picker")
+            placeholder("Restore a hidden built-in, or reset an edited one back to its original values")
         }
     }
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.53.0</string>
+	<string>0.54.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.53.0</string>
+	<string>0.54.0</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -316,10 +316,10 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         return newValue
     }
 
-    /// Sets input gain in dB, forking the active preset if it's built-in and gain isn't
+    /// Sets input gain in dB, saving it into the active preset in place when gain isn't
     /// shared globally — mirrors `DreamViewModel.applyInputGain`
     /// (Sources/iQualize/DreamUI/DreamViewModel.swift), plus persisting `selectedPresetID`
-    /// so a fork survives a relaunch instead of reverting to the built-in original.
+    /// so the edit survives a relaunch.
     func setInputGain(_ db: Float) {
         if audioEngine.gainIsGlobal {
             audioEngine.inputGainDB = db
@@ -327,10 +327,10 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             s.inputGainDB = db
             s.save()
         } else {
-            var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+            var preset = audioEngine.activePreset
             preset.inputGainDB = db
             audioEngine.activePreset = preset
-            presetStore.saveCustomPreset(preset)
+            persistPreset(preset)
             var s = iQualizeState.load()
             s.selectedPresetID = preset.id
             s.save()
@@ -338,7 +338,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         eqWindowController?.syncUIToPreset()
     }
 
-    /// Sets output gain in dB — same fork-if-built-in rule as `setInputGain`.
+    /// Sets output gain in dB — same in-place save rule as `setInputGain`.
     func setOutputGain(_ db: Float) {
         if audioEngine.gainIsGlobal {
             audioEngine.outputGainDB = db
@@ -346,10 +346,10 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             s.outputGainDB = db
             s.save()
         } else {
-            var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+            var preset = audioEngine.activePreset
             preset.outputGainDB = db
             audioEngine.activePreset = preset
-            presetStore.saveCustomPreset(preset)
+            persistPreset(preset)
             var s = iQualizeState.load()
             s.selectedPresetID = preset.id
             s.save()
@@ -383,8 +383,9 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         return newValue
     }
 
-    /// Mirrors SettingsWindowController.toggleLinkGainGlobally(_:) verbatim — forks the
-    /// active preset on the global -> per-preset transition so it survives a relaunch.
+    /// Mirrors SettingsWindowController.toggleLinkGainGlobally(_:) verbatim — saves the
+    /// active preset's gain in place on the global -> per-preset transition so it survives
+    /// a relaunch.
     func setGainIsGlobal(_ global: Bool) {
         var s = iQualizeState.load()
         if global {
@@ -395,10 +396,10 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
             audioEngine.gainIsGlobal = true
         } else {
             audioEngine.gainIsGlobal = false
-            var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+            var preset = audioEngine.activePreset
             preset.inputGainDB = audioEngine.inputGainDB
             preset.outputGainDB = audioEngine.outputGainDB
-            presetStore.saveCustomPreset(preset)
+            persistPreset(preset)
             audioEngine.activePreset = preset
             s.linkGainGlobally = false
             s.save()
@@ -491,10 +492,21 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
                                bandwidth: band.bandwidth, filterType: band.filterType.rawValue, muted: band.muted)
     }
 
-    /// Same fork -> mutate -> push -> persist -> sync shape as setInputGain/setPeakLimiter.
+    /// Persists `preset` to whichever store it belongs in — the built-in override table if
+    /// it's a built-in, `customPresets` otherwise. Nothing forks: a built-in stays a built-in,
+    /// edited and saved in place.
+    private func persistPreset(_ preset: EQPresetData) {
+        if preset.isBuiltIn {
+            presetStore.saveBuiltInOverride(preset)
+        } else {
+            presetStore.saveCustomPreset(preset)
+        }
+    }
+
+    /// Same mutate -> push -> persist -> sync shape as setInputGain/setPeakLimiter.
     private func persistBandMutation(_ preset: EQPresetData) {
         audioEngine.activePreset = preset
-        presetStore.saveCustomPreset(preset)
+        persistPreset(preset)
         var s = iQualizeState.load()
         s.selectedPresetID = preset.id
         s.save()
@@ -507,7 +519,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     }
 
     func addBand(frequency: Float?, gain: Float?, bandwidth: Float?, filterType: String?) throws -> CLIBandSummary {
-        var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        var preset = audioEngine.activePreset
         let type: FilterType
         if let filterType {
             guard let parsed = FilterType(rawValue: filterType) else {
@@ -526,7 +538,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     }
 
     func deleteBand(index: Int?, matchFrequency: Float?) throws {
-        var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        var preset = audioEngine.activePreset
         let id = try resolveBandID(index: index, matchFrequency: matchFrequency, in: preset)
         guard preset.bands.count > EQPresetData.minBandCount else {
             throw CLIHandlerError(message: "preset must keep at least \(EQPresetData.minBandCount) band")
@@ -536,7 +548,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     }
 
     func setBand(index: Int?, matchFrequency: Float?, frequency: Float?, gain: Float?, bandwidth: Float?, filterType: String?) throws -> CLIBandSummary {
-        var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        var preset = audioEngine.activePreset
         let id = try resolveBandID(index: index, matchFrequency: matchFrequency, in: preset)
         guard let i = preset.bands.firstIndex(where: { $0.id == id }) else {
             throw CLIHandlerError(message: "band not found")
@@ -557,7 +569,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     /// Mirrors DreamViewModel.moveBandHorizontally(id:dir:) exactly: swaps FREQUENCY VALUES
     /// with the adjacent band in sorted order — not an array reorder.
     func moveBand(index: Int?, matchFrequency: Float?, direction: String) throws -> CLIBandSummary {
-        var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        var preset = audioEngine.activePreset
         let id = try resolveBandID(index: index, matchFrequency: matchFrequency, in: preset)
         let sorted = preset.bands.sorted { $0.frequency < $1.frequency }
         guard let idx = sorted.firstIndex(where: { $0.id == id }) else {
@@ -591,7 +603,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
     /// stored gain here would lose it permanently; AudioEngine.applyBands' effectiveGain(_:)
     /// respects `.muted` at the DSP layer instead.
     func setBandMute(index: Int?, matchFrequency: Float?, muted: Bool) throws -> CLIBandSummary {
-        var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        var preset = audioEngine.activePreset
         let id = try resolveBandID(index: index, matchFrequency: matchFrequency, in: preset)
         guard let i = preset.bands.firstIndex(where: { $0.id == id }) else {
             throw CLIHandlerError(message: "band not found")
@@ -603,7 +615,7 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
 
     @discardableResult
     func toggleBandMute(index: Int?, matchFrequency: Float?) throws -> CLIBandSummary {
-        let preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        let preset = audioEngine.activePreset
         let id = try resolveBandID(index: index, matchFrequency: matchFrequency, in: preset)
         guard let current = preset.bands.first(where: { $0.id == id })?.muted else {
             throw CLIHandlerError(message: "band not found")
@@ -621,16 +633,14 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         return presetStore.allPresets.first { $0.name.caseInsensitiveCompare(idOrName) == .orderedSame }
     }
 
-    /// Forks (if needed) and persists the active preset. A no-op in the common case (already
-    /// a custom preset with no pending changes since every CLI mutation already persists
-    /// immediately) — the one thing it actually does is "adopt" a freshly-selected built-in
-    /// into a real custom preset, mirroring the GUI's Save -> Save-As-for-built-ins rule
-    /// minus the name prompt (per the CLI's auto-fork convention).
+    /// Persists the active preset as-is. A no-op in the common case (every CLI mutation
+    /// already persists immediately) — matters only for a freshly-selected, never-touched
+    /// built-in, which this saves back to itself as a (no-op) override.
     @discardableResult
     func saveActivePreset() -> CLIPresetSummary {
-        let preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+        let preset = audioEngine.activePreset
         persistBandMutation(preset)
-        return CLIPresetSummary(id: preset.id, name: preset.name, isBuiltIn: false,
+        return CLIPresetSummary(id: preset.id, name: preset.name, isBuiltIn: preset.isBuiltIn,
                                  isFavorite: presetStore.isFavorite(preset.id), isActive: true)
     }
 
@@ -679,9 +689,9 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         return CLIPresetSummary(id: preset.id, name: preset.name, isBuiltIn: false, isFavorite: false, isActive: true)
     }
 
-    /// Renaming a built-in forks it first and renames the fork — the true built-in is never
-    /// mutated in place, consistent with every other CLI mutation. Renaming "Flat" itself is
-    /// deliberately not blocked (unlike delete): it only ever creates a harmless fork.
+    /// Renaming a built-in now renames it in place — an override, name included — consistent
+    /// with every other CLI mutation. Renaming "Flat" itself is still not blocked (unlike
+    /// delete): it only ever changes the display name, not Flat's protected id.
     func renamePreset(idOrName: String, newName: String) throws -> CLIPresetSummary {
         guard let source = resolvePreset(idOrName: idOrName) else {
             throw CLIHandlerError(message: "no preset named '\(idOrName)'")
@@ -691,13 +701,13 @@ final class MenuBarController: NSObject, @preconcurrency NSMenuDelegate, CLIComm
         guard !presetStore.allPresets.contains(where: { $0.id != source.id && $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }) else {
             throw CLIHandlerError(message: "a preset named '\(trimmed)' already exists")
         }
-        var renamed = presetStore.forkIfBuiltIn(source)
+        var renamed = source
         renamed.name = trimmed
-        presetStore.saveCustomPreset(renamed)
+        persistPreset(renamed)
         if audioEngine.activePreset.id == source.id {
             persistBandMutation(renamed)
         }
-        return CLIPresetSummary(id: renamed.id, name: renamed.name, isBuiltIn: false,
+        return CLIPresetSummary(id: renamed.id, name: renamed.name, isBuiltIn: renamed.isBuiltIn,
                                  isFavorite: presetStore.isFavorite(renamed.id), isActive: audioEngine.activePreset.id == renamed.id)
     }
 

--- a/Sources/iQualize/PresetBrowserWindowController.swift
+++ b/Sources/iQualize/PresetBrowserWindowController.swift
@@ -8,7 +8,11 @@ import SwiftUI
 @available(macOS 14.2, *)
 @MainActor
 final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate {
-    init(presetStore: PresetStore, onImportOPRA: @escaping (OPRAProductEntry, OPRACurveEntry) -> Void) {
+    init(
+        presetStore: PresetStore,
+        onImportOPRA: @escaping (OPRAProductEntry, OPRACurveEntry) -> Void,
+        onResetBuiltIn: @escaping (UUID) -> Void
+    ) {
         let window = ShortcutAwareWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
@@ -22,7 +26,7 @@ final class PresetBrowserWindowController: NSWindowController, NSWindowDelegate 
         super.init(window: window)
         window.delegate = self
 
-        let host = NSHostingView(rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA))
+        let host = NSHostingView(rootView: PresetBrowserView(presetStore: presetStore, onImportOPRA: onImportOPRA, onResetBuiltIn: onResetBuiltIn))
         host.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -12,9 +12,15 @@ final class PresetStore {
     private(set) var hiddenBuiltInPresetIDs: [UUID] = []
     /// Preset pinned per output device, keyed by the device's stable CoreAudio UID.
     private(set) var pinnedPresetIDByDeviceUID: [String: UUID] = [:]
+    /// Built-in presets the user has edited and saved in place, keyed by the built-in's own
+    /// (stable) id. A built-in with no entry here is still exactly what shipped. Independent
+    /// of `hiddenBuiltInPresetIDs` — a built-in can be hidden, overridden, both, or neither.
+    private(set) var builtInOverrides: [UUID: EQPresetData] = [:]
 
     var allPresets: [EQPresetData] {
-        EQPresetData.builtInPresets.filter { !hiddenBuiltInPresetIDs.contains($0.id) } + customPresets
+        EQPresetData.builtInPresets
+            .filter { !hiddenBuiltInPresetIDs.contains($0.id) }
+            .map(resolved) + customPresets
     }
 
     /// Favorited presets, in favorite order. Skips IDs that no longer resolve to a preset.
@@ -23,15 +29,28 @@ final class PresetStore {
     }
 
     /// Built-in presets currently hidden from the picker — shown in the Preset Browser's
-    /// iQualize tab so they can be brought back.
+    /// iQualize tab so they can be brought back. Reflects any saved edits, not the pristine
+    /// original, so "Restore" brings back what the user last saved.
     var hiddenBuiltInPresets: [EQPresetData] {
-        EQPresetData.builtInPresets.filter { hiddenBuiltInPresetIDs.contains($0.id) }
+        EQPresetData.builtInPresets.filter { hiddenBuiltInPresetIDs.contains($0.id) }.map(resolved)
+    }
+
+    /// Built-in presets the user has edited and saved in place, in catalog order — shown in
+    /// the Preset Browser's iQualize tab so they can be reset back to their original values.
+    var overriddenBuiltInPresets: [EQPresetData] {
+        EQPresetData.builtInPresets.compactMap { builtInOverrides[$0.id] }
+    }
+
+    /// Resolves a built-in to its saved override, or itself if untouched.
+    private func resolved(_ builtIn: EQPresetData) -> EQPresetData {
+        builtInOverrides[builtIn.id] ?? builtIn
     }
 
     private static let key = "com.iqualize.customPresets"
     private static let favoritesKey = "com.iqualize.favoritePresetIDs"
     private static let hiddenBuiltInsKey = "com.iqualize.hiddenBuiltInPresetIDs"
     private static let devicePinsKey = "com.iqualize.pinnedPresetsByDevice"
+    private static let builtInOverridesKey = "com.iqualize.builtInOverrides"
 
     /// Injectable so tests can use an isolated suite instead of polluting the real app's
     /// persisted state (or leaking test data between runs).
@@ -121,24 +140,28 @@ final class PresetStore {
         persistHiddenBuiltIns()
     }
 
-    /// Returns a "(Custom)" fork of `preset` (deduped name against `allPresets`) if it's
-    /// built-in; returns `preset` unchanged otherwise. Pure — does not persist and does not
-    /// touch AudioEngine; callers decide whether/when to call `saveCustomPreset`.
-    func forkIfBuiltIn(_ preset: EQPresetData) -> EQPresetData {
-        guard preset.isBuiltIn else { return preset }
-        return EQPresetData(
-            id: UUID(),
-            name: dedupedName(base: "\(preset.name) (Custom)"),
-            bands: preset.bands,
-            rightBands: preset.rightBands,
-            isBuiltIn: false,
-            inputGainDB: preset.inputGainDB,
-            outputGainDB: preset.outputGainDB
-        )
+    /// Whether `id` (a built-in's id) currently has a saved override.
+    func hasOverride(_ id: UUID) -> Bool {
+        builtInOverrides[id] != nil
+    }
+
+    /// Saves `preset` as the in-place override for the built-in it belongs to. No-ops for a
+    /// non-built-in — use `saveCustomPreset` for those.
+    func saveBuiltInOverride(_ preset: EQPresetData) {
+        guard preset.isBuiltIn else { return }
+        builtInOverrides[preset.id] = preset
+        persistBuiltInOverrides()
+    }
+
+    /// Discards the saved override for the built-in `id`, reverting it back to whatever
+    /// `EQPresetData.builtInPresets` ships. A no-op if there's no override.
+    func resetBuiltInToOriginal(id: UUID) {
+        guard builtInOverrides.removeValue(forKey: id) != nil else { return }
+        persistBuiltInOverrides()
     }
 
     /// Appends " 2", " 3", ... to `base` until it doesn't collide (exact match) with any
-    /// current preset name. Shared by `forkIfBuiltIn` and the CLI's `duplicate` command.
+    /// current preset name. Used by the CLI's `duplicate` command.
     func dedupedName(base: String) -> String {
         let existing = Set(allPresets.map { $0.name })
         guard existing.contains(base) else { return base }
@@ -164,6 +187,10 @@ final class PresetStore {
            let pins = try? JSONDecoder().decode([String: UUID].self, from: data) {
             pinnedPresetIDByDeviceUID = pins
         }
+        if let data = defaults.data(forKey: Self.builtInOverridesKey),
+           let overrides = try? JSONDecoder().decode([UUID: EQPresetData].self, from: data) {
+            builtInOverrides = overrides
+        }
     }
 
     private func persist() {
@@ -187,6 +214,12 @@ final class PresetStore {
     private func persistDevicePins() {
         if let data = try? JSONEncoder().encode(pinnedPresetIDByDeviceUID) {
             defaults.set(data, forKey: Self.devicePinsKey)
+        }
+    }
+
+    private func persistBuiltInOverrides() {
+        if let data = try? JSONEncoder().encode(builtInOverrides) {
+            defaults.set(data, forKey: Self.builtInOverridesKey)
         }
     }
 }

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -334,12 +334,16 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             audioEngine.gainIsGlobal = true
         } else {
             // Global -> Per-preset: seed the active preset with the current global gain,
-            // forking it out of a built-in first if needed.
+            // saved in place whether it's a built-in or a custom preset.
             audioEngine.gainIsGlobal = false
-            var preset = presetStore.forkIfBuiltIn(audioEngine.activePreset)
+            var preset = audioEngine.activePreset
             preset.inputGainDB = audioEngine.inputGainDB
             preset.outputGainDB = audioEngine.outputGainDB
-            presetStore.saveCustomPreset(preset)
+            if preset.isBuiltIn {
+                presetStore.saveBuiltInOverride(preset)
+            } else {
+                presetStore.saveCustomPreset(preset)
+            }
             audioEngine.activePreset = preset
             state.linkGainGlobally = false
             state.save()

--- a/Sources/iqualize-cli/PresetLifecycleCommand.swift
+++ b/Sources/iqualize-cli/PresetLifecycleCommand.swift
@@ -27,7 +27,7 @@ extension Presets {
     }
 
     struct Save: ParsableCommand {
-        static let configuration = CommandConfiguration(abstract: "Save the active preset, forking it first if it's built-in.")
+        static let configuration = CommandConfiguration(abstract: "Save the active preset in place, built-in or not.")
 
         @Flag(help: "Show quick usage examples for this command.")
         var tldr = false
@@ -88,7 +88,7 @@ extension Presets {
     }
 
     struct Rename: ParsableCommand {
-        static let configuration = CommandConfiguration(abstract: "Rename a preset. Forks it first if it's built-in.")
+        static let configuration = CommandConfiguration(abstract: "Rename a preset, built-in or not.")
 
         @Argument(help: "Preset name (case-insensitive) or UUID to rename.")
         var name: String?

--- a/Sources/iqualize-cli/TldrCommand.swift
+++ b/Sources/iqualize-cli/TldrCommand.swift
@@ -94,7 +94,7 @@ struct Tldr: ParsableCommand {
             ("Mute the first band", "iqualize band mute --index 1 on"),
             ("Toggle the band nearest 500 Hz", "iqualize band mute --near 500 toggle"),
         ]),
-        Entry(name: "presets save", description: "Save the active preset, forking it first if it's built-in.", examples: [
+        Entry(name: "presets save", description: "Save the active preset in place, built-in or not.", examples: [
             ("Save the active preset", "iqualize presets save"),
         ]),
         Entry(name: "presets reset", description: "Switch the active preset back to Flat.", examples: [
@@ -108,7 +108,7 @@ struct Tldr: ParsableCommand {
             ("Create a preset with an auto-generated name", "iqualize presets new"),
             ("Create a preset with a specific name", "iqualize presets new \"My EQ\""),
         ]),
-        Entry(name: "presets rename", description: "Rename a preset. Forks it first if it's built-in.", examples: [
+        Entry(name: "presets rename", description: "Rename a preset, built-in or not.", examples: [
             ("Rename a preset", "iqualize presets rename \"Custom EQ 1\" \"Studio Monitors\""),
         ]),
         Entry(name: "presets duplicate", description: "Duplicate a preset under a new name. Doesn't switch the active preset.", examples: [

--- a/Tests/iQualizeTests/PresetStoreTests.swift
+++ b/Tests/iQualizeTests/PresetStoreTests.swift
@@ -42,25 +42,77 @@ final class PresetStoreTests: XCTestCase {
         XCTAssertEqual(store.dedupedName(base: "Flat (Custom)"), "Flat (Custom) 3")
     }
 
-    // MARK: - forkIfBuiltIn
+    // MARK: - built-in overrides
 
-    func testForkIfBuiltInUsesDedupedName() {
+    func testSaveBuiltInOverrideAppliesInPlace() {
         let store = makeStore()
-        let fork1 = store.forkIfBuiltIn(EQPresetData.flat)
-        XCTAssertEqual(fork1.name, "Flat (Custom)")
-        XCTAssertFalse(fork1.isBuiltIn)
-        store.saveCustomPreset(fork1)
-        let fork2 = store.forkIfBuiltIn(EQPresetData.flat)
-        XCTAssertEqual(fork2.name, "Flat (Custom) 2")
-        XCTAssertNotEqual(fork1.id, fork2.id)
+        var edited = EQPresetData.flat
+        edited.name = "Flat (edited)"
+        edited.bands[0].gain = 6
+
+        store.saveBuiltInOverride(edited)
+
+        XCTAssertTrue(store.hasOverride(EQPresetData.flat.id))
+        let resolved = store.preset(for: EQPresetData.flat.id)
+        XCTAssertEqual(resolved?.id, EQPresetData.flat.id)
+        XCTAssertTrue(resolved?.isBuiltIn ?? false)
+        XCTAssertEqual(resolved?.name, "Flat (edited)")
+        XCTAssertEqual(resolved?.bands.first?.gain, 6)
+        // Identity and count in allPresets are unchanged — no fork appended.
+        XCTAssertEqual(store.allPresets.filter { $0.id == EQPresetData.flat.id }.count, 1)
     }
 
-    func testForkIfBuiltInReturnsUnchangedForCustomPreset() {
+    func testSaveBuiltInOverrideNoOpsForCustomPreset() {
         let store = makeStore()
         let custom = makePreset(name: "My Custom")
-        let forked = store.forkIfBuiltIn(custom)
-        XCTAssertEqual(forked.id, custom.id)
-        XCTAssertEqual(forked.name, custom.name)
+        store.saveBuiltInOverride(custom)
+        XCTAssertFalse(store.hasOverride(custom.id))
+    }
+
+    func testResetBuiltInToOriginalRevertsContent() {
+        let store = makeStore()
+        var edited = EQPresetData.bassBoost
+        edited.bands[0].gain = 0
+        store.saveBuiltInOverride(edited)
+        XCTAssertTrue(store.hasOverride(EQPresetData.bassBoost.id))
+
+        store.resetBuiltInToOriginal(id: EQPresetData.bassBoost.id)
+
+        XCTAssertFalse(store.hasOverride(EQPresetData.bassBoost.id))
+        XCTAssertEqual(store.preset(for: EQPresetData.bassBoost.id), EQPresetData.bassBoost)
+    }
+
+    func testOverriddenBuiltInPresetsListsOnlyOverriddenOnes() {
+        let store = makeStore()
+        XCTAssertTrue(store.overriddenBuiltInPresets.isEmpty)
+
+        var edited = EQPresetData.loudness
+        edited.name = "Loudness (edited)"
+        store.saveBuiltInOverride(edited)
+
+        XCTAssertEqual(store.overriddenBuiltInPresets.map(\.id), [EQPresetData.loudness.id])
+        XCTAssertEqual(store.overriddenBuiltInPresets.first?.name, "Loudness (edited)")
+    }
+
+    func testHiddenBuiltInPresetReflectsOverride() {
+        let store = makeStore()
+        var edited = EQPresetData.techno
+        edited.name = "Techno (edited)"
+        store.saveBuiltInOverride(edited)
+        store.hideBuiltInPreset(id: EQPresetData.techno.id)
+
+        XCTAssertEqual(store.hiddenBuiltInPresets.first?.name, "Techno (edited)")
+    }
+
+    func testBuiltInOverridePersistsAcrossReload() {
+        let store = makeStore()
+        var edited = EQPresetData.flat
+        edited.name = "Flat (edited)"
+        store.saveBuiltInOverride(edited)
+
+        let reloaded = makeStore()
+        XCTAssertTrue(reloaded.hasOverride(EQPresetData.flat.id))
+        XCTAssertEqual(reloaded.preset(for: EQPresetData.flat.id)?.name, "Flat (edited)")
     }
 
     // MARK: - saveCustomPreset upsert


### PR DESCRIPTION
## Summary
- Editing a built-in preset no longer forks it into a "(Custom)" copy — `PresetStore` gained a `builtInOverrides` table keyed by the built-in's own id, resolved transparently by `allPresets`/`hiddenBuiltInPresets`, so identity and picker position never change, only content. `forkIfBuiltIn` is gone from every GUI and CLI mutation path.
- Save on a built-in saves in place instead of redirecting to Save As. Reverting is exposed two ways: inline in the EQ window's Save menu ("Reset to Original", shown only when the active preset has a saved override) and in the Preset Browser's iQualize tab, which gained an "Edited" section next to the existing hidden/"Restore" one.
- Also fixes two bugs found while testing this live in the running app:
  - `savePreset()` never refreshed the window title, so the unsaved-changes dot lingered after a successful save (pre-existing for custom presets, only became visible once built-ins started saving through the same path).
  - The Preset Browser's "Reset to Original" called `PresetStore` directly, bypassing the EQ window's view model — resetting the preset currently loaded there left the window showing (and able to re-save) the stale override instead of the reverted original.

Fixes #101. Builds on the unsaved-fork-visibility work from #100 (already on main) — that machinery is identity-agnostic (compares preset content, not id/`isBuiltIn`), so removing the fork didn't require touching it.

## Scope
- No migration of presets already forked under the old model. Existing forks stay as regular custom presets, untouched — a fork can't be reliably distinguished from an independently-created custom preset with a coincidental name, and an automatic merge risked silently discarding state or guessing wrong.
- No new CLI verb for reset-to-original (`PresetStore.resetBuiltInToOriginal` exists regardless — cheap follow-up if wanted, same pattern as #122's CLI parity being tracked separately).
- Version bumped 0.53.0 → 0.54.0, CHANGELOG updated.

## Test plan
- [x] `swift test` — 64/64 pass, including new `PresetStoreTests` coverage for `saveBuiltInOverride`/`resetBuiltInToOriginal`/`hasOverride`/`overriddenBuiltInPresets` (save-in-place, no-op on custom presets, reset reverts content, hidden+overridden compose independently, persistence round-trip across a fresh `PresetStore` load).
- [x] Built, installed, and drove the actual running app end-to-end: edited a built-in ("Flat"), confirmed it stayed labeled "Flat (Built-in)" with no fork, saved in place, killed and relaunched the app from scratch and confirmed the override survived, used "Reset to Original" from both the EQ window's Save menu and the Preset Browser's "Edited" section and confirmed both revert correctly and stay in sync with each other.
- [x] CLI parity — drove the actual `iqualize` binary against the running app: `band set` and `presets rename` on the active built-in (Flat) both mutated/renamed in place (same id, `isBuiltIn: true`, no new picker entry, verified via `presets export`), `presets save` persisted cleanly, and the override survived a full app relaunch.
