### PR TITLE
feat: normalize OPRA headphone search across spacing and punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.57.0] - 2026-08-01
+
+### Changed
+- OPRA headphone search now normalizes spacing, hyphens, underscores, punctuation, case, and diacritics before matching, so equivalent model names return the same result set (#156). `Sennheiser HD800S`, `HD 800 S`, `HD-800-S`, and `hd_800_s` all resolve to the same product — previously a literal `contains` returned 3 vs. 27 profiles for the same headphone depending on spelling. Matching is extracted into a testable `OPRASearch` domain type outside the SwiftUI view, ranked exact-display → exact-normalized → prefix → substring with deterministic tie-breaking on catalog order. Manufacturer-only and partial-model queries still work; OPRA loading, caching, and import are unchanged.
+
 ## [0.56.0] - 2026-07-31
 
 ### Added

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -40,14 +40,13 @@ struct PresetBrowserView: View {
         Self.filter(products, matching: searchText)
     }
 
-    /// Products whose "Vendor Product" label contains `query` (case-insensitive). An empty
-    /// query matches everything. Pure so the selection-invalidation rule (#155) is testable
-    /// without a live view.
+    /// Products matching `query` against their "Vendor Product" label, normalized so that
+    /// spacing, hyphens, underscores, punctuation, case, and diacritics don't change the result
+    /// set (#156) — `HD800S`, `HD 800 S`, and `HD-800-S` all match the same models. Results are
+    /// ranked best-tier-first and deterministically ordered. An empty query matches everything.
+    /// Pure so the selection-invalidation rule (#155) is testable without a live view.
     static func filter(_ products: [OPRAProductEntry], matching query: String) -> [OPRAProductEntry] {
-        guard !query.isEmpty else { return products }
-        return products.filter {
-            "\($0.vendorName) \($0.productName)".localizedCaseInsensitiveContains(query)
-        }
+        OPRASearch.filter(products, matching: query)
     }
 
     /// The selection to keep after `query` changes: the current `selection` when it still

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.56.0</string>
+	<string>0.57.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.56.0</string>
+	<string>0.57</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/OPRASearch.swift
+++ b/Sources/iQualize/OPRASearch.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Normalizing, rankable search over the OPRA product catalog.
+///
+/// The catalog's model names are written inconsistently — `HD800S`, `HD 800 S`, `HD-800-S`,
+/// `hd_800_s` all name the same headphone — so a literal `contains` returns very different
+/// result sets depending on how the user happens to space or punctuate the query (#156). This
+/// type collapses those variants to one canonical form before matching.
+///
+/// Kept out of the SwiftUI view so it is independently testable domain logic.
+enum OPRASearch {
+    /// Canonical form used for both indexed names and user queries: Unicode-normalized,
+    /// diacritics stripped, case-folded, and reduced to alphanumerics only. Every separator
+    /// (space, hyphen, underscore, punctuation) is discarded, so compact, spaced, and
+    /// hyphenated spellings of the same model collapse to the same string.
+    ///
+    /// `HD800S`, `HD 800 S`, `HD-800-S`, `hd_800_s` → `hd800s`.
+    static func normalize(_ text: String) -> String {
+        // Decompose accented characters (é → e + combining accent), then drop the combining
+        // marks, so diacritics don't defeat matching. `folding` also lowercases.
+        let folded = text.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+        var result = String.UnicodeScalarView()
+        result.reserveCapacity(folded.unicodeScalars.count)
+        for scalar in folded.unicodeScalars where CharacterSet.alphanumerics.contains(scalar) {
+            result.append(scalar)
+        }
+        return String(result)
+    }
+
+    /// Match tiers, best first. `filter` sorts by this then by the catalog's existing
+    /// vendor/product order, so equal-ranked results stay deterministic.
+    enum Rank: Int, Comparable {
+        /// The query equals the whole "Vendor Product" display label, case-insensitively.
+        case exactDisplay = 0
+        /// The normalized query equals the normalized label exactly.
+        case exactNormalized = 1
+        /// The normalized label begins with the normalized query (token/model prefix).
+        case normalizedPrefix = 2
+        /// The normalized query appears somewhere inside the normalized label.
+        case normalizedSubstring = 3
+
+        static func < (lhs: Rank, rhs: Rank) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    /// The best tier at which `query` matches `product`, or `nil` when it doesn't match.
+    /// `rawQuery`/`normalizedQuery` are the caller-normalized forms, passed in so a `filter`
+    /// over the whole catalog normalizes the query only once.
+    ///
+    /// Matching considers both the combined "Vendor Product" label and the product name alone,
+    /// so a bare model query (`HD600`) ranks the headphone actually named that above one whose
+    /// label merely contains it (`Sony Custom HD 600 Edition`).
+    static func rank(
+        of product: OPRAProductEntry,
+        rawQuery: String,
+        normalizedQuery: String
+    ) -> Rank? {
+        let display = "\(product.vendorName) \(product.productName)"
+        if display.localizedCaseInsensitiveCompare(rawQuery) == .orderedSame {
+            return .exactDisplay
+        }
+        guard !normalizedQuery.isEmpty else { return nil }
+
+        let normalizedDisplay = normalize(display)
+        let normalizedName = normalize(product.productName)
+        if normalizedDisplay == normalizedQuery || normalizedName == normalizedQuery {
+            return .exactNormalized
+        }
+        if normalizedDisplay.hasPrefix(normalizedQuery) || normalizedName.hasPrefix(normalizedQuery) {
+            return .normalizedPrefix
+        }
+        if normalizedDisplay.contains(normalizedQuery) { return .normalizedSubstring }
+        return nil
+    }
+
+    /// Products matching `query`, best tier first, ties broken by the catalog's existing order
+    /// (a stable sort over an already vendor/product-sorted catalog). An empty or
+    /// whitespace-only query returns the catalog unchanged.
+    static func filter(_ products: [OPRAProductEntry], matching query: String) -> [OPRAProductEntry] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return products }
+        let normalizedQuery = normalize(trimmed)
+
+        let ranked: [(index: Int, product: OPRAProductEntry, rank: Rank)] = products.enumerated().compactMap {
+            guard let rank = rank(of: $0.element, rawQuery: trimmed, normalizedQuery: normalizedQuery) else {
+                return nil
+            }
+            return (index: $0.offset, product: $0.element, rank: rank)
+        }
+
+        return ranked.sorted {
+            $0.rank != $1.rank ? $0.rank < $1.rank : $0.index < $1.index
+        }.map(\.product)
+    }
+}

