### PR TITLE
fix: deliver CLI protocol frames whole and report truncation accurately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.57.4] - 2026-08-01
+
+### Fixed
+- CLI commands with a response over 64 KiB failed with "Couldn't reach iQualize. Is it installed?" (#167). `iqualize presets opra search "audio"` returns ~127 KB and hit two separate limits: `UnixSocketIO.writeFrame` issued a single `write(2)` on a socket whose send buffer is 8 KiB and treated the short write as failure, and `readLine` capped at 64 KiB and returned the partial data with no way to tell truncation from EOF. The truncated frame then failed to decode, which the client reported as a connection failure — so it launched a second copy of the app and retried for 5 seconds before blaming the user's install. Writes now loop until the whole frame is out, retrying `EINTR`; reads are chunked with a bounded 32 MB cap and throw a distinct error for truncation; and the launch-and-retry path only runs for a genuine connection failure. Server-side write failures are logged instead of discarded.
+
 ## [0.57.3] - 2026-08-01
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
         // the test bundle.
         .testTarget(
             name: "iQualizeTests",
-            dependencies: ["iQualize"],
+            dependencies: ["iQualize", "IQControlProtocol", "iqualize-cli"],
             path: "Tests/iQualizeTests"
         ),
     ],

--- a/Sources/IQControlProtocol/UnixSocketIO.swift
+++ b/Sources/IQControlProtocol/UnixSocketIO.swift
@@ -1,9 +1,35 @@
 import Darwin
 import Foundation
 
