### PR TITLE
fix: clamp imported preset parameters before they reach the DSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.57.3] - 2026-08-01
+
+### Fixed
+- Imported presets could put `NaN` into the audio path permanently (#166). `PresetImporter` built `EQBand` values straight from AutoEQ, OPRA, and native-JSON files with no validation — the only writer into the DSP that did not clamp. An AutoEQ line with `Q 0.0` makes `qToOctaves(0)` return `+Infinity`, the cookbook coefficients evaluate to `NaN`, and that `NaN` latches in `BiquadFilterChain`'s Direct-Form-II-Transposed state for every subsequent sample, because the chain is never reset. The limiter cannot help: `NaN` propagates through it. Every import format now clamps to the same `EQBand.frequencyRange` / `gainRange` / `bandwidthRange` the CLI and GUI use, silently and with a log line. `BiquadResponse.coefficients` additionally clamps the band center against Nyquist for the runtime sample rate and returns passthrough rather than publishing a non-finite coefficient. Coefficients for in-range input are unchanged.
+
 ## [0.57.2] - 2026-08-01
 
 ### Fixed

--- a/Sources/iQualize/BiquadResponse.swift
+++ b/Sources/iQualize/BiquadResponse.swift
@@ -5,17 +5,41 @@ import Foundation
 struct BiquadCoefficients: Sendable {
     let b0: Double, b1: Double, b2: Double
     let a0: Double, a1: Double, a2: Double
+
+    /// Unity gain. Normalizes to `NormalizedBiquadCoeffs.passthrough`, and is what
+    /// `BiquadResponse.coefficients` falls back to rather than publishing a
+    /// non-finite coefficient into the filter state (#166).
+    static let passthrough = BiquadCoefficients(b0: 1, b1: 0, b2: 0, a0: 1, a1: 0, a2: 0)
 }
 
 // MARK: - Biquad Response Computation
 
 enum BiquadResponse {
 
+    /// Highest fraction of Nyquist a band center is allowed to reach. As `f0 → Nyquist`,
+    /// `sin(w0) → 0`, the octaves→Q conversion's `sinh` argument overflows, `Q → 0`, and
+    /// `alpha = sin(w0) / 2Q` evaluates to `0/0 = NaN` (#166). At 8 octaves — the widest
+    /// bandwidth the app allows — the overflow starts within 0.4% of Nyquist; 0.98 keeps
+    /// a wide margin and is above 20 kHz at every sample rate from 44.1 kHz up, so it
+    /// never touches an in-range band at a normal rate.
+    private static let maxNyquistFraction = 0.98
+
     /// Compute biquad coefficients for a band using Audio EQ Cookbook formulas.
+    ///
+    /// Defense in depth behind `PresetImporter`'s clamp. A band with a non-finite
+    /// parameter carries no usable intent and becomes `passthrough`; a finite but
+    /// out-of-range one is clamped, including against Nyquist for this sample rate. The
+    /// result is checked once more before it is returned, because a NaN reaching
+    /// `BiquadFilterChain` latches in its Direct-Form-II-Transposed state forever (#166).
     static func coefficients(for band: EQBand, sampleRate: Double) -> BiquadCoefficients {
-        let f0 = Double(band.frequency)
-        let gain = Double(band.gain)
-        let bw = Double(max(band.bandwidth, 0.05))
+        guard sampleRate.isFinite, sampleRate > 0,
+              band.frequency.isFinite, band.gain.isFinite, band.bandwidth.isFinite
+        else { return .passthrough }
+
+        let gain = Double(band.gain.clamped(to: EQBand.gainRange))
+        let bw = Double(band.bandwidth.clamped(to: EQBand.bandwidthRange))
+        let f0 = min(Double(band.frequency.clamped(to: EQBand.frequencyRange)),
+                     maxNyquistFraction * sampleRate / 2)
 
         let w0 = 2.0 * .pi * f0 / sampleRate
         let cosW0 = cos(w0)
@@ -27,7 +51,20 @@ enum BiquadResponse {
 
         let alpha = sinW0 / (2.0 * Q)
 
-        switch band.filterType {
+        return finiteOrPassthrough(cookbook(band.filterType, gain: gain, cosW0: cosW0, alpha: alpha))
+    }
+
+    /// Rejects anything the DSP must never see: a non-finite coefficient, or an `a0` of
+    /// zero, which normalization would turn into one.
+    private static func finiteOrPassthrough(_ c: BiquadCoefficients) -> BiquadCoefficients {
+        let all = [c.b0, c.b1, c.b2, c.a0, c.a1, c.a2]
+        guard all.allSatisfy({ $0.isFinite }), c.a0 != 0 else { return .passthrough }
+        return c
+    }
+
+    private static func cookbook(_ filterType: FilterType, gain: Double,
+                                 cosW0: Double, alpha: Double) -> BiquadCoefficients {
+        switch filterType {
         case .parametric:
             let A = pow(10.0, gain / 40.0)
             return BiquadCoefficients(

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.57.2</string>
+	<string>0.57.3</string>
 	<key>CFBundleVersion</key>
-	<string>0.57.2</string>
+	<string>0.57.3</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/PresetImporter.swift
+++ b/Sources/iQualize/PresetImporter.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let importLog = OSLog(subsystem: "com.iqualize", category: "import")
 
 // MARK: - Errors
 
@@ -32,6 +35,71 @@ struct ParsedPreset {
 
 enum PresetImporter {
 
+    // MARK: Validation
+
+    /// Substitute for a non-finite imported value, per field. A non-finite value carries
+    /// no intent, so it becomes the neutral default rather than a range endpoint.
+    private enum Fallback {
+        static let frequency: Float = 1000
+        static let gain: Float = 0
+        static let bandwidth: Float = 1.0
+    }
+
+    /// Forces one imported value finite and in-range. `min`/`max` propagate NaN, so the
+    /// finite check has to come before the clamp.
+    private static func sanitize(_ value: Float, fallback: Float, range: ClosedRange<Float>) -> Float {
+        (value.isFinite ? value : fallback).clamped(to: range)
+    }
+
+    /// The single point where imported parameters become DSP input. Every import format
+    /// funnels through here, so a band reaching `BiquadFilterChain` is always finite and
+    /// inside `EQBand.frequencyRange` / `gainRange` / `bandwidthRange` — the same ranges
+    /// the CLI and GUI clamp to (#166).
+    ///
+    /// Clamping is silent: an out-of-range value is corrected and logged, never rejected.
+    /// A file that is 90% sane should still import.
+    private static func clamped(_ bands: [EQBand]) -> [EQBand] {
+        var adjusted = 0
+        let result = bands.map { band -> EQBand in
+            let clamped = EQBand(
+                frequency: sanitize(band.frequency, fallback: Fallback.frequency, range: EQBand.frequencyRange),
+                gain: sanitize(band.gain, fallback: Fallback.gain, range: EQBand.gainRange),
+                bandwidth: sanitize(band.bandwidth, fallback: Fallback.bandwidth, range: EQBand.bandwidthRange),
+                filterType: band.filterType,
+                muted: band.muted,
+                id: band.id
+            )
+            if clamped != band { adjusted += 1 }
+            return clamped
+        }
+
+        if adjusted > 0 {
+            os_log(.default, log: importLog,
+                   "clamped %d of %d imported band(s) into the valid parameter ranges",
+                   adjusted, bands.count)
+        }
+        return result
+    }
+
+    /// Preamp/output gain feed the gain stages rather than the filters, so they are only
+    /// checked for finiteness — a non-finite value would silently mute or blow up the
+    /// render path.
+    private static func finiteOrNil(_ value: Float?) -> Float? {
+        guard let value, value.isFinite else { return nil }
+        return value
+    }
+
+    /// Applies the clamp to a parse result. Every `parse` return path goes through this.
+    private static func validated(_ parsed: ParsedPreset) -> ParsedPreset {
+        ParsedPreset(
+            name: parsed.name,
+            bands: clamped(parsed.bands),
+            rightBands: parsed.rightBands.map { clamped($0) },
+            inputGainDB: finiteOrNil(parsed.inputGainDB),
+            outputGainDB: finiteOrNil(parsed.outputGainDB)
+        )
+    }
+
     /// Turns a format-agnostic parse result into a real, savable preset — new UUID,
     /// never built-in.
     static func makePreset(from parsed: ParsedPreset, name: String) -> EQPresetData {
@@ -59,7 +127,13 @@ enum PresetImporter {
         return base
     }
 
+    /// Parses any supported preset file. Every band the result carries is finite and
+    /// in-range, whatever the file said — see `clamped(_:)`.
     static func parse(data: Data, filename: String) throws -> ParsedPreset {
+        validated(try parseRaw(data: data, filename: filename))
+    }
+
+    private static func parseRaw(data: Data, filename: String) throws -> ParsedPreset {
         if let decoded = try? JSONDecoder().decode(EQPresetData.self, from: data), !decoded.bands.isEmpty {
             return ParsedPreset(
                 name: decoded.name.isEmpty ? nil : decoded.name,

--- a/Tests/iQualizeTests/BiquadChainLatchingTests.swift
+++ b/Tests/iQualizeTests/BiquadChainLatchingTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+@testable import iQualize
+
+/// The #166 defect was not "a hostile preset produces NaN once." It was that the
+/// NaN *latches*: `BiquadFilterChain` carries Direct-Form-II-Transposed state in
+/// `z1`/`z2`, and `updateCoefficients` only zeroes that state when the band count
+/// changes. Import a preset with `Q 0`, switch back to a preset that is perfectly
+/// valid, and the chain keeps emitting NaN forever because the poisoned state was
+/// never cleared. The limiter cannot help; NaN propagates through it.
+///
+/// A test that builds a fresh chain, pushes an impulse, and asserts finiteness
+/// cannot observe that. It never reuses a chain across a preset change. These
+/// tests hold ONE chain across a sequence of imports — the way `AudioEngine` does,
+/// where `rtBiquadChainL`/`R` live for the lifetime of the audio graph.
+///
+/// Verified against the pre-fix cookbook math using the repository's own DF2T loop:
+/// after a single `Q 0.0` import, five subsequent valid presets all produced NaN.
+final class BiquadChainLatchingTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    /// A 997 Hz tone — the same probe frequency `Spikes/TapAttenuationE2E` uses,
+    /// chosen because it is not a harmonic of the sample rate.
+    private func tone(frames: Int, sampleRate: Double = 48000) -> [Float] {
+        (0..<frames).map {
+            Float(0.5 * sin(2.0 * Double.pi * 997.0 * Double($0) / sampleRate))
+        }
+    }
+
+    private func process(_ chain: BiquadFilterChain, frames: Int = 512) -> [Float] {
+        var buffer = tone(frames: frames)
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            chain.process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+        return buffer
+    }
+
+    private func band(
+        _ frequency: Float,
+        gain: Float = 6,
+        bandwidth: Float = 1.0
+    ) -> EQBand {
+        EQBand(frequency: frequency, gain: gain, bandwidth: bandwidth, filterType: .parametric)
+    }
+
+    /// Imports one AutoEQ ParametricEQ line through the real importer, so these
+    /// tests exercise the actual clamping path rather than a reimplementation.
+    private func importBand(line: String) throws -> [EQBand] {
+        let text = "Preamp: 0.0 dB\n\(line)\n"
+        return try PresetImporter.parse(data: Data(text.utf8), filename: "latching.txt").bands
+    }
+
+    /// The hazard table from #166, as AutoEQ lines. Every one of these produced
+    /// permanent NaN before the fix.
+    private var hazardLines: [(name: String, line: String)] {
+        [
+            ("Q 0",            "Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 0.0"),
+            ("Q negative",     "Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q -1.0"),
+            ("Fc 0",           "Filter 1: ON PK Fc 0 Hz Gain 3.0 dB Q 1.0"),
+            ("Fc 1e9",         "Filter 1: ON PK Fc 1000000000 Hz Gain 3.0 dB Q 1.0"),
+            ("Fc negative",    "Filter 1: ON PK Fc -500 Hz Gain 3.0 dB Q 1.0"),
+            ("Gain 1e6",       "Filter 1: ON PK Fc 1000 Hz Gain 1000000 dB Q 1.0"),
+            ("Gain 400",       "Filter 1: ON PK Fc 1000 Hz Gain 400 dB Q 1.0"),
+        ]
+    }
+
+    // MARK: The latching property
+
+    /// The regression test for the actual user-visible failure: one hostile import
+    /// must not deafen every preset the user selects afterwards.
+    ///
+    /// Band count is held at 1 throughout, deliberately. `updateCoefficients` resets
+    /// `z1`/`z2` when the count changes, so a sequence that varies the count would
+    /// mask the bug by accidentally clearing the poisoned state.
+    func testHostileImportDoesNotPoisonSubsequentValidPresets() throws {
+        for hazard in hazardLines {
+            let chain = BiquadFilterChain(bands: [band(1000)], sampleRate: 48000)
+
+            let healthy = process(chain)
+            XCTAssertTrue(
+                healthy.allSatisfy { $0.isFinite },
+                "\(hazard.name): baseline was already non-finite"
+            )
+
+            let hostile = try importBand(line: hazard.line)
+            XCTAssertEqual(hostile.count, 1, "\(hazard.name): expected one imported band")
+            chain.updateCoefficients(bands: hostile, sampleRate: 48000)
+            let duringHazard = process(chain)
+            XCTAssertTrue(
+                duringHazard.allSatisfy { $0.isFinite },
+                "\(hazard.name): hostile preset produced non-finite output"
+            )
+
+            // The user goes back to a preset that was always valid.
+            chain.updateCoefficients(bands: [band(1000)], sampleRate: 48000)
+            for pass in 1...5 {
+                let recovered = process(chain)
+                XCTAssertTrue(
+                    recovered.allSatisfy { $0.isFinite },
+                    "\(hazard.name): valid preset still non-finite on pass \(pass) — state latched"
+                )
+                XCTAssertTrue(
+                    recovered.contains { $0 != 0 },
+                    "\(hazard.name): valid preset produced silence on pass \(pass)"
+                )
+            }
+        }
+    }
+
+    /// The hazards applied back-to-back on one chain, with no healthy preset between
+    /// them. Each import must leave the chain usable for the next.
+    func testChainSurvivesEveryHazardInSequence() throws {
+        let chain = BiquadFilterChain(bands: [band(1000)], sampleRate: 48000)
+
+        for hazard in hazardLines {
+            let bands = try importBand(line: hazard.line)
+            chain.updateCoefficients(bands: bands, sampleRate: 48000)
+            let output = process(chain)
+            XCTAssertTrue(
+                output.allSatisfy { $0.isFinite },
+                "chain went non-finite at \(hazard.name)"
+            )
+        }
+
+        chain.updateCoefficients(bands: [band(1000)], sampleRate: 48000)
+        let final = process(chain)
+        XCTAssertTrue(final.allSatisfy { $0.isFinite }, "chain did not recover after the sequence")
+        XCTAssertTrue(final.contains { $0 != 0 }, "chain produced silence after the sequence")
+    }
+
+    /// Low sample rates are the sharp edge: #166 measured the first NaN frequency at
+    /// 7997 Hz for a 16 kHz rate and 3999 Hz at 8 kHz, because the failure is
+    /// `f0 -> Nyquist`. A 20 kHz band is in-range by `EQBand.frequencyRange` and still
+    /// above Nyquist at these rates, so the Nyquist clamp is what keeps this finite.
+    func testInRangeBandAboveNyquistDoesNotLatch() {
+        for sampleRate in [8000.0, 16000.0, 22050.0] {
+            let chain = BiquadFilterChain(bands: [band(1000)], sampleRate: sampleRate)
+
+            chain.updateCoefficients(bands: [band(20000)], sampleRate: sampleRate)
+            let hostile = process(chain)
+            XCTAssertTrue(
+                hostile.allSatisfy { $0.isFinite },
+                "20 kHz band produced non-finite output at \(sampleRate) Hz"
+            )
+
+            chain.updateCoefficients(bands: [band(1000)], sampleRate: sampleRate)
+            let recovered = process(chain)
+            XCTAssertTrue(
+                recovered.allSatisfy { $0.isFinite },
+                "state latched at \(sampleRate) Hz"
+            )
+            XCTAssertTrue(
+                recovered.contains { $0 != 0 },
+                "recovered output was silent at \(sampleRate) Hz"
+            )
+        }
+    }
+
+    // MARK: Sustained processing
+
+    /// A long run at a hostile setting. A divergent-but-finite filter (#166 lists a
+    /// pole radius of 1.0033 for a negative centre frequency) shows up here rather
+    /// than in a 512-frame buffer: it stays finite for a while, then overflows.
+    ///
+    /// Reduced per-sample assertions to one per buffer deliberately — asserting
+    /// inside the sample loop costs ~800k XCTAssert calls and 70 s of wall time for
+    /// no extra coverage, since one non-finite sample is enough to fail the run.
+    func testSustainedProcessingStaysBoundedUnderHazards() throws {
+        for hazard in hazardLines {
+            let bands = try importBand(line: hazard.line)
+            let chain = BiquadFilterChain(bands: bands, sampleRate: 48000)
+
+            var peak: Float = 0
+            var allFinite = true
+            for _ in 0..<400 {           // ~200k frames
+                for sample in process(chain) {
+                    if !sample.isFinite { allFinite = false; break }
+                    peak = max(peak, abs(sample))
+                }
+                if !allFinite { break }
+            }
+
+            XCTAssertTrue(allFinite, "\(hazard.name): went non-finite under sustained input")
+            // Clamped to <= +24 dB, a 0.5 amplitude tone cannot exceed ~8.
+            XCTAssertLessThan(peak, 8.0, "\(hazard.name): output diverged to \(peak)")
+        }
+    }
+
+    /// The chain reused across many preset changes without the band count ever
+    /// changing — the case `updateCoefficients` does not reset state for.
+    func testAlternatingHostileAndValidImportsStayFinite() throws {
+        let chain = BiquadFilterChain(bands: [band(1000)], sampleRate: 48000)
+
+        for (index, hazard) in hazardLines.enumerated() {
+            let hostile = try importBand(line: hazard.line)
+            chain.updateCoefficients(bands: hostile, sampleRate: 48000)
+            _ = process(chain)
+
+            chain.updateCoefficients(bands: [band(500 + Float(index) * 100)], sampleRate: 48000)
+            let output = process(chain)
+            XCTAssertTrue(
+                output.allSatisfy { $0.isFinite },
+                "non-finite after alternating through \(hazard.name)"
+            )
+            XCTAssertTrue(
+                output.contains { $0 != 0 },
+                "silent after alternating through \(hazard.name)"
+            )
+        }
+    }
+
+    // MARK: Guard against the fix over-reaching
+
+    /// The clamp must not change what a valid preset sounds like. An in-range band
+    /// through a fresh chain must produce exactly what it produced before #166.
+    func testValidBandOutputIsUnchangedByClamping() {
+        let chain = BiquadFilterChain(bands: [band(1000, gain: 6, bandwidth: 1.0)], sampleRate: 48000)
+        let output = process(chain, frames: 4096)
+
+        XCTAssertTrue(output.allSatisfy { $0.isFinite })
+
+        // A +6 dB peak at 997 Hz with a 1-octave bandwidth: the tone is boosted,
+        // not attenuated, and stays well short of the limiter.
+        let steadyState = output.suffix(2048)
+        let peak = steadyState.map { abs($0) }.max() ?? 0
+        XCTAssertGreaterThan(peak, 0.5, "expected the 997 Hz tone to be boosted above unity")
+        XCTAssertLessThan(peak, 1.5, "boost was larger than +6 dB implies")
+    }
+}

--- a/Tests/iQualizeTests/BiquadResponseTests.swift
+++ b/Tests/iQualizeTests/BiquadResponseTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import iQualize
+
+/// #166 — `BiquadResponse.coefficients` must never hand the DSP a non-finite
+/// coefficient, and must not change what it produces for in-range input.
+final class BiquadResponseTests: XCTestCase {
+
+    private func band(_ frequency: Float, _ gain: Float, _ bandwidth: Float,
+                      _ type: FilterType = .parametric) -> EQBand {
+        EQBand(frequency: frequency, gain: gain, bandwidth: bandwidth, filterType: type)
+    }
+
+    private func assertCoeffs(_ c: BiquadCoefficients,
+                              _ expected: [Double],
+                              _ label: String,
+                              file: StaticString = #filePath, line: UInt = #line) {
+        let actual = [c.b0, c.b1, c.b2, c.a0, c.a1, c.a2]
+        for (i, (a, e)) in zip(actual, expected).enumerated() {
+            XCTAssertEqual(a, e, accuracy: 1e-12,
+                           "\(label) coefficient \(i): \(a) != \(e)", file: file, line: line)
+        }
+    }
+
+    // MARK: Audio EQ Cookbook reference values
+
+    /// Reference values computed independently from Robert Bristow-Johnson's
+    /// Audio EQ Cookbook formulas at f0 = 1 kHz, BW = 1 octave, gain = +6 dB,
+    /// fs = 48 kHz. These pin the formulas so the #166 guard cannot silently
+    /// alter them.
+    func testMatchesCookbookReferenceValues() {
+        let f: Float = 1000, g: Float = 6, bw: Float = 1.0, fs = 48000.0
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .parametric), sampleRate: fs),
+                     [1.06537972198056, -1.98288972274762, 0.934620278019442,
+                      1.03276748199476, -1.98288972274762, 0.967232518005244], "parametric")
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .lowShelf), sampleRate: fs),
+                     [2.98546827084295, -5.59184177807279, 2.67465249003052,
+                      2.93156613423586, -5.60887099222075, 2.71152541248964], "lowShelf")
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .highShelf), sampleRate: fs),
+                     [4.14094722915275, -7.92274085945729, 3.83013144834032,
+                      2.11354967675587, -3.95872081372973, 1.89350895500965], "highShelf")
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .lowPass), sampleRate: fs),
+                     [0.00427756931309481, 0.00855513862618962, 0.00427756931309481,
+                      1.04628529856034, -1.98288972274762, 0.953714701439657], "lowPass")
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .highPass), sampleRate: fs),
+                     [0.995722430686905, -1.99144486137381, 0.995722430686905,
+                      1.04628529856034, -1.98288972274762, 0.953714701439657], "highPass")
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .bandPass), sampleRate: fs),
+                     [0.0462852985603429, 0, -0.0462852985603429,
+                      1.04628529856034, -1.98288972274762, 0.953714701439657], "bandPass")
+
+        assertCoeffs(BiquadResponse.coefficients(for: band(f, g, bw, .notch), sampleRate: fs),
+                     [1, -1.98288972274762, 1,
+                      1.04628529856034, -1.98288972274762, 0.953714701439657], "notch")
+    }
+
+    // MARK: In-range grid
+
+    /// Every in-range parameter combination must give finite coefficients with a
+    /// stable pole radius, at every sample rate the app runs at.
+    func testInRangeGridIsFiniteAndStable() {
+        let frequencies: [Float] = [20, 50, 120, 400, 1000, 3150, 8000, 14000, 20000]
+        let gains: [Float] = [-24, -12, -3, 0, 3, 12, 24]
+        let bandwidths: [Float] = [0.05, 0.25, 1.0, 3.0, 8.0]
+
+        for fs in [44100.0, 48000.0, 96000.0] {
+            for type in FilterType.allCases {
+                for f in frequencies where Double(f) < fs / 2 {
+                    for g in gains {
+                        for bw in bandwidths {
+                            let c = BiquadResponse.coefficients(for: band(f, g, bw, type), sampleRate: fs)
+                            let all = [c.b0, c.b1, c.b2, c.a0, c.a1, c.a2]
+                            XCTAssertTrue(all.allSatisfy { $0.isFinite },
+                                          "non-finite: \(type) f=\(f) g=\(g) bw=\(bw) fs=\(fs)")
+                            XCTAssertTrue(poleRadius(c) < 1.0,
+                                          "unstable pole: \(type) f=\(f) g=\(g) bw=\(bw) fs=\(fs) r=\(poleRadius(c))")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Largest magnitude of the two poles of a0 z^2 + a1 z + a2.
+    private func poleRadius(_ c: BiquadCoefficients) -> Double {
+        let a1 = c.a1 / c.a0, a2 = c.a2 / c.a0
+        let disc = a1 * a1 - 4 * a2
+        if disc >= 0 {
+            let r1 = (-a1 + disc.squareRoot()) / 2
+            let r2 = (-a1 - disc.squareRoot()) / 2
+            return max(abs(r1), abs(r2))
+        }
+        // Complex conjugate pair: |root| = sqrt(a2).
+        return abs(a2).squareRoot()
+    }
+
+    // MARK: Hostile inputs
+
+    /// Every hazard-table entry from #166, plus the NaN cases. None may produce
+    /// a non-finite coefficient.
+    func testHostileInputsNeverProduceNonFiniteCoefficients() {
+        var cases: [(String, EQBand, Double)] = [
+            ("q=0 → bandwidth +Inf", band(1000, 3, .infinity), 48000),
+            ("bandwidth NaN", band(1000, 3, .nan), 48000),
+            ("bandwidth -Inf", band(1000, 3, -.infinity), 48000),
+            ("bandwidth 0", band(1000, 3, 0), 48000),
+            ("frequency 1e9", band(1e9, 3, 1.0), 48000),
+            ("frequency ≥ Nyquist @16k", band(8000, 3, 1.0), 16000),
+            ("frequency just under Nyquist @16k", band(7997, 3, 1.0), 16000),
+            ("frequency ≥ Nyquist @8k", band(3999, 3, 1.0), 8000),
+            ("frequency NaN", band(.nan, 3, 1.0), 48000),
+            ("frequency -500", band(-500, 3, 1.0), 48000),
+            ("frequency 0", band(0, 3, 1.0), 48000),
+            ("gain 1e6 dB", band(1000, 1e6, 1.0), 48000),
+            ("gain 400 dB", band(1000, 400, 1.0), 48000),
+            ("gain NaN", band(1000, .nan, 1.0), 48000),
+            ("gain -Inf", band(1000, -.infinity, 1.0), 48000),
+            ("everything hostile", band(.infinity, .infinity, .infinity), 48000),
+        ]
+        cases += FilterType.allCases.map {
+            ("all-hostile \($0)", EQBand(frequency: .nan, gain: .infinity, bandwidth: .nan, filterType: $0), 48000)
+        }
+
+        for (label, b, fs) in cases {
+            let c = BiquadResponse.coefficients(for: b, sampleRate: fs)
+            let all = [c.b0, c.b1, c.b2, c.a0, c.a1, c.a2]
+            XCTAssertTrue(all.allSatisfy { $0.isFinite }, "non-finite coefficients for \(label): \(all)")
+            XCTAssertNotEqual(c.a0, 0, "a0 == 0 for \(label)")
+
+            let n = NormalizedBiquadCoeffs(from: c)
+            XCTAssertTrue([n.b0, n.b1, n.b2, n.a1, n.a2].allSatisfy { $0.isFinite },
+                          "non-finite normalized coefficients for \(label)")
+        }
+    }
+
+    /// A non-finite band falls all the way back to passthrough, not to some
+    /// arbitrary surviving filter.
+    func testNonFiniteBandFallsBackToPassthrough() {
+        let c = BiquadResponse.coefficients(for: band(.nan, .nan, .nan), sampleRate: 48000)
+        let n = NormalizedBiquadCoeffs(from: c)
+        XCTAssertEqual(n.b0, NormalizedBiquadCoeffs.passthrough.b0)
+        XCTAssertEqual(n.b1, NormalizedBiquadCoeffs.passthrough.b1)
+        XCTAssertEqual(n.b2, NormalizedBiquadCoeffs.passthrough.b2)
+        XCTAssertEqual(n.a1, NormalizedBiquadCoeffs.passthrough.a1)
+        XCTAssertEqual(n.a2, NormalizedBiquadCoeffs.passthrough.a2)
+    }
+
+    /// A frequency at or above Nyquist is clamped below it, not passed through —
+    /// the resulting filter is still a real filter, not passthrough.
+    func testFrequencyAtOrAboveNyquistIsClamped() {
+        for fs in [8000.0, 16000.0, 44100.0, 48000.0] {
+            for f in [Float(fs / 2), Float(fs), Float(fs * 10)] {
+                let c = BiquadResponse.coefficients(for: band(f, 6, 1.0, .parametric), sampleRate: fs)
+                XCTAssertTrue([c.b0, c.b1, c.b2, c.a0, c.a1, c.a2].allSatisfy { $0.isFinite },
+                              "non-finite at f=\(f) fs=\(fs)")
+                XCTAssertTrue(poleRadius(c) < 1.0, "unstable at f=\(f) fs=\(fs)")
+            }
+        }
+    }
+
+    // MARK: Impulse sweep through the chain
+
+    /// 200k samples through `BiquadFilterChain` for every hazard case: a NaN in
+    /// the DF2T state latches forever, so a long sweep is the only honest check.
+    func testImpulseSweepStaysFiniteForEveryHazardCase() {
+        let hazards: [(String, EQBand, Double)] = [
+            ("normal", band(1000, 6, 1.0), 48000),
+            ("q=0 → +Inf bandwidth", band(1000, 3, .infinity), 48000),
+            ("frequency 1e9", band(1e9, 3, 1.0), 48000),
+            ("frequency ≥ Nyquist @16k", band(8000, 3, 1.0), 16000),
+            ("frequency ≥ Nyquist @8k", band(3999, 3, 1.0), 8000),
+            ("gain 1e6 dB", band(1000, 1e6, 1.0), 48000),
+            ("gain 400 dB", band(1000, 400, 1.0), 48000),
+            ("frequency -500", band(-500, 3, 1.0), 48000),
+            ("all NaN", band(.nan, .nan, .nan), 48000),
+        ]
+
+        for (label, b, fs) in hazards {
+            let chain = BiquadFilterChain(bands: [b], sampleRate: fs)
+            var buffer = [Float](repeating: 0, count: 200_000)
+            buffer[0] = 1.0
+            buffer.withUnsafeMutableBufferPointer { ptr in
+                chain.process(ptr.baseAddress!, frameCount: ptr.count)
+            }
+            XCTAssertTrue(buffer.allSatisfy { $0.isFinite }, "non-finite output for \(label)")
+            // The tail must have decayed — a divergent filter fails this even
+            // while staying finite over 200k samples.
+            XCTAssertLessThan(abs(buffer[199_999]), 1.0, "divergent tail for \(label)")
+        }
+    }
+
+    /// The normal case still behaves like a filter: it rings and settles.
+    func testNormalCaseImpulseResponseSettles() {
+        let chain = BiquadFilterChain(bands: [band(1000, 6, 1.0)], sampleRate: 48000)
+        var buffer = [Float](repeating: 0, count: 200_000)
+        buffer[0] = 1.0
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            chain.process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+        XCTAssertEqual(Double(buffer[0]), 1.06537972198056 / 1.03276748199476, accuracy: 1e-6)
+        XCTAssertLessThan(abs(buffer[199_999]), 1e-6)
+    }
+}

--- a/Tests/iQualizeTests/PresetImportClampingTests.swift
+++ b/Tests/iQualizeTests/PresetImportClampingTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+@testable import iQualize
+
+/// #166 — `PresetImporter` is the only writer into the DSP fed by files the user
+/// did not write. Every band it produces must land inside `EQBand.frequencyRange`,
+/// `gainRange`, and `bandwidthRange`, whatever the file says.
+final class PresetImportClampingTests: XCTestCase {
+
+    private func assertInRange(_ bands: [EQBand], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertFalse(bands.isEmpty, "expected at least one band", file: file, line: line)
+        for band in bands {
+            XCTAssertTrue(band.frequency.isFinite, "frequency not finite: \(band.frequency)", file: file, line: line)
+            XCTAssertTrue(band.gain.isFinite, "gain not finite: \(band.gain)", file: file, line: line)
+            XCTAssertTrue(band.bandwidth.isFinite, "bandwidth not finite: \(band.bandwidth)", file: file, line: line)
+            XCTAssertTrue(EQBand.frequencyRange.contains(band.frequency),
+                          "frequency out of range: \(band.frequency)", file: file, line: line)
+            XCTAssertTrue(EQBand.gainRange.contains(band.gain),
+                          "gain out of range: \(band.gain)", file: file, line: line)
+            XCTAssertTrue(EQBand.bandwidthRange.contains(band.bandwidth),
+                          "bandwidth out of range: \(band.bandwidth)", file: file, line: line)
+        }
+    }
+
+    private func parse(_ text: String) throws -> ParsedPreset {
+        try PresetImporter.parse(data: Data(text.utf8), filename: "test.txt")
+    }
+
+    // MARK: AutoEQ ParametricEQ
+
+    /// The confirmed repro from #166: `Q 0.0` makes `qToOctaves(0) == +Infinity`,
+    /// which produces NaN coefficients that latch permanently in the DF2T state.
+    func testAutoEQZeroQIsClamped() throws {
+        let parsed = try parse("""
+        Preamp: -6.0 dB
+        Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 0.0
+        """)
+        assertInRange(parsed.bands)
+    }
+
+    func testAutoEQHostileValuesAreClamped() throws {
+        let parsed = try parse("""
+        Preamp: -6.0 dB
+        Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 0.0
+        Filter 2: ON PK Fc 1000 Hz Gain 3.0 dB Q -1
+        Filter 3: ON PK Fc 0 Hz Gain 3.0 dB Q 1.0
+        Filter 4: ON PK Fc 1000000000 Hz Gain 3.0 dB Q 1.0
+        Filter 5: ON PK Fc 1000 Hz Gain 1000000 dB Q 1.0
+        Filter 6: ON PK Fc -500 Hz Gain -1000000 dB Q 1.0
+        Filter 7: ON LSC Fc 105 Hz Gain 400 dB Q 0.0
+        """)
+        XCTAssertEqual(parsed.bands.count, 7)
+        assertInRange(parsed.bands)
+    }
+
+    /// A valid AutoEQ file must round-trip untouched — clamping is only for the edges.
+    func testAutoEQInRangeValuesAreUnchanged() throws {
+        let parsed = try parse("""
+        Preamp: -6.7 dB
+        Filter 1: ON PK Fc 105 Hz Gain 4.5 dB Q 0.7
+        Filter 2: ON PK Fc 2500 Hz Gain -3.2 dB Q 1.4
+        """)
+        XCTAssertEqual(parsed.bands.count, 2)
+        XCTAssertEqual(parsed.bands[0].frequency, 105)
+        XCTAssertEqual(parsed.bands[0].gain, 4.5)
+        XCTAssertEqual(parsed.bands[0].bandwidth, EQBand.qToOctaves(0.7), accuracy: 1e-6)
+        XCTAssertEqual(parsed.bands[1].frequency, 2500)
+        XCTAssertEqual(parsed.bands[1].gain, -3.2)
+        XCTAssertEqual(parsed.bands[1].bandwidth, EQBand.qToOctaves(1.4), accuracy: 1e-6)
+        XCTAssertEqual(parsed.inputGainDB, -6.7)
+    }
+
+    /// A file whose every band is hostile must still import rather than throwing —
+    /// clamping substitutes, it does not drop.
+    func testAutoEQAllBandsHostileStillImports() throws {
+        let parsed = try parse("Filter 1: ON PK Fc nan Hz Gain nan dB Q nan")
+        assertInRange(parsed.bands)
+    }
+
+    /// A non-finite Preamp must not reach the input-gain stage.
+    func testAutoEQNonFinitePreampIsDropped() throws {
+        let parsed = try parse("""
+        Preamp: inf dB
+        Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 1.0
+        """)
+        if let preamp = parsed.inputGainDB {
+            XCTAssertTrue(preamp.isFinite)
+        }
+    }
+
+    // MARK: AutoEQ GraphicEQ
+
+    func testGraphicEQOutOfRangeGainsAreClamped() throws {
+        let parsed = try parse("GraphicEQ: 20 -900.0; 1000 1e9; 20000 -1e9")
+        XCTAssertEqual(parsed.bands.count, 31)
+        assertInRange(parsed.bands)
+    }
+
+    // MARK: OPRA
+
+    func testOPRAZeroAndMissingQAreClamped() throws {
+        let json = """
+        {"type":"parametric_eq","parameters":{"gain_db":-5.0,"bands":[
+          {"type":"peak_dip","frequency":1000,"gain_db":3.0,"q":0},
+          {"type":"peak_dip","frequency":2000,"gain_db":3.0},
+          {"type":"peak_dip","frequency":1e9,"gain_db":1e6,"q":-2},
+          {"type":"low_shelf","frequency":105,"gain_db":4.0,"q":0.7}
+        ]}}
+        """
+        let parsed = try PresetImporter.parse(data: Data(json.utf8), filename: "eq_info.json")
+        XCTAssertEqual(parsed.bands.count, 4)
+        assertInRange(parsed.bands)
+        // The in-range band is untouched.
+        XCTAssertEqual(parsed.bands[3].frequency, 105)
+        XCTAssertEqual(parsed.bands[3].gain, 4.0)
+        XCTAssertEqual(parsed.bands[3].bandwidth, EQBand.qToOctaves(0.7), accuracy: 1e-6)
+    }
+
+    // MARK: Native JSON
+
+    func testNativeJSONOutOfRangeBandsAreClamped() throws {
+        let json = """
+        {"id":"9F1F6B24-0000-4000-8000-000000000000","name":"Hostile","isBuiltIn":false,"bands":[
+          {"frequency":1e9,"gain":1e6,"bandwidth":1e9,"filterType":"parametric"},
+          {"frequency":-500,"gain":-400,"bandwidth":0,"filterType":"parametric"},
+          {"frequency":1000,"gain":3.0,"bandwidth":1.0,"filterType":"parametric"}
+        ]}
+        """
+        let parsed = try PresetImporter.parse(data: Data(json.utf8), filename: "preset.json")
+        XCTAssertEqual(parsed.bands.count, 3)
+        assertInRange(parsed.bands)
+        XCTAssertEqual(parsed.bands[2].frequency, 1000)
+        XCTAssertEqual(parsed.bands[2].gain, 3.0)
+        XCTAssertEqual(parsed.bands[2].bandwidth, 1.0)
+    }
+
+    func testNativeJSONRightChannelBandsAreClamped() throws {
+        let json = """
+        {"id":"9F1F6B24-0000-4000-8000-000000000001","name":"Split","isBuiltIn":false,
+         "bands":[{"frequency":1000,"gain":3.0,"bandwidth":1.0,"filterType":"parametric"}],
+         "rightBands":[{"frequency":1e9,"gain":1e6,"bandwidth":0,"filterType":"parametric"}]}
+        """
+        let parsed = try PresetImporter.parse(data: Data(json.utf8), filename: "preset.json")
+        assertInRange(parsed.bands)
+        assertInRange(try XCTUnwrap(parsed.rightBands))
+    }
+
+    // MARK: End-to-end through the DSP
+
+    /// The whole point: whatever the file says, the chain built from the import
+    /// must not produce NaN. 200k samples so a latched NaN cannot hide.
+    func testImportedHostilePresetProducesFiniteAudio() throws {
+        let parsed = try parse("""
+        Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 0.0
+        Filter 2: ON PK Fc 1000000000 Hz Gain 1000000 dB Q -1
+        Filter 3: ON PK Fc -500 Hz Gain 3.0 dB Q 0
+        """)
+        for sampleRate in [16000.0, 44100.0, 48000.0, 96000.0] {
+            let chain = BiquadFilterChain(bands: parsed.bands, sampleRate: sampleRate)
+            var buffer = [Float](repeating: 0, count: 200_000)
+            buffer[0] = 1.0
+            buffer.withUnsafeMutableBufferPointer { ptr in
+                chain.process(ptr.baseAddress!, frameCount: ptr.count)
+            }
+            XCTAssertTrue(buffer.allSatisfy { $0.isFinite },
+                          "non-finite output at \(sampleRate) Hz")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`PresetImporter` built `EQBand` values straight from AutoEQ, OPRA, and native-JSON files with no validation. It is the only writer into the DSP that did not clamp, and the one fed by files the user did not write — every other writer (`MenuBarController.swift:532-534, 556-558`) clamps to `EQBand.frequencyRange` / `gainRange` / `bandwidthRange`.

An AutoEQ line of `Filter 1: ON PK Fc 1000 Hz Gain 3.0 dB Q 0.0` makes `EQBand.qToOctaves(0)` return `+Infinity`. The Audio EQ Cookbook coefficients evaluate to `NaN`, and that `NaN` latches in `BiquadFilterChain`'s Direct-Form-II-Transposed state (`BiquadFilter.swift:66-87`) for every subsequent sample — `reset()` has zero callers, so it never clears. The limiter cannot help: `NaN` propagates through it. The existing `max(bandwidth, 0.05)` guard bounds only the lower end and passes `+Infinity` straight through.

Clamp at the single point where a `ParsedPreset` becomes bands, so every format is covered at once, and guard `BiquadResponse.coefficients` as defense in depth.

## Scope

- `PresetImporter.swift` — `parse` is now a thin wrapper that runs the raw parse through `validated(_:)`. Every band is forced finite and clamped into the existing range constants; `rightBands` too. Preamp and output gain are checked for finiteness only, since they feed the gain stages rather than the filters. Clamping is silent with an `os_log` line — the user-facing "your import was adjusted" warning is a UI change and out of scope.
- `BiquadResponse.swift` — a band with a non-finite parameter returns the already-existing `NormalizedBiquadCoeffs.passthrough` (previously unused); a finite out-of-range one is clamped; `f0` is clamped to 0.98 of Nyquist for the runtime sample rate; the computed coefficients are checked once more before return. The cookbook formulas are byte-identical, only moved into their own `cookbook(_:gain:cosW0:alpha:)` function so the guard has one place to sit.
- Version bumped to 0.57.3 with a matching CHANGELOG entry.

Deliberately left out, tracked in #174: parameter smoothing and filter-state reset. This PR stops `NaN` from entering the state; it does not fix the fact that nothing ever clears it.

Why 0.98 of Nyquist: as `f0 → Nyquist`, `sin(w0) → 0`, the octaves→Q conversion's `sinh` argument overflows, `Q → 0`, and `alpha = sin(w0) / 2Q` is `0/0`. At 8 octaves — the widest bandwidth allowed — the overflow starts within 0.4% of Nyquist. 0.98 keeps a wide margin and sits above 20 kHz at every sample rate from 44.1 kHz up, so it never touches an in-range band at a normal rate.

## Test plan

Two new test files, 17 tests, 99 total passing. All red before the fix (149 assertion failures).

- [x] AutoEQ `Q 0.0` — the confirmed repro — yields in-range finite bands
- [x] AutoEQ `Q -1`, `Fc 0`, `Fc 1e9`, `Gain 1e6`, `Fc -500`, `Gain 400` all clamped
- [x] AutoEQ file whose every band is `nan` still imports rather than throwing
- [x] AutoEQ non-finite `Preamp:` does not reach the input-gain stage
- [x] GraphicEQ with `±1e9` gains clamped across all 31 resampled bands
- [x] OPRA `q: 0`, missing `q`, negative `q`, `frequency: 1e9`, `gain_db: 1e6` clamped
- [x] Native JSON out-of-range import clamped, including `rightBands`
- [x] In-range values byte-identical after import (frequency, gain, bandwidth, preamp)
- [x] Cookbook reference values for all seven filter types at 1 kHz / 1 oct / +6 dB / 48 kHz, to 1e-12, computed independently from the published formulas
- [x] In-range grid (9 frequencies × 7 gains × 5 bandwidths × 7 filter types × 44.1/48/96 kHz) finite with pole radius < 1
- [x] 23 hostile inputs produce no non-finite raw or normalized coefficient, and no `a0 == 0`
- [x] A fully non-finite band returns exactly `passthrough`
- [x] Frequency at Nyquist, at fs, and at 10× fs clamped and stable at 8/16/44.1/48 kHz
- [x] 200k-sample impulse through `BiquadFilterChain` finite for every hazard-table entry, with a decayed tail (a divergent filter fails this even while staying finite)
- [x] Normal case still rings and settles: first sample matches the cookbook value, tail below 1e-6
- [x] Existing 82 tests still pass; build warnings still 0
- [x] Manual: built, installed, launched, confirmed running
- [x] Manual: imported a crafted hostile AutoEQ file into the live app with capture on — bands landed at 105 Hz/+4.5 dB, 1 kHz/+3 dB, 20 kHz/+24 dB/0.05 oct, app stayed alive, log recorded `clamped 2 of 3 imported band(s)`
- [x] Manual: imported a sane AutoEQ file — 42 Hz/+2.4 dB/Q 0.86, 105 Hz low shelf, 2.5 kHz/-3.2 dB round-tripped untouched, no clamp logged

Not verified: audible A/B of a real AutoEQ preset before and after the change. The coefficient-level regression test covers it numerically (identical output for in-range input), but I did not listen.

Fixes #166