--- a/Tests/iQualizeTests/OPRASearchTests.swift
+++ b/Tests/iQualizeTests/OPRASearchTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import iQualize
+
+@available(macOS 14.2, *)
+final class OPRASearchTests: XCTestCase {
+    private func product(_ id: String, vendor: String, name: String) -> OPRAProductEntry {
+        OPRAProductEntry(
+            id: id, vendorName: vendor, productName: name,
+            subtype: nil, thumbnailURL: nil, curves: [])
+    }
+
+    // A catalog in the same vendor/product-sorted order OPRACatalog.parse produces.
+    private lazy var catalog: [OPRAProductEntry] = [
+        product("apple-airpods", vendor: "Apple", name: "AirPods Max"),
+        product("focal-utopia", vendor: "Focal", name: "Utopia"),
+        product("sennheiser-hd600", vendor: "Sennheiser", name: "HD 600"),
+        product("sennheiser-hd650", vendor: "Sennheiser", name: "HD 650"),
+        product("sennheiser-hd800s", vendor: "Sennheiser", name: "HD 800 S"),
+        product("sony-1000", vendor: "Sony", name: "WH-1000XM5"),
+        product("beyer-dt770", vendor: "beyerdynamic", name: "DT 770 PRO"),
+    ]
+
+    private func ids(_ query: String) -> [String] {
+        OPRASearch.filter(catalog, matching: query).map(\.id)
+    }
+
+    // MARK: - normalize
+
+    // Compact, spaced, hyphenated, and underscored spellings collapse to one canonical form.
+    func testNormalizeCollapsesSeparators() {
+        let canonical = "hd800s"
+        for variant in ["HD800S", "HD 800 S", "HD-800-S", "hd_800_s", "  HD 800  S  ", "H.D 800/S"] {
+            XCTAssertEqual(OPRASearch.normalize(variant), canonical, "\(variant) should normalize to \(canonical)")
+        }
+    }
+
+    // Diacritics fold to their base letters.
+    func testNormalizeStripsDiacritics() {
+        XCTAssertEqual(OPRASearch.normalize("Sennheiser Ié"), "sennheiserie")
+        XCTAssertEqual(OPRASearch.normalize("Åmp"), "amp")
+    }
+
+    // MARK: - equivalent spellings (the reported bug)
+
+    // The core #156 case: compact vs. spaced model names return the same product.
+    func testCompactAndSpacedModelMatchIdentically() {
+        XCTAssertEqual(ids("Sennheiser HD800S"), ids("Sennheiser HD 800 S"))
+        XCTAssertEqual(ids("Sennheiser HD800S"), ["sennheiser-hd800s"])
+    }
+
+    // Compact, spaced, hyphenated, underscored, and mixed-case model queries all agree.
+    func testAllSeparatorVariantsMatch() {
+        for query in ["HD800S", "HD 800 S", "HD-800-S", "hd_800_s", "hd800s", "Hd 800 s"] {
+            XCTAssertEqual(ids(query), ["sennheiser-hd800s"], "query \(query) should match only HD 800 S")
+        }
+    }
+
+    // MARK: - partial and manufacturer-only queries
+
+    // A manufacturer-only query returns every product for that vendor, vendor/product-ordered.
+    func testManufacturerOnlyQuery() {
+        XCTAssertEqual(ids("Sennheiser"), ["sennheiser-hd600", "sennheiser-hd650", "sennheiser-hd800s"])
+    }
+
+    // Manufacturer matching ignores case and spacing (beyerdynamic is one compact word).
+    func testManufacturerNormalizedMatch() {
+        XCTAssertEqual(ids("beyer dynamic"), ["beyer-dt770"])
+        XCTAssertEqual(ids("BEYERDYNAMIC"), ["beyer-dt770"])
+    }
+
+    // A partial model query still matches.
+    func testPartialModelQuery() {
+        XCTAssertEqual(ids("HD 8"), ["sennheiser-hd800s"])
+        XCTAssertEqual(Set(ids("HD 6")), ["sennheiser-hd600", "sennheiser-hd650"])
+    }
+
+    // Repeated and leading/trailing whitespace doesn't change the result.
+    func testRepeatedWhitespace() {
+        XCTAssertEqual(ids("   Sennheiser    HD   800  S "), ["sennheiser-hd800s"])
+    }
+
+    // MARK: - empty and no-match
+
+    // An empty or whitespace-only query returns the whole catalog unchanged.
+    func testEmptyQueryReturnsAll() {
+        XCTAssertEqual(ids(""), catalog.map(\.id))
+        XCTAssertEqual(ids("   "), catalog.map(\.id))
+    }
+
+    // A query with no plausible match returns nothing — normalization must not over-match.
+    func testUnrelatedQueryReturnsNothing() {
+        XCTAssertEqual(ids("Grado SR80"), [])
+        XCTAssertEqual(ids("zzzz"), [])
+    }
+
+    // MARK: - ranking and determinism
+
+    // Exact display-name and normalized-exact matches outrank substring matches.
+    func testRankingPrefersExactOverSubstring() {
+        let ranked = [
+            product("substring", vendor: "Sony", name: "Custom HD 600 Edition"),
+            product("exact", vendor: "Sennheiser", name: "HD 600"),
+        ]
+        // "HD600" is a normalized-exact match for the Sennheiser and a substring for the Sony;
+        // the exact match must come first regardless of catalog order.
+        XCTAssertEqual(OPRASearch.filter(ranked, matching: "Sennheiser HD600").map(\.id), ["exact"])
+        XCTAssertEqual(OPRASearch.filter(ranked, matching: "HD600").map(\.id), ["exact", "substring"])
+    }
+
+    // Equal-ranked results keep the catalog's incoming order (deterministic, stable).
+    func testEqualRankKeepsCatalogOrder() {
+        XCTAssertEqual(ids("Sennheiser"), ["sennheiser-hd600", "sennheiser-hd650", "sennheiser-hd800s"])
+    }
+}