+/// Why a frame couldn't be read whole. The point of the distinction is that a caller must
+/// never mistake a truncated response for a connection failure — see `IQClient.send`.
+public enum FrameReadError: Error, Equatable, CustomStringConvertible {
+    /// EOF or a read error before a single byte arrived. The peer hung up with nothing to say.
+    case noData
+    /// Bytes arrived but the stream ended before the newline delimiter. The frame is a prefix
+    /// of a real frame; decoding it would fail in a way that looks like corruption.
+    case incomplete(bytesRead: Int)
+    /// `maxBytes` was reached without a delimiter. A bounded cap, not an unbounded read, so a
+    /// hostile or wedged writer can't exhaust memory.
+    case tooLarge(limit: Int)
+
+    public var description: String {
+        switch self {
+        case .noData: return "connection closed before any data was received"
+        case .incomplete(let n): return "connection closed after \(n) bytes with no frame delimiter"
+        case .tooLarge(let limit): return "frame exceeded the \(limit)-byte limit"
+        }
+    }
+}
+
 /// Small raw-socket helpers shared by the app's `CLIControlServer` and the CLI's
 /// `IQClient` — both sides speak the same newline-delimited-JSON-over-AF_UNIX protocol.
 public enum UnixSocketIO {
+    /// Cap on a single frame. Generous — the largest real payload today is the OPRA catalog
+    /// search at ~130 KB — but bounded, so a peer that never sends a newline can't make us
+    /// allocate without limit.
+    public static let maxFrameBytes = 32 * 1024 * 1024
+
     /// Fills a `sockaddr_un` for `path`, or `nil` if it doesn't fit in `sun_path`
     /// (a fixed 104-byte buffer on Darwin).
     public static func makeSockaddrUn(path: String) -> sockaddr_un? {
@@ -20,29 +46,65 @@ public enum UnixSocketIO {
         return addr
     }
 
-    /// Reads bytes from `fd` until a newline (exclusive) or EOF/error. `nil` if nothing
-    /// was read before EOF/error.
-    public static func readLine(fd: Int32, maxBytes: Int = 64 * 1024) -> Data? {
+    /// Reads one newline-delimited frame from `fd`, excluding the delimiter.
+    ///
+    /// Reads in chunks rather than a byte at a time; a 127 KB response would otherwise cost
+    /// 127k `read(2)` calls. Any bytes that arrive after the delimiter are discarded, which is
+    /// safe because this protocol is one frame per connection on both sides — the server reads
+    /// a request and closes, the client reads a response and closes.
+    ///
+    /// Throws `FrameReadError` rather than returning a prefix, so truncation is never
+    /// mistaken for a complete frame.
+    public static func readFrame(fd: Int32, maxBytes: Int = maxFrameBytes) throws -> Data {
         var data = Data()
-        var byte: UInt8 = 0
-        while data.count < maxBytes {
-            let n = read(fd, &byte, 1)
-            if n <= 0 { break }
-            if byte == 0x0A { return data }
-            data.append(byte)
+        var chunk = [UInt8](repeating: 0, count: 16 * 1024)
+
+        while true {
+            let n = chunk.withUnsafeMutableBytes { raw -> Int in
+                read(fd, raw.baseAddress, min(raw.count, maxBytes - data.count + 1))
+            }
+            if n < 0 {
+                if errno == EINTR { continue }
+                break
+            }
+            if n == 0 { break }
+
+            if let newlineIndex = chunk[0..<n].firstIndex(of: 0x0A) {
+                data.append(contentsOf: chunk[0..<newlineIndex])
+                guard data.count <= maxBytes else { throw FrameReadError.tooLarge(limit: maxBytes) }
+                return data
+            }
+            data.append(contentsOf: chunk[0..<n])
+            if data.count > maxBytes { throw FrameReadError.tooLarge(limit: maxBytes) }
         }
-        return data.isEmpty ? nil : data
+
+        throw data.isEmpty ? FrameReadError.noData : FrameReadError.incomplete(bytesRead: data.count)
     }
 
     /// Writes `payload` followed by a newline delimiter. Returns whether the full frame
     /// was written.
+    ///
+    /// Loops until every byte is out. A single `write(2)` on a `SOCK_STREAM` Unix socket
+    /// returns short as soon as the 8 KiB send buffer fills, and `EINTR` is not a failure —
+    /// treating either as one was the cause of #167.
     @discardableResult
     public static func writeFrame(_ payload: Data, fd: Int32) -> Bool {
         var data = payload
         data.append(0x0A)
-        let written = data.withUnsafeBytes { raw -> Int in
-            write(fd, raw.baseAddress, raw.count)
+        return data.withUnsafeBytes { buffer -> Bool in
+            guard var pointer = buffer.baseAddress else { return true }
+            var remaining = buffer.count
+            while remaining > 0 {
+                let n = write(fd, pointer, remaining)
+                if n > 0 {
+                    remaining -= n
+                    pointer = pointer.advanced(by: n)
+                    continue
+                }
+                if n < 0 && errno == EINTR { continue }
+                return false
+            }
+            return true
         }
-        return written == data.count
     }
 }

--- a/Sources/iQualize/CLIControlServer.swift
+++ b/Sources/iQualize/CLIControlServer.swift
@@ -1,6 +1,9 @@
 import Darwin
 import Foundation
 import IQControlProtocol
+import os.log
+
+private let cliLog = OSLog(subsystem: "com.iqualize", category: "cli")
 
 /// Methods the CLI control channel can invoke, implemented by `MenuBarController`. All
 /// isolated to the main actor since they touch `AudioEngine`/`PresetStore`/window state.
@@ -169,7 +172,7 @@ final class CLIControlServer: @unchecked Sendable {
         var timeout = timeval(tv_sec: 5, tv_usec: 0)
         setsockopt(clientFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
 
-        guard let requestData = UnixSocketIO.readLine(fd: clientFD),
+        guard let requestData = try? UnixSocketIO.readFrame(fd: clientFD),
               let request = try? JSONDecoder().decode(CLIRequest.self, from: requestData) else {
             Self.writeResponse(.failure("malformed request"), to: clientFD)
             close(clientFD)
@@ -448,7 +451,16 @@ final class CLIControlServer: @unchecked Sendable {
     // MARK: - Raw I/O helpers
 
     private static func writeResponse(_ response: CLIResponse, to fd: Int32) {
-        guard let data = try? JSONEncoder().encode(response) else { return }
-        UnixSocketIO.writeFrame(data, fd: fd)
+        guard let data = try? JSONEncoder().encode(response) else {
+            os_log(.error, log: cliLog, "failed to encode CLI response")
+            return
+        }
+        // A dropped response leaves the CLI reporting a transport failure with no trace on
+        // this side; #167 was diagnosed the hard way for exactly that reason.
+        if !UnixSocketIO.writeFrame(data, fd: fd) {
+            os_log(.error, log: cliLog,
+                   "failed to write %{public}d-byte CLI response errno=%{public}d",
+                   data.count, errno)
+        }
     }
 }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.57.3</string>
+	<string>0.57.4</string>
 	<key>CFBundleVersion</key>
-	<string>0.57.3</string>
+	<string>0.57.4</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iqualize-cli/IQClient.swift
+++ b/Sources/iqualize-cli/IQClient.swift
@@ -5,11 +5,21 @@ import IQControlProtocol
 enum IQClientError: Error, CustomStringConvertible {
     case appNotReachable
     case malformedResponse
+    /// The app answered but the frame didn't arrive whole. Distinct from `appNotReachable`
+    /// because the app is plainly running — telling the user to check their install would be
+    /// wrong, and relaunching it would be pointless.
+    case truncatedResponse(FrameReadError)
+    /// A whole frame arrived and failed to decode.
+    case decodeFailed(Error)
 
     var description: String {
         switch self {
         case .appNotReachable: return "Couldn't reach iQualize. Is it installed?"
         case .malformedResponse: return "Received a malformed response from iQualize."
+        case .truncatedResponse(let reason):
+            return "iQualize's response was cut short (\(reason))."
+        case .decodeFailed(let error):
+            return "Couldn't decode iQualize's response: \(error)"
         }
     }
 }
@@ -19,15 +29,34 @@ enum IQClientError: Error, CustomStringConvertible {
 /// few seconds before giving up.
 enum IQClient {
     static func send(_ request: CLIRequest) throws -> CLIResponse {
-        if let response = try? sendOnce(request) {
-            return response
+        try send(request, attempt: sendOnce, launch: launchApp, wait: { usleep(100_000) })
+    }
+
+    /// The retry policy, with its side effects injected so a test can observe them.
+    ///
+    /// Only a genuine connection failure justifies launching the app and retrying. A
+    /// truncated or undecodable response means the app answered — retrying it 50 times and
+    /// then blaming the user's install is what made #167 so hard to diagnose.
+    static func send(
+        _ request: CLIRequest,
+        attempt: (CLIRequest) throws -> CLIResponse,
+        launch: () -> Void,
+        wait: () -> Void,
+        retries: Int = 50 // 50 × 100ms — ~5s total before giving up
+    ) throws -> CLIResponse {
+        do {
+            return try attempt(request)
+        } catch let error as IQClientError {
+            guard case .appNotReachable = error else { throw error }
         }
 
-        launchApp()
-        for _ in 0..<50 {
-            usleep(100_000) // 100ms — ~5s total before giving up
-            if let response = try? sendOnce(request) {
-                return response
+        launch()
+        for _ in 0..<retries {
+            wait()
+            do {
+                return try attempt(request)
+            } catch let error as IQClientError {
+                guard case .appNotReachable = error else { throw error }
             }
         }
         throw IQClientError.appNotReachable
@@ -62,12 +91,25 @@ enum IQClient {
         var timeout = timeval(tv_sec: 30, tv_usec: 0)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
 
-        let data = try JSONEncoder().encode(request)
-        guard UnixSocketIO.writeFrame(data, fd: fd) else { throw IQClientError.appNotReachable }
-
-        guard let responseData = UnixSocketIO.readLine(fd: fd) else {
+        guard let data = try? JSONEncoder().encode(request) else {
             throw IQClientError.malformedResponse
         }
-        return try JSONDecoder().decode(CLIResponse.self, from: responseData)
+        guard UnixSocketIO.writeFrame(data, fd: fd) else { throw IQClientError.appNotReachable }
+
+        let responseData: Data
+        do {
+            responseData = try UnixSocketIO.readFrame(fd: fd)
+        } catch let error as FrameReadError {
+            // Nothing at all came back: the app isn't listening in any useful sense, so the
+            // launch-and-retry path is the right response. Anything else means it answered.
+            if case .noData = error { throw IQClientError.appNotReachable }
+            throw IQClientError.truncatedResponse(error)
+        }
+
+        do {
+            return try JSONDecoder().decode(CLIResponse.self, from: responseData)
+        } catch {
+            throw IQClientError.decodeFailed(error)
+        }
     }
 }

--- a/Tests/iQualizeTests/IQClientRetryTests.swift
+++ b/Tests/iQualizeTests/IQClientRetryTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import IQControlProtocol
+import XCTest
+
+@testable import iqualize_cli
+
+/// #167: the CLI reported a truncated 127 KB response as "Couldn't reach iQualize. Is it
+/// installed?" — after launching a second copy of the app and retrying for five seconds.
+/// Only a genuine connection failure may take that path.
+final class IQClientRetryTests: XCTestCase {
+    private let request = CLIRequest(command: CLICommand.status)
+
+    private func run(
+        failures: [IQClientError],
+        thenSucceed: Bool = false
+    ) throws -> (result: Result<CLIResponse, Error>, attempts: Int, launched: Int) {
+        var attempts = 0
+        var launched = 0
+        var remaining = failures
+
+        let result = Result {
+            try IQClient.send(
+                request,
+                attempt: { _ in
+                    attempts += 1
+                    if !remaining.isEmpty { throw remaining.removeFirst() }
+                    if thenSucceed { return CLIResponse.success() }
+                    throw IQClientError.appNotReachable
+                },
+                launch: { launched += 1 },
+                wait: {},
+                retries: 3
+            )
+        }
+        return (result, attempts, launched)
+    }
+
+    // A decode failure means the app answered. Launching another copy and retrying is wrong.
+    func testDecodeFailureDoesNotLaunchOrRetry() throws {
+        let decodeError = IQClientError.decodeFailed(
+            DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "bad json")))
+        let (result, attempts, launched) = try run(failures: [decodeError])
+
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(launched, 0)
+        guard case .failure(let error) = result, case .decodeFailed = error as? IQClientError else {
+            return XCTFail("expected the decode failure to propagate, got \(result)")
+        }
+    }
+
+    // Same for truncation — the frame came from a running app.
+    func testTruncationDoesNotLaunchOrRetry() throws {
+        let (result, attempts, launched) = try run(
+            failures: [.truncatedResponse(.incomplete(bytesRead: 65_536))])
+
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(launched, 0)
+        guard case .failure(let error) = result,
+              case .truncatedResponse = error as? IQClientError else {
+            return XCTFail("expected the truncation error to propagate, got \(result)")
+        }
+    }
+
+    // The app genuinely not being reachable is still worth a launch and a few retries.
+    func testConnectionFailureLaunchesAndRetries() throws {
+        let (result, attempts, launched) = try run(
+            failures: [.appNotReachable, .appNotReachable], thenSucceed: true)
+
+        XCTAssertEqual(launched, 1)
+        XCTAssertEqual(attempts, 3)
+        guard case .success = result else { return XCTFail("expected success, got \(result)") }
+    }
+
+    // Exhausting the retries reports the connection failure, as before.
+    func testExhaustedRetriesReportsNotReachable() throws {
+        let (result, _, launched) = try run(failures: [])
+        XCTAssertEqual(launched, 1)
+        guard case .failure(let error) = result,
+              case .appNotReachable = error as? IQClientError else {
+            return XCTFail("expected appNotReachable, got \(result)")
+        }
+    }
+}

--- a/Tests/iQualizeTests/UnixSocketIOTests.swift
+++ b/Tests/iQualizeTests/UnixSocketIOTests.swift
@@ -1,0 +1,213 @@
+import Darwin
+import Foundation
+import IQControlProtocol
+import XCTest
+
+/// Bumped by the SIGUSR1 handler in the EINTR test. A C function pointer can't capture
+/// context, so the counter has to live at file scope.
+private nonisolated(unsafe) var interruptCount = 0
+
+/// Regression coverage for #167: a frame larger than the socket's send buffer must be
+/// delivered whole, and a frame that isn't must be reported as truncation rather than
+/// silently handed back as a prefix.
+final class UnixSocketIOTests: XCTestCase {
+    /// Cross-thread scratch space. The writer runs on its own thread so it can block while
+    /// the test's thread drains the socket; a lock-guarded box is the least ceremony that
+    /// satisfies strict concurrency.
+    private final class Box<T>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: T
+        init(_ value: T) { storage = value }
+        var value: T {
+            get { lock.lock(); defer { lock.unlock() }; return storage }
+            set { lock.lock(); storage = newValue; lock.unlock() }
+        }
+    }
+
+    /// A connected `SOCK_STREAM` pair, closed at the end of the test.
+    private func makeSocketPair() throws -> (Int32, Int32) {
+        var fds: [Int32] = [0, 0]
+        let result = fds.withUnsafeMutableBufferPointer { buffer in
+            socketpair(AF_UNIX, SOCK_STREAM, 0, buffer.baseAddress)
+        }
+        try XCTSkipIf(result != 0, "socketpair failed: errno \(errno)")
+        let (a, b) = (fds[0], fds[1])
+        addTeardownBlock { close(a); close(b) }
+        return (a, b)
+    }
+
+    /// Writes `payload` on a background thread — with a payload larger than the 8 KiB send
+    /// buffer, `writeFrame` blocks until the reader drains it, so it can't run inline.
+    private func writeInBackground(
+        _ payload: Data, fd: Int32, ignoreSIGPIPE: Bool = false
+    ) -> (done: XCTestExpectation, succeeded: Box<Bool>) {
+        let done = expectation(description: "write finished")
+        let succeeded = Box(false)
+        Thread.detachNewThread {
+            let previous = ignoreSIGPIPE ? signal(SIGPIPE, SIG_IGN) : nil
+            succeeded.value = UnixSocketIO.writeFrame(payload, fd: fd)
+            if let previous { signal(SIGPIPE, previous) }
+            done.fulfill()
+        }
+        return (done, succeeded)
+    }
+
+    // MARK: - Round-trip
+
+    // The bug: a single write(2) on an 8 KiB socket buffer returns short, and the old code
+    // called that a failure. A megabyte has to cross in many writes and come back intact.
+    func testRoundTripsPayloadLargerThanOneMegabyte() throws {
+        let (a, b) = try makeSocketPair()
+        // Byte values avoid 0x0A: the delimiter can't appear inside a frame. JSON
+        // encoding never emits a raw newline, so the real protocol never does either.
+        let payload = Data((0..<1_500_000).map { UInt8(0x20 &+ ($0 % 200)) })
+        let writer = writeInBackground(payload, fd: a)
+
+        let received = try UnixSocketIO.readFrame(fd: b)
+        wait(for: [writer.done], timeout: 30)
+
+        XCTAssertTrue(writer.succeeded.value)
+        XCTAssertEqual(received.count, payload.count)
+        XCTAssertEqual(received, payload)
+    }
+
+    // A payload the size of the failing `presets opra search "audio"` response — the exact
+    // case that used to be truncated at the old 64 KiB read cap.
+    func testRoundTripsPayloadLargerThanTheOldSixtyFourKilobyteCap() throws {
+        let (a, b) = try makeSocketPair()
+        let payload = Data(repeating: 0x7B, count: 127 * 1024)
+        let writer = writeInBackground(payload, fd: a)
+
+        let received = try UnixSocketIO.readFrame(fd: b)
+        wait(for: [writer.done], timeout: 30)
+
+        XCTAssertTrue(writer.succeeded.value)
+        XCTAssertEqual(received, payload)
+    }
+
+    // A payload smaller than the send buffer still round-trips, and the delimiter is stripped.
+    func testRoundTripsSmallPayload() throws {
+        let (a, b) = try makeSocketPair()
+        let payload = Data("{\"ok\":true}".utf8)
+        XCTAssertTrue(UnixSocketIO.writeFrame(payload, fd: a))
+        XCTAssertEqual(try UnixSocketIO.readFrame(fd: b), payload)
+    }
+
+    // An empty payload is a zero-length frame, not EOF.
+    func testRoundTripsEmptyPayload() throws {
+        let (a, b) = try makeSocketPair()
+        XCTAssertTrue(UnixSocketIO.writeFrame(Data(), fd: a))
+        XCTAssertEqual(try UnixSocketIO.readFrame(fd: b), Data())
+    }
+
+    // MARK: - EINTR
+
+    // A signal delivered mid-write makes write(2) return -1/EINTR. That's not a failure; the
+    // loop has to retry. The signal has to be aimed at the writing thread with pthread_kill —
+    // kill(2) lets the kernel deliver to any thread with the signal unblocked, and it does not
+    // reliably pick the one parked in the write. The handler is installed without SA_RESTART;
+    // with it the kernel restarts the syscall transparently and there is nothing to test.
+    func testWriteInterruptedBySignalCompletes() throws {
+        let (a, b) = try makeSocketPair()
+        let payload = Data((0..<800_000).map { UInt8(0x20 &+ ($0 % 200)) })
+
+        var action = sigaction()
+        action.__sigaction_u.__sa_handler = { _ in interruptCount &+= 1 }
+        action.sa_flags = 0
+        sigemptyset(&action.sa_mask)
+        var previous = sigaction()
+        XCTAssertEqual(sigaction(SIGUSR1, &action, &previous), 0)
+        let saved = Box(previous)
+        addTeardownBlock { var p = saved.value; sigaction(SIGUSR1, &p, nil) }
+        interruptCount = 0
+
+        let writerThread = Box<pthread_t?>(nil)
+        let done = expectation(description: "write finished")
+        let succeeded = Box(false)
+        Thread.detachNewThread {
+            writerThread.value = pthread_self()
+            succeeded.value = UnixSocketIO.writeFrame(payload, fd: a)
+            writerThread.value = nil
+            done.fulfill()
+        }
+
+        let stop = Box(false)
+        Thread.detachNewThread {
+            for _ in 0..<20_000 {
+                if stop.value { break }
+                if let target = writerThread.value { pthread_kill(target, SIGUSR1) }
+                usleep(100)
+            }
+        }
+
+        let received = try UnixSocketIO.readFrame(fd: b)
+        wait(for: [done], timeout: 30)
+        stop.value = true
+
+        XCTAssertGreaterThan(interruptCount, 0, "the writer was never actually signalled")
+        XCTAssertTrue(succeeded.value, "an EINTR-interrupted write must complete, not fail")
+        XCTAssertEqual(received, payload)
+    }
+
+    // A real failure is still a failure: writing to a socket whose peer is gone returns
+    // false rather than looping forever.
+    func testWriteToClosedPeerFails() throws {
+        let (a, b) = try makeSocketPair()
+        let previous = signal(SIGPIPE, SIG_IGN)
+        addTeardownBlock { signal(SIGPIPE, previous) }
+        close(b)
+        XCTAssertFalse(UnixSocketIO.writeFrame(Data(repeating: 0x41, count: 64 * 1024), fd: a))
+    }
+
+    // MARK: - Truncation
+
+    // Bytes then EOF with no delimiter used to come back as a valid-looking partial frame.
+    // Now it's an error the caller can act on.
+    func testTruncatedFrameThrowsIncomplete() throws {
+        let (a, b) = try makeSocketPair()
+        let partial = Data("{\"ok\":tr".utf8)
+        _ = partial.withUnsafeBytes { write(a, $0.baseAddress, $0.count) }
+        close(a)
+
+        XCTAssertThrowsError(try UnixSocketIO.readFrame(fd: b)) { error in
+            XCTAssertEqual(error as? FrameReadError, .incomplete(bytesRead: partial.count))
+        }
+    }
+
+    // EOF with nothing at all is distinct from a truncated frame — it's the only case that
+    // should make the CLI conclude the app isn't there.
+    func testEmptyStreamThrowsNoData() throws {
+        let (a, b) = try makeSocketPair()
+        close(a)
+        XCTAssertThrowsError(try UnixSocketIO.readFrame(fd: b)) { error in
+            XCTAssertEqual(error as? FrameReadError, .noData)
+        }
+    }
+
+    // The cap is bounded on purpose: a peer that never sends a delimiter must not be able to
+    // make the reader allocate without limit.
+    func testFrameOverTheCapThrowsTooLarge() throws {
+        let (a, b) = try makeSocketPair()
+        let limit = 32 * 1024
+        let writer = writeInBackground(
+            Data(repeating: 0x41, count: limit * 4), fd: a, ignoreSIGPIPE: true)
+
+        XCTAssertThrowsError(try UnixSocketIO.readFrame(fd: b, maxBytes: limit)) { error in
+            XCTAssertEqual(error as? FrameReadError, .tooLarge(limit: limit))
+        }
+        close(b)
+        wait(for: [writer.done], timeout: 30)
+    }
+
+    // A frame exactly at the cap is legal; the limit is inclusive.
+    func testFrameExactlyAtTheCapSucceeds() throws {
+        let (a, b) = try makeSocketPair()
+        let limit = 32 * 1024
+        let payload = Data(repeating: 0x41, count: limit)
+        let writer = writeInBackground(payload, fd: a)
+
+        XCTAssertEqual(try UnixSocketIO.readFrame(fd: b, maxBytes: limit), payload)
+        wait(for: [writer.done], timeout: 30)
+        XCTAssertTrue(writer.succeeded.value)
+    }
+}


### PR DESCRIPTION
## Summary

`iqualize presets opra search "audio"` returns about 127 KB and failed with "Couldn't reach iQualize. Is it installed?" after a five-second pause. Two limits, one on each side of the socket, plus an error taxonomy that turned both into the wrong message.

`UnixSocketIO.writeFrame` issued a single `write(2)` and compared the result to the payload length. A `SOCK_STREAM` Unix socket has an 8 KiB send buffer (`net.local.stream.sendspace`), so any larger payload returns short and was treated as a failure. `readLine` capped at 64 KiB and returned whatever it had at EOF, giving the caller no way to tell a truncated frame from a complete one. The truncated frame then failed to decode, and `IQClient` mapped every failure to `appNotReachable` — so it launched a second copy of the app and retried 50 times before telling the user to check their install.

The 64 KiB cap predicted the reported results exactly: every query under it worked, every query over it failed.

## Scope

- **`UnixSocketIO.writeFrame`** — loop until the whole frame is out, retrying `EINTR` rather than reporting it as a failure. This pattern already existed in `iQualizeCapture/main.swift:484-499`.
- **`UnixSocketIO.readFrame`** (replaces `readLine`) — read in 16 KiB chunks, and throw `FrameReadError` (`noData` / `incomplete` / `tooLarge`) instead of returning a prefix. Bounded at 32 MB rather than unbounded, so a peer that never sends a delimiter cannot exhaust memory.
- **`IQClient`** — split the retry policy from the transport. Only `appNotReachable` justifies launching the app; a truncation or decode failure means the app answered and is surfaced as itself. Side effects are injected so a test can assert the launch does not happen.
- **`CLIControlServer.writeResponse`** — log write failures instead of discarding `writeFrame`'s `Bool`. A dropped response left no trace on the app side, which is most of why this was hard to diagnose.
- **`Package.swift`** — the test target needs `IQControlProtocol` and `iqualize-cli`.

The wire format is unchanged, so a mixed-version app and CLI keep working.

## Out of scope

- **Length-prefixed framing.** It would make truncation structurally impossible, but it is a wire-format change.
- **Protocol versioning** (#175), **paginating `opra search`**, and any response-schema change.

## Test plan

- [x] `writeFrame`/`readFrame` round-trip a >1 MB payload over a `socketpair`
- [x] Round-trip a payload just over the old 64 KiB cap
- [x] A write interrupted by `SIGUSR1` completes rather than failing — the signal is aimed with `pthread_kill` at the thread parked in the write, and the handler is installed without `SA_RESTART`, so the `EINTR` is real
- [x] Writing to a closed peer still fails
- [x] A truncated frame throws `incomplete`; an empty stream throws `noData`; a frame over the cap throws `tooLarge`; a frame exactly at the cap succeeds
- [x] A decode failure does not launch the app or retry
- [x] A truncation does not launch the app or retry
- [x] A genuine connection failure still launches and retries, and reports `appNotReachable` when retries are exhausted
- [x] Full suite: 96 tests, 0 failures
- [x] App builds, installs, and launches (pid confirmed); `iqualize status` reports 0.57.4
- [x] **`presets opra search "audio"` returns 1004 products in 0.65 s** — the reported failure
- [x] Regressions, all previously in the failing or passing set: `"in"` 722, `"pro"` 438, `"sennheiser"` 283, `"hd"` 166, `"hd 600"` 4
- [x] `status`, `presets list`, `band list` unchanged

Fixes #167
