### PR TITLE
Clear stale OPRA profile details when the search invalidates the selected product

### DIFF
--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -37,10 +37,29 @@ struct PresetBrowserView: View {
     private enum LoadState { case loading, loaded, failed(String) }
 
     private var filteredProducts: [OPRAProductEntry] {
-        guard !searchText.isEmpty else { return products }
+        Self.filter(products, matching: searchText)
+    }
+
+    /// Products whose "Vendor Product" label contains `query` (case-insensitive). An empty
+    /// query matches everything. Pure so the selection-invalidation rule (#155) is testable
+    /// without a live view.
+    static func filter(_ products: [OPRAProductEntry], matching query: String) -> [OPRAProductEntry] {
+        guard !query.isEmpty else { return products }
         return products.filter {
-            "\($0.vendorName) \($0.productName)".localizedCaseInsensitiveContains(searchText)
+            "\($0.vendorName) \($0.productName)".localizedCaseInsensitiveContains(query)
         }
+    }
+
+    /// The selection to keep after `query` changes: the current `selection` when it still
+    /// appears in the filtered results, otherwise `nil`. Clearing a query that still contains
+    /// the selection preserves it (#155).
+    static func validatedSelection(
+        _ selection: String?,
+        in products: [OPRAProductEntry],
+        matching query: String
+    ) -> String? {
+        guard let selection else { return nil }
+        return filter(products, matching: query).contains { $0.id == selection } ? selection : nil
     }
 
     private var filteredHiddenPresets: [EQPresetData] {
@@ -89,7 +108,20 @@ struct PresetBrowserView: View {
         // Clear the search when switching catalogs — a term left over from OPRA
         // otherwise filters the iQualize tab and hides deleted built-ins that are
         // actually there, ready to restore (#115).
-        .onChange(of: catalog) { searchText = "" }
+        .onChange(of: catalog) {
+            searchText = ""
+            // Drop any OPRA selection so switching away and back doesn't restore a
+            // stale detail pane (#155).
+            selectedProductID = nil
+        }
+        // Editing the search can filter the selected product out of the sidebar. The
+        // detail pane derives from `filteredProducts`, so a dropped selection already
+        // falls back to the placeholder, but clear the id too so the selection doesn't
+        // silently reappear when the query is cleared again (#155).
+        .onChange(of: searchText) {
+            selectedProductID = Self.validatedSelection(
+                selectedProductID, in: products, matching: searchText)
+        }
     }
 
     // MARK: - Search
@@ -229,7 +261,8 @@ struct PresetBrowserView: View {
     private var detail: some View {
         switch catalog {
         case .opra:
-            if let selectedProductID, let product = products.first(where: { $0.id == selectedProductID }) {
+            if let selectedProductID,
+               let product = filteredProducts.first(where: { $0.id == selectedProductID }) {
                 VStack(alignment: .leading, spacing: 0) {
                     Text("\(product.vendorName) \(product.productName)")
                         .font(.headline)

--- a/Tests/iQualizeTests/PresetBrowserSelectionTests.swift
+++ b/Tests/iQualizeTests/PresetBrowserSelectionTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import iQualize
+
+@available(macOS 14.2, *)
+final class PresetBrowserSelectionTests: XCTestCase {
+    private func product(_ id: String, vendor: String, name: String) -> OPRAProductEntry {
+        OPRAProductEntry(
+            id: id, vendorName: vendor, productName: name,
+            subtype: nil, thumbnailURL: nil, curves: [])
+    }
+
+    private lazy var catalog: [OPRAProductEntry] = [
+        product("sony-1000", vendor: "Sony", name: "WH-1000XM5"),
+        product("sennheiser-hd600", vendor: "Sennheiser", name: "HD 600"),
+        product("apple-airpods", vendor: "Apple", name: "AirPods Max"),
+    ]
+
+    // Selecting a product, then querying a different model clears the stale selection.
+    func testSelectionClearedWhenQueryExcludesIt() {
+        let result = PresetBrowserView.validatedSelection(
+            "sony-1000", in: catalog, matching: "Sennheiser")
+        XCTAssertNil(result)
+    }
+
+    // Editing the query while it still matches the selection keeps it intact.
+    func testSelectionRetainedWhenQueryStillMatches() {
+        let result = PresetBrowserView.validatedSelection(
+            "sony-1000", in: catalog, matching: "sony")
+        XCTAssertEqual(result, "sony-1000")
+    }
+
+    // Clearing the query preserves a still-valid selection rather than discarding it.
+    func testSelectionRetainedWhenQueryCleared() {
+        let result = PresetBrowserView.validatedSelection(
+            "sony-1000", in: catalog, matching: "")
+        XCTAssertEqual(result, "sony-1000")
+    }
+
+    // A nil selection stays nil regardless of query.
+    func testNilSelectionStaysNil() {
+        XCTAssertNil(PresetBrowserView.validatedSelection(nil, in: catalog, matching: "sony"))
+        XCTAssertNil(PresetBrowserView.validatedSelection(nil, in: catalog, matching: ""))
+    }
+
+    // A selection no longer present in the catalog is dropped.
+    func testSelectionClearedWhenAbsentFromCatalog() {
+        let result = PresetBrowserView.validatedSelection(
+            "removed-id", in: catalog, matching: "")
+        XCTAssertNil(result)
+    }
+
+    // Matching is case-insensitive and spans the "Vendor Product" label.
+    func testFilterMatchesVendorAndProductCaseInsensitively() {
+        XCTAssertEqual(PresetBrowserView.filter(catalog, matching: "AIRPODS").map(\.id), ["apple-airpods"])
+        XCTAssertEqual(PresetBrowserView.filter(catalog, matching: "hd 600").map(\.id), ["sennheiser-hd600"])
+        XCTAssertEqual(PresetBrowserView.filter(catalog, matching: "").count, 3)
+    }
+}


### PR DESCRIPTION
## Summary

The OPRA preset browser kept showing the previously selected headphone and its EQ profiles in the detail pane after the search changed so the selected product was no longer in the results.

Root cause: the sidebar rendered `filteredProducts` while the detail pane and selection state resolved `selectedProductID` against the full unfiltered `products` collection (`PresetBrowserView.swift:146` vs `:232`). Editing the search filtered the selected product out of the sidebar without clearing the selection, so its profiles stayed visible.

## Scope

- Re-validate the selection against `filteredProducts` on every search change, clearing it only when it no longer matches.
- Clear the OPRA selection when switching catalogs, so switching away and back can't restore a stale detail pane.
- Resolve the detail pane from `filteredProducts` so selection and detail derive from the same result set.
- Extract `filter`/`validatedSelection` as pure static helpers to make the invalidation rule testable without a live view.

Deliberately out of scope: OPRA query matching/ranking, browser layout, and database loading/caching, per #155.

## Test plan

- [x] `swift test` - 70 passing, including 6 new `PresetBrowserSelectionTests`
- [x] Manual, in the running dev build via accessibility inspection:
  - [x] Select "Apple AirPods Max", change query to "Sony WH" -> detail pane reverts to the placeholder
  - [x] Select "Sony WH-1000XM2", narrow query "Sony WH" -> "Sony WH-1000" (still matching) -> selection and profiles persist
- [x] Clearing the query back to empty with a still-valid selection (covered by unit test, not re-verified in the UI)
- [x] Switching OPRA <-> iQualize catalogs in the UI (covered by the `onChange(of: catalog)` clear + unit coverage, not re-verified in the UI)

Fixes #155. Reported in #154.