### PR DESCRIPTION
## Summary

OPRA search matched with one literal `localizedCaseInsensitiveContains` against the `"Vendor Product"` label, so equivalent model names returned wildly different result sets depending on how the user spaced or punctuated the query. `Sennheiser HD800S` returned 3 EQ profiles; `Sennheiser HD 800 S` returned 27 — the same headphone (#156).

Root cause: the comparison was case-insensitive but otherwise literal, with no normalization of alphanumeric boundaries.

## Scope

- New `Sources/iQualize/OPRASearch.swift` — testable domain type, outside the SwiftUI view.
  - `normalize(_:)` case-folds, strips diacritics (Unicode-decompose + drop combining marks), and discards every non-alphanumeric character. `HD800S`, `HD 800 S`, `HD-800-S`, `hd_800_s` all collapse to `hd800s`.
  - `filter(_:matching:)` ranks matches exact-display → exact-normalized → normalized-prefix → normalized-substring, tie-broken on the catalog's existing vendor/product order so results are deterministic. Empty/whitespace queries return the catalog unchanged.
  - Matching considers the product name alone as well as the combined label, so a bare model query (`HD600`) ranks the headphone actually named that above one whose label merely contains it (`Sony Custom HD 600 Edition`).
- `PresetBrowserView.filter` (`Sources/iQualize/DreamUI/PresetBrowserView.swift:43-50`) now delegates to `OPRASearch`, keeping the #155 selection-invalidation logic and its existing tests intact.
- Version 0.56.0 → 0.57.0, CHANGELOG updated.

Deliberately out of scope, per the issue's non-goals: fuzzy edit-distance matching, spelling correction, changing the OPRA source database, and searching author/details fields.

## Test plan

New table-driven `Tests/iQualizeTests/OPRASearchTests.swift`:
- [x] `normalize` collapses compact/spaced/hyphenated/underscored/punctuated variants to one form
- [x] `normalize` strips diacritics
- [x] `Sennheiser HD800S` and `Sennheiser HD 800 S` return the identical product
- [x] all separator variants (`HD800S` / `HD 800 S` / `HD-800-S` / `hd_800_s`) match only HD 800 S
- [x] manufacturer-only query returns every vendor product, in order
- [x] normalized manufacturer match (`beyer dynamic` → `beyerdynamic`)
- [x] partial-model queries still match
- [x] repeated/leading/trailing whitespace is ignored
- [x] empty/whitespace query returns the whole catalog
- [x] unrelated queries return nothing (normalization doesn't over-match)
- [x] exact match outranks substring; equal ranks keep catalog order
- [x] full suite green: 82 tests, 0 failures
- [x] build + install + launch verified

Fixes #156
