### PR TITLE
fix: land M3 real-time state architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.58.0] - 2026-08-02
+
+### Changed
+- Real-time audio configuration now publishes complete immutable snapshots with sequentially consistent reader protection and off-render reclamation, so callbacks observe an old or new configuration rather than a mixed one (#164, #173).
+- Live biquad edits reuse filter state and ramp coefficients over 64 frames. Preset switches publish zeroed filter state while retaining the same ramp, and explicit reset publishes a fresh zero-state snapshot (#174).
+
+### Fixed
+- Removed render-thread scratch-buffer growth and the spectrum analyzer's per-channel scale-array allocation. Oversized render slices now produce silence instead of allocating, while unlimited band counts remain supported (#152).
+
 ## [0.57.5] - 2026-08-01
 
 ### Added

--- a/Sources/IQRingAtomics/include/iq_ring_atomics.h
+++ b/Sources/IQRingAtomics/include/iq_ring_atomics.h
@@ -32,4 +32,32 @@ static inline void iq_store_relaxed_u64(uint64_t *p, uint64_t v) {
     __atomic_store_n(p, v, __ATOMIC_RELAXED);
 }
 
+// Render-thread snapshot publication primitives. A publisher initializes a
+// complete snapshot, exchanges it with acq_rel ordering, then waits for the
+// reader count to reach zero before reclaiming the old snapshot. A reader must
+// increment readers with acq_rel ordering before loading current with acquire
+// ordering, and decrement with release ordering after it stops dereferencing
+// the snapshot. This ordering closes the race where a callback starts while a
+// publisher is retiring the previous pointer: callbacks that can still see the
+// old pointer are counted before the publisher observes quiescence.
+static inline void *iq_load_acquire_ptr(void * const *p) {
+    return __atomic_load_n(p, __ATOMIC_ACQUIRE);
+}
+
+static inline void *iq_exchange_acq_rel_ptr(void **p, void *v) {
+    return __atomic_exchange_n(p, v, __ATOMIC_ACQ_REL);
+}
+
+static inline uint32_t iq_load_acquire_u32(const uint32_t *p) {
+    return __atomic_load_n(p, __ATOMIC_ACQUIRE);
+}
+
+static inline uint32_t iq_fetch_add_acq_rel_u32(uint32_t *p, uint32_t v) {
+    return __atomic_fetch_add(p, v, __ATOMIC_ACQ_REL);
+}
+
+static inline uint32_t iq_fetch_sub_release_u32(uint32_t *p, uint32_t v) {
+    return __atomic_fetch_sub(p, v, __ATOMIC_RELEASE);
+}
+
 #endif /* IQ_RING_ATOMICS_H */

--- a/Sources/IQRingAtomics/include/iq_ring_atomics.h
+++ b/Sources/IQRingAtomics/include/iq_ring_atomics.h
@@ -32,32 +32,43 @@ static inline void iq_store_relaxed_u64(uint64_t *p, uint64_t v) {
     __atomic_store_n(p, v, __ATOMIC_RELAXED);
 }
 
-// Render-thread snapshot publication primitives. A publisher initializes a
-// complete snapshot, exchanges it with acq_rel ordering, then waits for the
-// reader count to reach zero before reclaiming the old snapshot. A reader must
-// increment readers with acq_rel ordering before loading current with acquire
-// ordering, and decrement with release ordering after it stops dereferencing
-// the snapshot. This ordering closes the race where a callback starts while a
-// publisher is retiring the previous pointer: callbacks that can still see the
-// old pointer are counted before the publisher observes quiescence.
-static inline void *iq_load_acquire_ptr(void * const *p) {
-    return __atomic_load_n(p, __ATOMIC_ACQUIRE);
+// Render-thread snapshot publication primitives. The reader-count protocol
+// uses one sequentially consistent order for the reader increment, pointer
+// load, publisher exchange, and quiescence load:
+//
+//   reader:    increment readers; load current; ...; decrement readers
+//   publisher: exchange current; load readers; reclaim only when zero
+//
+// If the reader loads the retired pointer, its increment is ordered before the
+// publisher's quiescence load. If its increment is ordered after that load,
+// its pointer load is ordered after the exchange and it sees the replacement.
+// Acquire/release alone does not establish that total order on arm64.
+static inline void *iq_load_snapshot_ptr(void * const *p) {
+    return __atomic_load_n(p, __ATOMIC_SEQ_CST);
 }
 
-static inline void *iq_exchange_acq_rel_ptr(void **p, void *v) {
-    return __atomic_exchange_n(p, v, __ATOMIC_ACQ_REL);
+static inline void *iq_exchange_snapshot_ptr(void **p, void *v) {
+    return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST);
 }
 
-static inline uint32_t iq_load_acquire_u32(const uint32_t *p) {
-    return __atomic_load_n(p, __ATOMIC_ACQUIRE);
+static inline uint32_t iq_load_snapshot_readers(const uint32_t *p) {
+    return __atomic_load_n(p, __ATOMIC_SEQ_CST);
 }
 
-static inline uint32_t iq_fetch_add_acq_rel_u32(uint32_t *p, uint32_t v) {
-    return __atomic_fetch_add(p, v, __ATOMIC_ACQ_REL);
+static inline uint32_t iq_enter_snapshot_reader(uint32_t *p) {
+    return __atomic_fetch_add(p, 1, __ATOMIC_SEQ_CST);
 }
 
-static inline uint32_t iq_fetch_sub_release_u32(uint32_t *p, uint32_t v) {
-    return __atomic_fetch_sub(p, v, __ATOMIC_RELEASE);
+static inline uint32_t iq_leave_snapshot_reader(uint32_t *p) {
+    return __atomic_fetch_sub(p, 1, __ATOMIC_SEQ_CST);
+}
+
+static inline uint32_t iq_load_snapshot_u32(const uint32_t *p) {
+    return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}
+
+static inline void iq_store_snapshot_u32(uint32_t *p, uint32_t v) {
+    __atomic_store_n(p, v, __ATOMIC_SEQ_CST);
 }
 
 #endif /* IQ_RING_ATOMICS_H */

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -30,10 +30,10 @@ nonisolated(unsafe) private var rtScratchBuffer: UnsafeMutablePointer<Float>?
 nonisolated(unsafe) private var rtScratchCapacity: Int = 0
 
 /// Complete immutable configuration acquired by the render callback. The
-/// snapshot contains only raw pointers and scalar values, so acquiring it does
-/// not retain a CaptureClient or BiquadFilterChain. The owning main-actor
-/// properties remain alive until the publication quiescence protocol retires
-/// this snapshot.
+/// callback-visible fields are raw pointers and scalars, so acquiring them does
+/// not retain a CaptureClient or BiquadFilterChain. The private owner fields
+/// retain those objects off the callback path until the publication quiescence
+/// protocol retires this snapshot.
 struct RenderConfiguration: @unchecked Sendable {
     let captureClient: UnsafeMutableRawPointer?
     let channelCount: UInt32
@@ -168,7 +168,7 @@ func publishRenderConfigurationForTesting(_ configuration: RenderConfiguration?)
 @discardableResult
 func reclaimQuiescentRenderConfigurationsForTesting() -> Int {
     let readers = withUnsafePointer(to: &rtRenderPublication.pointee.readers) { pointer in
-        iq_load_acquire_u32(pointer)
+        iq_load_snapshot_readers(pointer)
     }
     guard readers == 0 else { return retiredRenderConfigurations.count }
     let retired = retiredRenderConfigurations
@@ -775,15 +775,31 @@ final class AudioEngine {
         }
     }
 
-    /// Build replacement chains off the render thread. The callback sees them only
-    /// after the complete snapshot is atomically published.
-    private func updateBiquadChains(leftBands: [EQBand], rightBands: [EQBand], sampleRate: Double) {
-        renderBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sampleRate)
-        renderBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sampleRate)
+    /// Build or update chains off the render thread. Reusing a chain preserves
+    /// delay state and lets its immutable snapshots ramp coefficients during
+    /// live edits. A changed preset identity requests the documented zero-state
+    /// reset while still using the same coefficient ramp.
+    private func updateBiquadChains(
+        leftBands: [EQBand],
+        rightBands: [EQBand],
+        sampleRate: Double,
+        resetState: Bool = false
+    ) {
+        if let chain = renderBiquadChainL {
+            chain.updateCoefficients(bands: leftBands, sampleRate: sampleRate, resetState: resetState)
+        } else {
+            renderBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sampleRate)
+        }
+        if let chain = renderBiquadChainR {
+            chain.updateCoefficients(bands: rightBands, sampleRate: sampleRate, resetState: resetState)
+        } else {
+            renderBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sampleRate)
+        }
     }
 
     private func applyBands(from old: EQPresetData? = nil) {
         guard let eq else { return }
+        let resetState = old.map { $0.id != activePreset.id } ?? false
 
         if splitChannelActive && !bypassed {
             // Split channel mode: bypass AVAudioUnitEQ, use custom biquad chains
@@ -791,7 +807,12 @@ final class AudioEngine {
             eq.bypass = true
             let leftBands = withEffectiveGain(activePreset.bands)
             let rightBands = withEffectiveGain(activePreset.rightBands ?? activePreset.bands)
-            updateBiquadChains(leftBands: leftBands, rightBands: rightBands, sampleRate: outputSampleRate)
+            updateBiquadChains(
+                leftBands: leftBands,
+                rightBands: rightBands,
+                sampleRate: outputSampleRate,
+                resetState: resetState
+            )
             publishRenderConfiguration()
         } else {
             // Linked mode: AVAudioUnitEQ natively processes the first
@@ -832,7 +853,12 @@ final class AudioEngine {
 
             if allBands.count > Self.avEQNativeBandCount {
                 let overflowBands = withEffectiveGain(Array(allBands[Self.avEQNativeBandCount...]))
-                updateBiquadChains(leftBands: overflowBands, rightBands: overflowBands, sampleRate: outputSampleRate)
+                updateBiquadChains(
+                    leftBands: overflowBands,
+                    rightBands: overflowBands,
+                    sampleRate: outputSampleRate,
+                    resetState: resetState
+                )
             } else {
                 renderBiquadChainL = nil
                 renderBiquadChainR = nil

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -2,6 +2,7 @@ import CoreAudio
 import AudioToolbox
 import AVFAudio
 import Foundation
+import IQRingAtomics
 import Observation
 import os.log
 
@@ -24,30 +25,166 @@ func defaultOutputDeviceChanged(previousUID: String?, currentUID: String?) -> Bo
 // defined inside a @MainActor class — because Swift 6 strict concurrency inserts
 // runtime isolation checks that crash on non-main threads.
 
-nonisolated(unsafe) private var rtCaptureClient: CaptureClient?
-nonisolated(unsafe) private var rtChannelCount: UInt32 = 2
-
 /// Scratch buffer for deinterleaving (allocated once, reused).
 nonisolated(unsafe) private var rtScratchBuffer: UnsafeMutablePointer<Float>?
 nonisolated(unsafe) private var rtScratchCapacity: Int = 0
-nonisolated(unsafe) private var rtBalanceLeft: Float = 1.0
-nonisolated(unsafe) private var rtBalanceRight: Float = 1.0
-nonisolated(unsafe) private var rtInputGain: Float = 1.0
-/// Multiplies back the stereo-pair headroom attenuation of the mixdown tap
-/// (see GainPolicy.tapHeadroomCompensation). Applied unconditionally — the tap
-/// attenuates in Bypass too, so Bypass must compensate to sound like app-off.
-nonisolated(unsafe) private var rtVolumeCompensation: Float = 1.0
-/// Per-channel biquad filter chains, run in this callback ahead of AVAudioUnitEQ.
-/// Only active when rtBiquadChainActive is true. Two roles, depending on mode:
-/// in split channel mode they carry the full band lists (AVAudioUnitEQ is bypassed
-/// entirely); in linked mode they carry only the bands beyond AVAudioUnitEQ's fixed
-/// native capacity (see AudioEngine.avEQNativeBandCount), so there's no hard cap on
-/// band count in either mode.
-/// Channels 2+ (e.g. 5.1/7.1 surround) pass through unprocessed — per-channel
-/// EQ for >2 channels is a separate feature.
-nonisolated(unsafe) private var rtBiquadChainL: BiquadFilterChain?
-nonisolated(unsafe) private var rtBiquadChainR: BiquadFilterChain?
-nonisolated(unsafe) private var rtBiquadChainActive: Bool = false
+
+/// Complete immutable configuration acquired by the render callback. The
+/// snapshot contains only raw pointers and scalar values, so acquiring it does
+/// not retain a CaptureClient or BiquadFilterChain. The owning main-actor
+/// properties remain alive until the publication quiescence protocol retires
+/// this snapshot.
+struct RenderConfiguration: @unchecked Sendable {
+    let captureClient: UnsafeMutableRawPointer?
+    let channelCount: UInt32
+    let scratchBuffer: UnsafeMutablePointer<Float>?
+    let scratchCapacity: Int
+    let balanceLeft: Float
+    let balanceRight: Float
+    let inputGain: Float
+    /// Multiplies back the stereo-pair headroom attenuation of the mixdown tap
+    /// (see GainPolicy.tapHeadroomCompensation). Applied unconditionally — the tap
+    /// attenuates in Bypass too, so Bypass must compensate to sound like app-off.
+    let volumeCompensation: Float
+    /// Per-channel biquad filter chains, run in this callback ahead of AVAudioUnitEQ.
+    /// In split channel mode they carry the full band lists; in linked mode they
+    /// carry only the bands beyond AVAudioUnitEQ's fixed native capacity. There is
+    /// no bounded internal capacity here: each publication allocates exactly the
+    /// requested chain sizes off the real-time path, preserving unlimited bands.
+    let biquadChainL: UnsafeMutableRawPointer?
+    let biquadChainR: UnsafeMutableRawPointer?
+
+    // These owners are deliberately not read by the render callback. They live
+    // inside the published storage so an old snapshot keeps its raw pointers
+    // valid until the main-actor reclamation pass destroys that storage.
+    private let captureClientOwner: CaptureClient?
+    private let biquadChainLOwner: BiquadFilterChain?
+    private let biquadChainROwner: BiquadFilterChain?
+
+    var biquadChainActive: Bool { biquadChainL != nil || biquadChainR != nil }
+
+    init(
+        captureClient: CaptureClient?,
+        channelCount: UInt32,
+        scratchBuffer: UnsafeMutablePointer<Float>? = nil,
+        scratchCapacity: Int = 0,
+        balanceLeft: Float,
+        balanceRight: Float,
+        inputGain: Float,
+        volumeCompensation: Float,
+        biquadChainL: BiquadFilterChain?,
+        biquadChainR: BiquadFilterChain?
+    ) {
+        self.captureClientOwner = captureClient
+        self.biquadChainLOwner = biquadChainL
+        self.biquadChainROwner = biquadChainR
+        self.captureClient = captureClient.map { Unmanaged.passUnretained($0).toOpaque() }
+        self.channelCount = channelCount
+        self.scratchBuffer = scratchBuffer
+        self.scratchCapacity = scratchCapacity
+        self.balanceLeft = balanceLeft
+        self.balanceRight = balanceRight
+        self.inputGain = inputGain
+        self.volumeCompensation = volumeCompensation
+        self.biquadChainL = biquadChainL.map { Unmanaged.passUnretained($0).toOpaque() }
+        self.biquadChainR = biquadChainR.map { Unmanaged.passUnretained($0).toOpaque() }
+    }
+
+    /// Test-only owner access. The render callback reads only the raw pointer
+    /// fields below and never calls this property.
+    var biquadChainLForTesting: BiquadFilterChain? {
+        guard let biquadChainL else { return nil }
+        return Unmanaged<BiquadFilterChain>.fromOpaque(biquadChainL).takeUnretainedValue()
+    }
+
+    var biquadChainRForTesting: BiquadFilterChain? {
+        guard let biquadChainR else { return nil }
+        return Unmanaged<BiquadFilterChain>.fromOpaque(biquadChainR).takeUnretainedValue()
+    }
+}
+
+struct RenderConfigurationHandle {
+    fileprivate let pointer: UnsafeMutableRawPointer?
+
+    private var storage: UnsafeMutablePointer<RenderConfiguration>? {
+        pointer?.assumingMemoryBound(to: RenderConfiguration.self)
+    }
+
+    // Callback-safe scalar/raw-pointer accessors. Returning the whole struct
+    // would copy its owner references and introduce ARC traffic on the IO
+    // thread, so the callback must use these fields instead.
+    var captureClient: UnsafeMutableRawPointer? { storage?.pointee.captureClient }
+    var channelCount: UInt32 { storage?.pointee.channelCount ?? 0 }
+    var scratchBuffer: UnsafeMutablePointer<Float>? { storage?.pointee.scratchBuffer }
+    var scratchCapacity: Int { storage?.pointee.scratchCapacity ?? 0 }
+    var balanceLeft: Float { storage?.pointee.balanceLeft ?? 1 }
+    var balanceRight: Float { storage?.pointee.balanceRight ?? 1 }
+    var inputGain: Float { storage?.pointee.inputGain ?? 1 }
+    var volumeCompensation: Float { storage?.pointee.volumeCompensation ?? 1 }
+    var biquadChainL: UnsafeMutableRawPointer? { storage?.pointee.biquadChainL }
+    var biquadChainR: UnsafeMutableRawPointer? { storage?.pointee.biquadChainR }
+
+    /// Test-only value access. Production callback code must use the scalar
+    /// accessors above so the owner references are never copied on the IO path.
+    var configurationForTesting: RenderConfiguration? {
+        storage?.pointee
+    }
+
+    func releaseRead() {
+        rtLeave(rtRenderPublication)
+    }
+}
+
+nonisolated(unsafe) private let rtRenderPublication: UnsafeMutablePointer<RTSnapshotPublication> = {
+    let pointer = UnsafeMutablePointer<RTSnapshotPublication>.allocate(capacity: 1)
+    pointer.initialize(to: RTSnapshotPublication())
+    return pointer
+}()
+
+nonisolated(unsafe) private var retiredRenderConfigurations: [UnsafeMutableRawPointer] = []
+
+func acquireRenderConfigurationForTesting() -> RenderConfigurationHandle {
+    let pointer = rtEnter(rtRenderPublication)
+    return RenderConfigurationHandle(pointer: pointer)
+}
+
+@discardableResult
+func publishRenderConfigurationForTesting(_ configuration: RenderConfiguration?) -> Int {
+    let newPointer: UnsafeMutableRawPointer? = configuration.map { value in
+        let pointer = UnsafeMutablePointer<RenderConfiguration>.allocate(capacity: 1)
+        pointer.initialize(to: value)
+        return UnsafeMutableRawPointer(pointer)
+    }
+    if let oldPointer = publishSnapshot(rtRenderPublication, newPointer) {
+        retiredRenderConfigurations.append(oldPointer)
+    }
+    // Never wait for a zero-reader window during an ordinary configuration
+    // update. Audio callbacks may run continuously. A later main-thread pass
+    // reclaims retired storage once the reader count reaches zero.
+    _ = reclaimQuiescentRenderConfigurationsForTesting()
+    return retiredRenderConfigurations.count
+}
+
+@discardableResult
+func reclaimQuiescentRenderConfigurationsForTesting() -> Int {
+    let readers = withUnsafePointer(to: &rtRenderPublication.pointee.readers) { pointer in
+        iq_load_acquire_u32(pointer)
+    }
+    guard readers == 0 else { return retiredRenderConfigurations.count }
+    let retired = retiredRenderConfigurations
+    retiredRenderConfigurations.removeAll(keepingCapacity: true)
+    for oldPointer in retired {
+        let pointer = oldPointer.assumingMemoryBound(to: RenderConfiguration.self)
+        pointer.deinitialize(count: 1)
+        pointer.deallocate()
+    }
+    return retiredRenderConfigurations.count
+}
+
+private func waitAndReclaimRenderConfigurations() {
+    waitForSnapshotQuiescence(rtRenderPublication)
+    _ = reclaimQuiescentRenderConfigurationsForTesting()
+}
 
 /// AVAudioSourceNode render block: pulls interleaved audio from the capture
 /// client's shared ring buffer, deinterleaves into separate channel buffers
@@ -58,48 +195,74 @@ private func renderCallback(
     frameCount: UInt32,
     audioBufferList: UnsafeMutablePointer<AudioBufferList>
 ) -> OSStatus {
-    guard let client = rtCaptureClient else { return noErr }
-    let ch = Int(rtChannelCount)
-    let frames = Int(frameCount)
-    let interleavedCount = frames * ch
     let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
-
-    // Preallocated in start() for the AU's maximumFramesPerSlice default;
-    // growing here on the audio thread is a never-expected fallback.
-    if rtScratchCapacity < interleavedCount {
-        rtScratchBuffer?.deallocate()
-        rtScratchBuffer = .allocate(capacity: interleavedCount)
-        rtScratchCapacity = interleavedCount
+    let handle = acquireRenderConfigurationForTesting()
+    guard let client = handle.captureClient else {
+        renderSilence(bufferList, frameCount: Int(frameCount))
+        handle.releaseRead()
+        return noErr
     }
-    guard let scratch = rtScratchBuffer else { return noErr }
+    let ch = Int(handle.channelCount)
+    let frames = Int(frameCount)
+    let interleavedCount = frames.multipliedReportingOverflow(by: ch)
+
+    // The render path never grows storage. The engine preallocates for the
+    // audio unit's maximum slice during start; an unexpected oversized slice
+    // is rendered as silence rather than allocating on the IO thread.
+    guard !interleavedCount.overflow,
+          renderScratchCapacityAllows(frameCount: frames, channelCount: ch,
+                                      scratchCapacity: handle.scratchCapacity),
+          let scratch = handle.scratchBuffer else {
+        renderSilence(bufferList, frameCount: frames)
+        handle.releaseRead()
+        return noErr
+    }
+    let sampleCount = interleavedCount.partialValue
 
     // All-or-nothing: a full drift-compensated block (#133), or silence
     // while the ring seeds / after an underrun.
-    if client.readResampled(scratch, frames: frames) == 0 {
-        scratch.initialize(repeating: 0.0, count: interleavedCount)
+    if CaptureClient.readResampledRT(client, destination: scratch, frames: frames) == 0 {
+        scratch.initialize(repeating: 0.0, count: sampleCount)
     }
 
     for i in 0..<bufferList.count {
         guard let outData = bufferList[i].mData?.assumingMemoryBound(to: Float.self) else { continue }
-        let balance = i == 0 ? rtBalanceLeft : rtBalanceRight
+        let balance = i == 0 ? handle.balanceLeft : handle.balanceRight
         deinterleaveChannel(scratch, into: outData, channel: i, channelCount: ch,
-                            frames: frames, gain: rtInputGain * balance * rtVolumeCompensation)
+                            frames: frames, gain: handle.inputGain * balance * handle.volumeCompensation)
     }
 
     // Apply per-channel biquad EQ when a chain is configured — either the whole
     // preset in split channel mode (AVAudioUnitEQ bypassed), or the overflow
     // bands beyond AVAudioUnitEQ's native capacity in linked mode (runs ahead
     // of it in the graph, feeding it already-partially-EQ'd audio).
-    if rtBiquadChainActive {
+    if handle.biquadChainL != nil || handle.biquadChainR != nil {
         if bufferList.count > 0, let outL = bufferList[0].mData?.assumingMemoryBound(to: Float.self) {
-            rtBiquadChainL?.process(outL, frameCount: frames)
+            if let chain = handle.biquadChainL {
+                BiquadFilterChain.processRT(chain, buffer: outL, frameCount: frames)
+            }
         }
         if bufferList.count > 1, let outR = bufferList[1].mData?.assumingMemoryBound(to: Float.self) {
-            rtBiquadChainR?.process(outR, frameCount: frames)
+            if let chain = handle.biquadChainR {
+                BiquadFilterChain.processRT(chain, buffer: outR, frameCount: frames)
+            }
         }
     }
 
+    handle.releaseRead()
     return noErr
+}
+
+/// Fill the source node's caller-owned output buffers without allocating. This
+/// is used when the graph is inactive or asks for more frames than the bounded
+/// scratch buffer can hold.
+@inline(__always)
+func renderSilence(_ bufferList: UnsafeMutableAudioBufferListPointer, frameCount: Int) {
+    guard frameCount > 0 else { return }
+    for index in 0..<bufferList.count {
+        guard let data = bufferList[index].mData?.assumingMemoryBound(to: Float.self) else { continue }
+        data.initialize(repeating: 0, count: frameCount)
+    }
 }
 
 /// Copy one channel out of an interleaved buffer, applying the channel's total
@@ -118,6 +281,16 @@ func deinterleaveChannel(
     }
 }
 
+/// The render callback may only use its preallocated scratch storage. An
+/// oversized callback is rendered as silence rather than growing storage on
+/// the real-time thread.
+@inline(__always)
+func renderScratchCapacityAllows(frameCount: Int, channelCount: Int, scratchCapacity: Int) -> Bool {
+    guard frameCount >= 0, channelCount >= 0 else { return false }
+    let (sampleCount, overflow) = frameCount.multipliedReportingOverflow(by: channelCount)
+    return !overflow && sampleCount <= scratchCapacity
+}
+
 // MARK: - AudioEngine
 
 @available(macOS 14.2, *)
@@ -128,6 +301,10 @@ final class AudioEngine {
     /// detail, not a user-facing limit. See the comment at its allocation in start(),
     /// and docs/EQ_BAND_CAPACITY.md for why this can't just be raised.
     private static let avEQNativeBandCount = 31
+    /// The source AU is explicitly bounded before render resources are
+    /// allocated. Requests above this value are rendered as silence rather
+    /// than growing scratch storage on the IO thread.
+    private static let renderMaximumFramesPerSlice: AVAudioFrameCount = 4096
 
     private(set) var isRunning = false
     private(set) var lifecycleState: AudioLifecycleState = .inactive
@@ -150,6 +327,13 @@ final class AudioEngine {
     private var eq: AVAudioUnitEQ?
     private var outputGainEQ: AVAudioUnitEQ?
     private var limiter: AVAudioUnitEffect?
+    private var renderChannelCount: UInt32 = 2
+    private var renderBalanceLeft: Float = 1.0
+    private var renderBalanceRight: Float = 1.0
+    private var renderInputGain: Float = 1.0
+    private var renderVolumeCompensation: Float = 1.0
+    private var renderBiquadChainL: BiquadFilterChain?
+    private var renderBiquadChainR: BiquadFilterChain?
 
     @ObservationIgnored
     nonisolated(unsafe) private var deviceChangeListenerBlock: AudioObjectPropertyListenerBlock?
@@ -217,15 +401,32 @@ final class AudioEngine {
     /// bypassed and restored on un-bypass, without touching the stored/displayed
     /// control values (see #118). The math lives in GainPolicy.
     private func updateInputGain() {
-        rtInputGain = GainPolicy.inputGain(dB: inputGainDB, bypassed: bypassed)
+        renderInputGain = GainPolicy.inputGain(dB: inputGainDB, bypassed: bypassed)
+        publishRenderConfiguration()
     }
 
     private func updateBalance() {
-        (rtBalanceLeft, rtBalanceRight) = GainPolicy.balanceGains(balance, bypassed: bypassed)
+        (renderBalanceLeft, renderBalanceRight) = GainPolicy.balanceGains(balance, bypassed: bypassed)
+        publishRenderConfiguration()
     }
 
     private func updateOutputGain() {
         outputGainEQ?.globalGain = GainPolicy.outputGainDB(outputGainDB, bypassed: bypassed)
+    }
+
+    private func publishRenderConfiguration() {
+        publishRenderConfigurationForTesting(RenderConfiguration(
+            captureClient: captureClient,
+            channelCount: renderChannelCount,
+            scratchBuffer: rtScratchBuffer,
+            scratchCapacity: rtScratchCapacity,
+            balanceLeft: renderBalanceLeft,
+            balanceRight: renderBalanceRight,
+            inputGain: renderInputGain,
+            volumeCompensation: renderVolumeCompensation,
+            biquadChainL: renderBiquadChainL,
+            biquadChainR: renderBiquadChainR
+        ))
     }
 
     var maxGainDB: Float = 12
@@ -318,17 +519,7 @@ final class AudioEngine {
         let sampleRate = client.sampleRate
         let channels = client.channels
         self.outputSampleRate = sampleRate
-        rtCaptureClient = client
-        rtChannelCount = channels
-
-        // Preallocate the render scratch for the AU maximumFramesPerSlice
-        // default (4096) so the render callback never allocates in practice.
-        let scratchFloats = 4096 * Int(channels)
-        if rtScratchCapacity < scratchFloats {
-            rtScratchBuffer?.deallocate()
-            rtScratchBuffer = .allocate(capacity: scratchFloats)
-            rtScratchCapacity = scratchFloats
-        }
+        renderChannelCount = channels
 
         os_log(.default, log: appLog,
                "capture helper sr: %{public}.0f  ch: %{public}u  output: %{public}@",
@@ -348,6 +539,24 @@ final class AudioEngine {
                                    channels: AVAudioChannelCount(channels))!
 
         let sourceNode = AVAudioSourceNode(format: format, renderBlock: renderCallback)
+        sourceNode.auAudioUnit.maximumFramesToRender = Self.renderMaximumFramesPerSlice
+        let maximumFramesPerSlice = Int(sourceNode.auAudioUnit.maximumFramesToRender)
+        guard maximumFramesPerSlice > 0 else {
+            throw NSError(domain: "iQualize", code: -201, userInfo: [
+                NSLocalizedDescriptionKey: "Audio source returned an invalid maximum render slice"
+            ])
+        }
+        let scratchFloats = maximumFramesPerSlice.multipliedReportingOverflow(by: Int(channels))
+        guard !scratchFloats.overflow else {
+            throw NSError(domain: "iQualize", code: -202, userInfo: [
+                NSLocalizedDescriptionKey: "Audio render scratch size overflowed"
+            ])
+        }
+        if rtScratchCapacity < scratchFloats.partialValue {
+            rtScratchBuffer?.deallocate()
+            rtScratchBuffer = .allocate(capacity: scratchFloats.partialValue)
+            rtScratchCapacity = scratchFloats.partialValue
+        }
         self.sourceNode = sourceNode
 
         // AVAudioUnitEQ (Apple's AUNBandEQ) natively processes up to
@@ -396,10 +605,11 @@ final class AudioEngine {
         // guards the restored level. Recomputed on every start(); device
         // switches funnel through the lifecycle coordinator's stop + start path.
         let outputChannels = Int(avEngine.outputNode.outputFormat(forBus: 0).channelCount)
-        rtVolumeCompensation = GainPolicy.tapHeadroomCompensation(outputChannels: outputChannels)
+        renderVolumeCompensation = GainPolicy.tapHeadroomCompensation(outputChannels: outputChannels)
+        publishRenderConfiguration()
         os_log(.default, log: appLog,
                "output hw channels: %{public}d  tap headroom compensation: x%{public}.1f",
-               outputChannels, rtVolumeCompensation)
+               outputChannels, renderVolumeCompensation)
 
         // Retain the graph before starting it so a thrown start() can still be
         // stopped by the shared teardown path.
@@ -498,11 +708,12 @@ final class AudioEngine {
             self.configChangeObserver = nil
         }
 
-        rtCaptureClient = nil
-        rtBiquadChainL = nil
-        rtBiquadChainR = nil
-        rtBiquadChainActive = false
-        rtVolumeCompensation = 1.0
+        // Keep the old owners alive while the graph stops. The callback holds
+        // only opaque pointers, so dropping these properties before the graph
+        // is quiescent would create a use-after-free window.
+        let retiringClient = captureClient
+        let retiringChainL = renderBiquadChainL
+        let retiringChainR = renderBiquadChainR
 
         // Remove spectrum taps before stopping engine
         if sourceTapInstalled {
@@ -521,10 +732,30 @@ final class AudioEngine {
         outputGainEQ = nil
         limiter = nil
 
+        // No new callbacks can start after the graph stops. Retire the
+        // configuration and wait only for a callback that was already in
+        // flight before stopping the engine.
+        captureClient = nil
+        renderBiquadChainL = nil
+        renderBiquadChainR = nil
+        renderVolumeCompensation = 1.0
+        publishRenderConfigurationForTesting(nil)
+        waitAndReclaimRenderConfigurations()
+
         // Terminate the capture helper. It cleans up its own CATap, aggregate,
         // IOProc, and shared memory.
-        captureClient?.stop()
-        captureClient = nil
+        retiringClient?.stop()
+
+        // No callback can dereference the retired configuration now. Release the
+        // scratch storage that the snapshot carried as a raw pointer.
+        rtScratchBuffer?.deallocate()
+        rtScratchBuffer = nil
+        rtScratchCapacity = 0
+
+        // Keep these locals alive until after reclamation so the lifetime proof
+        // remains explicit even if the retired snapshot was already reclaimed.
+        _ = retiringChainL
+        _ = retiringChainR
     }
 
     // MARK: - EQ Control
@@ -544,18 +775,11 @@ final class AudioEngine {
         }
     }
 
-    /// Push `bands` into `rtBiquadChainL`/`R`, creating the chains on first use.
+    /// Build replacement chains off the render thread. The callback sees them only
+    /// after the complete snapshot is atomically published.
     private func updateBiquadChains(leftBands: [EQBand], rightBands: [EQBand], sampleRate: Double) {
-        if let chainL = rtBiquadChainL {
-            chainL.updateCoefficients(bands: leftBands, sampleRate: sampleRate)
-        } else {
-            rtBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sampleRate)
-        }
-        if let chainR = rtBiquadChainR {
-            chainR.updateCoefficients(bands: rightBands, sampleRate: sampleRate)
-        } else {
-            rtBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sampleRate)
-        }
+        renderBiquadChainL = BiquadFilterChain(bands: leftBands, sampleRate: sampleRate)
+        renderBiquadChainR = BiquadFilterChain(bands: rightBands, sampleRate: sampleRate)
     }
 
     private func applyBands(from old: EQPresetData? = nil) {
@@ -568,7 +792,7 @@ final class AudioEngine {
             let leftBands = withEffectiveGain(activePreset.bands)
             let rightBands = withEffectiveGain(activePreset.rightBands ?? activePreset.bands)
             updateBiquadChains(leftBands: leftBands, rightBands: rightBands, sampleRate: outputSampleRate)
-            rtBiquadChainActive = true
+            publishRenderConfiguration()
         } else {
             // Linked mode: AVAudioUnitEQ natively processes the first
             // Self.avEQNativeBandCount bands; any remaining bands run through
@@ -609,12 +833,16 @@ final class AudioEngine {
             if allBands.count > Self.avEQNativeBandCount {
                 let overflowBands = withEffectiveGain(Array(allBands[Self.avEQNativeBandCount...]))
                 updateBiquadChains(leftBands: overflowBands, rightBands: overflowBands, sampleRate: outputSampleRate)
-                rtBiquadChainActive = true
             } else {
-                rtBiquadChainL = nil
-                rtBiquadChainR = nil
-                rtBiquadChainActive = false
+                renderBiquadChainL = nil
+                renderBiquadChainR = nil
+                publishRenderConfiguration()
+                eq.globalGain = 0
+                eq.bypass = bypassed || activePreset.isFlat
+                limiter?.bypass = !peakLimiter || bypassed
+                return
             }
+            publishRenderConfiguration()
 
             eq.globalGain = 0
             eq.bypass = bypassed || activePreset.isFlat

--- a/Sources/iQualize/BiquadFilter.swift
+++ b/Sources/iQualize/BiquadFilter.swift
@@ -1,8 +1,6 @@
 import Foundation
+import IQRingAtomics
 
-// MARK: - Normalized Biquad Coefficients
-
-/// Pre-normalized biquad coefficients (divided by a0) for real-time processing.
 struct NormalizedBiquadCoeffs: Sendable {
     let b0: Float, b1: Float, b2: Float
     let a1: Float, a2: Float
@@ -23,52 +21,121 @@ struct NormalizedBiquadCoeffs: Sendable {
     }
 }
 
-// MARK: - Biquad Filter Chain
+private struct BiquadSnapshot {
+    let coeffs: UnsafeMutablePointer<NormalizedBiquadCoeffs>
+    let z1: UnsafeMutablePointer<Float>
+    let z2: UnsafeMutablePointer<Float>
+    let bandCount: Int
+}
 
-/// Real-time biquad filter chain for per-channel EQ processing.
-/// Maintains filter state (delay elements) per band.
-/// Designed for use on the Core Audio IO thread — no allocations after setup.
+/// Real-time biquad chain with complete immutable coefficient/state snapshots.
+/// Main-actor publication allocates and reclaims snapshots. The callback only
+/// enters the raw-pointer quiescence protocol and mutates the selected state.
 final class BiquadFilterChain: @unchecked Sendable {
-    /// Per-band coefficients.
-    private var coeffs: [NormalizedBiquadCoeffs]
-    /// Per-band delay state: z1, z2 (Direct Form II Transposed).
-    private var z1: [Float]
-    private var z2: [Float]
-    private var bandCount: Int
+    private let publication: UnsafeMutablePointer<RTSnapshotPublication>
+    private var retiredSnapshots: [UnsafeMutableRawPointer] = []
+    private(set) var retiredSnapshotCount = 0
+    private(set) var lastRetirementWasOnMainThread = false
 
     init(bands: [EQBand], sampleRate: Double) {
-        bandCount = bands.count
-        coeffs = bands.map { band in
-            NormalizedBiquadCoeffs(from: BiquadResponse.coefficients(for: band, sampleRate: sampleRate))
-        }
-        z1 = [Float](repeating: 0, count: bandCount)
-        z2 = [Float](repeating: 0, count: bandCount)
+        publication = .allocate(capacity: 1)
+        publication.initialize(to: RTSnapshotPublication())
+        let snapshot = Self.makeSnapshot(bands: bands, sampleRate: sampleRate)
+        _ = publishSnapshot(publication, UnsafeMutableRawPointer(snapshot))
     }
 
-    /// Update coefficients from new band parameters. Resets state if band count changed.
+    deinit {
+        if let retired = publishSnapshot(publication, nil) { retiredSnapshots.append(retired) }
+        waitForSnapshotQuiescence(publication)
+        reclaimQuiescentSnapshots()
+        publication.deinitialize(count: 1)
+        publication.deallocate()
+    }
+
     func updateCoefficients(bands: [EQBand], sampleRate: Double) {
-        let newCount = bands.count
-        let newCoeffs = bands.map { band in
-            NormalizedBiquadCoeffs(from: BiquadResponse.coefficients(for: band, sampleRate: sampleRate))
+        let replacement = Self.makeSnapshot(bands: bands, sampleRate: sampleRate)
+        if let retired = publishSnapshot(publication, UnsafeMutableRawPointer(replacement)) {
+            retiredSnapshots.append(retired)
         }
-
-        if newCount != bandCount {
-            z1 = [Float](repeating: 0, count: newCount)
-            z2 = [Float](repeating: 0, count: newCount)
-            bandCount = newCount
-        }
-
-        coeffs = newCoeffs
+        reclaimQuiescentSnapshots()
     }
 
-    /// Process audio samples in-place using Direct Form II Transposed.
-    /// Called on the Core Audio IO thread.
     func process(_ buffer: UnsafeMutablePointer<Float>, frameCount: Int) {
-        for b in 0..<bandCount {
-            let c = coeffs[b]
-            var s1 = z1[b]
-            var s2 = z2[b]
+        guard let raw = rtEnter(publication) else { return }
+        defer { rtLeave(publication) }
+        Self.processSnapshot(raw.assumingMemoryBound(to: BiquadSnapshot.self).pointee,
+                             buffer: buffer, frameCount: frameCount)
+    }
 
+    static func processRT(_ opaque: UnsafeMutableRawPointer,
+                          buffer: UnsafeMutablePointer<Float>,
+                          frameCount: Int) {
+        let chain = Unmanaged<BiquadFilterChain>.fromOpaque(opaque).takeUnretainedValue()
+        chain.process(buffer, frameCount: frameCount)
+    }
+
+    func reset() {
+        guard let raw = rtEnter(publication) else { return }
+        defer { rtLeave(publication) }
+        let snapshot = raw.assumingMemoryBound(to: BiquadSnapshot.self).pointee
+        for i in 0..<snapshot.bandCount {
+            snapshot.z1[i] = 0
+            snapshot.z2[i] = 0
+        }
+    }
+
+    func currentSnapshotCounts() -> (coefficients: Int, state: Int, bands: Int) {
+        guard let raw = rtEnter(publication) else { return (0, 0, 0) }
+        defer { rtLeave(publication) }
+        let count = raw.assumingMemoryBound(to: BiquadSnapshot.self).pointee.bandCount
+        return (count, count, count)
+    }
+
+    private static func makeSnapshot(bands: [EQBand], sampleRate: Double)
+        -> UnsafeMutablePointer<BiquadSnapshot> {
+        let count = bands.count
+        let coeffs = UnsafeMutablePointer<NormalizedBiquadCoeffs>.allocate(capacity: count)
+        let z1 = UnsafeMutablePointer<Float>.allocate(capacity: count)
+        let z2 = UnsafeMutablePointer<Float>.allocate(capacity: count)
+        for (index, band) in bands.enumerated() {
+            coeffs[index] = NormalizedBiquadCoeffs(
+                from: BiquadResponse.coefficients(for: band, sampleRate: sampleRate))
+            z1[index] = 0
+            z2[index] = 0
+        }
+        let snapshot = UnsafeMutablePointer<BiquadSnapshot>.allocate(capacity: 1)
+        snapshot.initialize(to: BiquadSnapshot(coeffs: coeffs, z1: z1, z2: z2, bandCount: count))
+        return snapshot
+    }
+
+    private static func destroySnapshot(_ snapshot: UnsafeMutablePointer<BiquadSnapshot>) {
+        snapshot.pointee.coeffs.deallocate()
+        snapshot.pointee.z1.deallocate()
+        snapshot.pointee.z2.deallocate()
+        snapshot.deinitialize(count: 1)
+        snapshot.deallocate()
+    }
+
+    private func reclaimQuiescentSnapshots() {
+        guard iq_load_acquire_u32(&publication.pointee.readers) == 0 else { return }
+        let retired = retiredSnapshots
+        retiredSnapshots.removeAll(keepingCapacity: true)
+        for pointer in retired {
+            Self.destroySnapshot(pointer.assumingMemoryBound(to: BiquadSnapshot.self))
+            retiredSnapshotCount += 1
+            lastRetirementWasOnMainThread = Thread.isMainThread
+        }
+    }
+
+    @inline(__always)
+    private static func processSnapshot(_ snapshot: BiquadSnapshot,
+                                        buffer: UnsafeMutablePointer<Float>,
+                                        frameCount: Int) {
+        guard frameCount > 0 else { return }
+        for b in 0..<snapshot.bandCount {
+            let c = snapshot.coeffs[b]
+            var s1 = snapshot.z1[b]
+            var s2 = snapshot.z2[b]
             for f in 0..<frameCount {
                 let x = buffer[f]
                 let y = c.b0 * x + s1
@@ -76,21 +143,10 @@ final class BiquadFilterChain: @unchecked Sendable {
                 s2 = c.b2 * x - c.a2 * y
                 buffer[f] = y
             }
-
-            // Flush denormals to zero
             if abs(s1) < 1e-15 { s1 = 0 }
             if abs(s2) < 1e-15 { s2 = 0 }
-
-            z1[b] = s1
-            z2[b] = s2
-        }
-    }
-
-    /// Reset all filter state (e.g., when switching presets to avoid transients).
-    func reset() {
-        for i in 0..<bandCount {
-            z1[i] = 0
-            z2[i] = 0
+            snapshot.z1[b] = s1
+            snapshot.z2[b] = s2
         }
     }
 }

--- a/Sources/iQualize/BiquadFilter.swift
+++ b/Sources/iQualize/BiquadFilter.swift
@@ -16,22 +16,80 @@ struct NormalizedBiquadCoeffs: Sendable {
 
     static let passthrough = NormalizedBiquadCoeffs(b0: 1, b1: 0, b2: 0, a1: 0, a2: 0)
 
+    /// Linear coefficient interpolation used by the render callback. The
+    /// initializer remains private so every coefficient set is either a
+    /// cookbook result or an interpolation of two validated sets.
+    @inline(__always)
+    static func interpolate(_ from: Self, _ to: Self, amount: Float) -> Self {
+        let inverse = 1 - amount
+        return Self(
+            b0: from.b0 * inverse + to.b0 * amount,
+            b1: from.b1 * inverse + to.b1 * amount,
+            b2: from.b2 * inverse + to.b2 * amount,
+            a1: from.a1 * inverse + to.a1 * amount,
+            a2: from.a2 * inverse + to.a2 * amount
+        )
+    }
+
     private init(b0: Float, b1: Float, b2: Float, a1: Float, a2: Float) {
-        self.b0 = b0; self.b1 = b1; self.b2 = b2; self.a1 = a1; self.a2 = a2
+        self.b0 = b0
+        self.b1 = b1
+        self.b2 = b2
+        self.a1 = a1
+        self.a2 = a2
+    }
+}
+
+/// State storage is manually retained by each published snapshot. The render
+/// callback sees only the raw z1/z2 pointers; the owner is retained and
+/// released during off-render reclamation.
+private final class BiquadStateStorage: @unchecked Sendable {
+    let z1: UnsafeMutablePointer<Float>
+    let z2: UnsafeMutablePointer<Float>
+
+    init(bandCount: Int) {
+        let capacity = max(1, bandCount)
+        z1 = .allocate(capacity: capacity)
+        z2 = .allocate(capacity: capacity)
+        if bandCount > 0 {
+            z1.initialize(repeating: 0, count: bandCount)
+            z2.initialize(repeating: 0, count: bandCount)
+        }
+    }
+
+    deinit {
+        z1.deallocate()
+        z2.deallocate()
     }
 }
 
 private struct BiquadSnapshot {
+    /// `coeffs` and `targetCoeffs` are immutable after publication. The
+    /// callback interpolates between them without allocating or mutating the
+    /// coefficient arrays.
     let coeffs: UnsafeMutablePointer<NormalizedBiquadCoeffs>
+    let targetCoeffs: UnsafeMutablePointer<NormalizedBiquadCoeffs>
     let z1: UnsafeMutablePointer<Float>
     let z2: UnsafeMutablePointer<Float>
+    /// Manually retained off the render path. This raw pointer is never read
+    /// by the callback and is released when the snapshot is reclaimed.
+    let stateOwner: UnsafeMutableRawPointer
     let bandCount: Int
+    let rampFrames: UInt32
+    let rampPosition: UnsafeMutablePointer<UInt32>
 }
 
-/// Real-time biquad chain with complete immutable coefficient/state snapshots.
-/// Main-actor publication allocates and reclaims snapshots. The callback only
-/// enters the raw-pointer quiescence protocol and mutates the selected state.
+/// Real-time biquad chain with complete coefficient/state snapshots.
+///
+/// Parameter updates preserve delay state when the band count is unchanged and
+/// linearly ramp coefficients over 64 frames. A band-count/topology change or
+/// an explicit reset publishes fresh zeroed state. This avoids mutating state
+/// that an in-flight callback may be using, while keeping ordinary drag edits
+/// continuous. All snapshot allocation, ownership, and reclamation happens
+/// off the render path.
 final class BiquadFilterChain: @unchecked Sendable {
+    static let coefficientRampFrames: UInt32 = 64
+
     private let publication: UnsafeMutablePointer<RTSnapshotPublication>
     private var retiredSnapshots: [UnsafeMutableRawPointer] = []
     private(set) var retiredSnapshotCount = 0
@@ -40,84 +98,230 @@ final class BiquadFilterChain: @unchecked Sendable {
     init(bands: [EQBand], sampleRate: Double) {
         publication = .allocate(capacity: 1)
         publication.initialize(to: RTSnapshotPublication())
-        let snapshot = Self.makeSnapshot(bands: bands, sampleRate: sampleRate)
+        let coefficients = Self.coefficients(for: bands, sampleRate: sampleRate)
+        let snapshot = Self.makeSnapshot(
+            targetCoefficients: coefficients,
+            startingCoefficients: nil,
+            stateOwner: nil,
+            rampFrames: 0
+        )
         _ = publishSnapshot(publication, UnsafeMutableRawPointer(snapshot))
     }
 
     deinit {
-        if let retired = publishSnapshot(publication, nil) { retiredSnapshots.append(retired) }
+        if let retired = publishSnapshot(publication, nil) {
+            retiredSnapshots.append(retired)
+        }
         waitForSnapshotQuiescence(publication)
         reclaimQuiescentSnapshots()
         publication.deinitialize(count: 1)
         publication.deallocate()
     }
 
-    func updateCoefficients(bands: [EQBand], sampleRate: Double) {
-        let replacement = Self.makeSnapshot(bands: bands, sampleRate: sampleRate)
-        if let retired = publishSnapshot(publication, UnsafeMutableRawPointer(replacement)) {
+    /// Update coefficients without touching the live callback state. When
+    /// `resetState` is true, the replacement starts with zero delay state,
+    /// which is the policy used for a preset switch. Ordinary live edits keep
+    /// the existing state storage when the topology is unchanged.
+    func updateCoefficients(bands: [EQBand], sampleRate: Double, resetState: Bool = false) {
+        let targetCoefficients = Self.coefficients(for: bands, sampleRate: sampleRate)
+        var startingCoefficients: [NormalizedBiquadCoeffs]?
+        var stateOwner: BiquadStateStorage?
+
+        let raw = rtEnter(publication)
+        if let raw {
+            let current = raw.assumingMemoryBound(to: BiquadSnapshot.self)
+            startingCoefficients = Self.effectiveCoefficients(current)
+            if !resetState && current.pointee.bandCount == targetCoefficients.count {
+                stateOwner = Unmanaged<BiquadStateStorage>
+                    .fromOpaque(current.pointee.stateOwner)
+                    .takeUnretainedValue()
+            }
+            rtLeave(publication)
+        } else {
+            // rtEnter increments before loading the pointer, so a nil result
+            // still needs the matching leave.
+            rtLeave(publication)
+        }
+
+        let snapshot = Self.makeSnapshot(
+            targetCoefficients: targetCoefficients,
+            startingCoefficients: startingCoefficients,
+            stateOwner: stateOwner,
+            rampFrames: startingCoefficients?.count == targetCoefficients.count
+                ? Self.coefficientRampFrames : 0
+        )
+        if let retired = publishSnapshot(publication, UnsafeMutableRawPointer(snapshot)) {
             retiredSnapshots.append(retired)
         }
         reclaimQuiescentSnapshots()
     }
 
+    /// Process one mono channel. The reader is released explicitly so the
+    /// callback has no deferred cleanup path or hidden ownership operation.
     func process(_ buffer: UnsafeMutablePointer<Float>, frameCount: Int) {
-        guard let raw = rtEnter(publication) else { return }
-        defer { rtLeave(publication) }
-        Self.processSnapshot(raw.assumingMemoryBound(to: BiquadSnapshot.self).pointee,
-                             buffer: buffer, frameCount: frameCount)
+        let raw = rtEnter(publication)
+        guard let raw else {
+            rtLeave(publication)
+            return
+        }
+        Self.processSnapshot(
+            raw.assumingMemoryBound(to: BiquadSnapshot.self),
+            buffer: buffer,
+            frameCount: frameCount
+        )
+        rtLeave(publication)
     }
 
-    static func processRT(_ opaque: UnsafeMutableRawPointer,
-                          buffer: UnsafeMutablePointer<Float>,
-                          frameCount: Int) {
+    static func processRT(
+        _ opaque: UnsafeMutableRawPointer,
+        buffer: UnsafeMutablePointer<Float>,
+        frameCount: Int
+    ) {
         let chain = Unmanaged<BiquadFilterChain>.fromOpaque(opaque).takeUnretainedValue()
         chain.process(buffer, frameCount: frameCount)
     }
 
+    /// Publish a zero-state snapshot with the current target coefficients.
+    /// This is safe even if the callback is active because the old state is
+    /// reclaimed only after the old snapshot has quiesced.
     func reset() {
-        guard let raw = rtEnter(publication) else { return }
-        defer { rtLeave(publication) }
-        let snapshot = raw.assumingMemoryBound(to: BiquadSnapshot.self).pointee
-        for i in 0..<snapshot.bandCount {
-            snapshot.z1[i] = 0
-            snapshot.z2[i] = 0
+        let raw = rtEnter(publication)
+        guard let raw else {
+            rtLeave(publication)
+            return
         }
+        let current = raw.assumingMemoryBound(to: BiquadSnapshot.self)
+        let target = Self.targetCoefficients(current)
+        rtLeave(publication)
+
+        let snapshot = Self.makeSnapshot(
+            targetCoefficients: target,
+            startingCoefficients: nil,
+            stateOwner: nil,
+            rampFrames: 0
+        )
+        if let retired = publishSnapshot(publication, UnsafeMutableRawPointer(snapshot)) {
+            retiredSnapshots.append(retired)
+        }
+        reclaimQuiescentSnapshots()
     }
 
     func currentSnapshotCounts() -> (coefficients: Int, state: Int, bands: Int) {
-        guard let raw = rtEnter(publication) else { return (0, 0, 0) }
-        defer { rtLeave(publication) }
+        let raw = rtEnter(publication)
+        guard let raw else {
+            rtLeave(publication)
+            return (0, 0, 0)
+        }
         let count = raw.assumingMemoryBound(to: BiquadSnapshot.self).pointee.bandCount
+        rtLeave(publication)
         return (count, count, count)
     }
 
-    private static func makeSnapshot(bands: [EQBand], sampleRate: Double)
-        -> UnsafeMutablePointer<BiquadSnapshot> {
-        let count = bands.count
-        let coeffs = UnsafeMutablePointer<NormalizedBiquadCoeffs>.allocate(capacity: count)
-        let z1 = UnsafeMutablePointer<Float>.allocate(capacity: count)
-        let z2 = UnsafeMutablePointer<Float>.allocate(capacity: count)
-        for (index, band) in bands.enumerated() {
-            coeffs[index] = NormalizedBiquadCoeffs(
-                from: BiquadResponse.coefficients(for: band, sampleRate: sampleRate))
-            z1[index] = 0
-            z2[index] = 0
+    /// Test-only visibility into the callback-owned ramp progress. The values
+    /// are loaded atomically and the snapshot remains protected for the read.
+    func rampStateForTesting() -> (position: UInt32, frames: UInt32) {
+        let raw = rtEnter(publication)
+        guard let raw else {
+            rtLeave(publication)
+            return (0, 0)
         }
+        let snapshot = raw.assumingMemoryBound(to: BiquadSnapshot.self)
+        let position = min(
+            iq_load_snapshot_u32(snapshot.pointee.rampPosition),
+            snapshot.pointee.rampFrames
+        )
+        let frames = snapshot.pointee.rampFrames
+        rtLeave(publication)
+        return (position, frames)
+    }
+
+    private static func coefficients(for bands: [EQBand], sampleRate: Double)
+        -> [NormalizedBiquadCoeffs] {
+        bands.map {
+            NormalizedBiquadCoeffs(
+                from: BiquadResponse.coefficients(for: $0, sampleRate: sampleRate)
+            )
+        }
+    }
+
+    private static func makeSnapshot(
+        targetCoefficients: [NormalizedBiquadCoeffs],
+        startingCoefficients: [NormalizedBiquadCoeffs]?,
+        stateOwner: BiquadStateStorage?,
+        rampFrames: UInt32
+    ) -> UnsafeMutablePointer<BiquadSnapshot> {
+        let count = targetCoefficients.count
+        let capacity = max(1, count)
+        let coeffs = UnsafeMutablePointer<NormalizedBiquadCoeffs>.allocate(capacity: capacity)
+        let targets = UnsafeMutablePointer<NormalizedBiquadCoeffs>.allocate(capacity: capacity)
+        let from = startingCoefficients?.count == count ? startingCoefficients! : targetCoefficients
+
+        if count > 0 {
+            for index in 0..<count {
+                coeffs[index] = from[index]
+                targets[index] = targetCoefficients[index]
+            }
+        }
+
+        let state = stateOwner ?? BiquadStateStorage(bandCount: count)
+        let retainedState = Unmanaged.passRetained(state).toOpaque()
+        let rampPosition = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
+        rampPosition.initialize(to: 0)
         let snapshot = UnsafeMutablePointer<BiquadSnapshot>.allocate(capacity: 1)
-        snapshot.initialize(to: BiquadSnapshot(coeffs: coeffs, z1: z1, z2: z2, bandCount: count))
+        snapshot.initialize(to: BiquadSnapshot(
+            coeffs: coeffs,
+            targetCoeffs: targets,
+            z1: state.z1,
+            z2: state.z2,
+            stateOwner: retainedState,
+            bandCount: count,
+            rampFrames: rampFrames,
+            rampPosition: rampPosition
+        ))
         return snapshot
     }
 
+    private static func targetCoefficients(
+        _ snapshot: UnsafeMutablePointer<BiquadSnapshot>
+    ) -> [NormalizedBiquadCoeffs] {
+        let count = snapshot.pointee.bandCount
+        guard count > 0 else { return [] }
+        return (0..<count).map { snapshot.pointee.targetCoeffs[$0] }
+    }
+
+    private static func effectiveCoefficients(
+        _ snapshot: UnsafeMutablePointer<BiquadSnapshot>
+    ) -> [NormalizedBiquadCoeffs] {
+        let count = snapshot.pointee.bandCount
+        guard count > 0 else { return [] }
+
+        let frames = snapshot.pointee.rampFrames
+        let position = min(
+            iq_load_snapshot_u32(snapshot.pointee.rampPosition),
+            frames
+        )
+        let amount = frames == 0 ? Float(1) : Float(position) / Float(frames)
+        return (0..<count).map {
+            NormalizedBiquadCoeffs.interpolate(
+                snapshot.pointee.coeffs[$0],
+                snapshot.pointee.targetCoeffs[$0],
+                amount: amount
+            )
+        }
+    }
+
     private static func destroySnapshot(_ snapshot: UnsafeMutablePointer<BiquadSnapshot>) {
+        let stateOwner = snapshot.pointee.stateOwner
         snapshot.pointee.coeffs.deallocate()
-        snapshot.pointee.z1.deallocate()
-        snapshot.pointee.z2.deallocate()
+        snapshot.pointee.targetCoeffs.deallocate()
+        snapshot.pointee.rampPosition.deallocate()
         snapshot.deinitialize(count: 1)
         snapshot.deallocate()
+        Unmanaged<BiquadStateStorage>.fromOpaque(stateOwner).release()
     }
 
     private func reclaimQuiescentSnapshots() {
-        guard iq_load_acquire_u32(&publication.pointee.readers) == 0 else { return }
+        guard iq_load_snapshot_readers(&publication.pointee.readers) == 0 else { return }
         let retired = retiredSnapshots
         retiredSnapshots.removeAll(keepingCapacity: true)
         for pointer in retired {
@@ -128,25 +332,63 @@ final class BiquadFilterChain: @unchecked Sendable {
     }
 
     @inline(__always)
-    private static func processSnapshot(_ snapshot: BiquadSnapshot,
-                                        buffer: UnsafeMutablePointer<Float>,
-                                        frameCount: Int) {
+    private static func processSnapshot(
+        _ snapshot: UnsafeMutablePointer<BiquadSnapshot>,
+        buffer: UnsafeMutablePointer<Float>,
+        frameCount: Int
+    ) {
         guard frameCount > 0 else { return }
-        for b in 0..<snapshot.bandCount {
-            let c = snapshot.coeffs[b]
-            var s1 = snapshot.z1[b]
-            var s2 = snapshot.z2[b]
-            for f in 0..<frameCount {
-                let x = buffer[f]
-                let y = c.b0 * x + s1
-                s1 = c.b1 * x - c.a1 * y + s2
-                s2 = c.b2 * x - c.a2 * y
-                buffer[f] = y
+        let bandCount = snapshot.pointee.bandCount
+        guard bandCount > 0 else { return }
+
+        let rampFrames = snapshot.pointee.rampFrames
+        let initialPosition = min(
+            iq_load_snapshot_u32(snapshot.pointee.rampPosition),
+            rampFrames
+        )
+
+        // The chain is cascaded band-by-band. Each band gets the same
+        // coefficient for a given frame, so the frame position is restarted
+        // for every band rather than advanced once per band.
+        for band in 0..<bandCount {
+            var position = initialPosition
+            var s1 = snapshot.pointee.z1[band]
+            var s2 = snapshot.pointee.z2[band]
+            let from = snapshot.pointee.coeffs[band]
+            let target = snapshot.pointee.targetCoeffs[band]
+
+            for frame in 0..<frameCount {
+                let coefficients: NormalizedBiquadCoeffs
+                if rampFrames == 0 || position >= rampFrames {
+                    coefficients = target
+                } else {
+                    coefficients = NormalizedBiquadCoeffs.interpolate(
+                        from,
+                        target,
+                        amount: Float(position) / Float(rampFrames)
+                    )
+                }
+
+                let x = buffer[frame]
+                let y = coefficients.b0 * x + s1
+                s1 = coefficients.b1 * x - coefficients.a1 * y + s2
+                s2 = coefficients.b2 * x - coefficients.a2 * y
+                buffer[frame] = y
+
+                if position < rampFrames {
+                    position += 1
+                }
             }
+
             if abs(s1) < 1e-15 { s1 = 0 }
             if abs(s2) < 1e-15 { s2 = 0 }
-            snapshot.z1[b] = s1
-            snapshot.z2[b] = s2
+            snapshot.pointee.z1[band] = s1
+            snapshot.pointee.z2[band] = s2
         }
+
+        let frameDelta = UInt32(clamping: frameCount)
+        let remaining = rampFrames - initialPosition
+        let finalPosition = initialPosition + min(frameDelta, remaining)
+        iq_store_snapshot_u32(snapshot.pointee.rampPosition, finalPosition)
     }
 }

--- a/Sources/iQualize/CaptureClient.swift
+++ b/Sources/iQualize/CaptureClient.swift
@@ -447,4 +447,17 @@ final class CaptureClient: @unchecked Sendable {
                              ((ratio - 1) * 1e6).bitPattern)
         return frames
     }
+
+    /// Raw-pointer bridge for the audio callback. AudioEngine's publication
+    /// quiescence protocol keeps the owning CaptureClient alive until every
+    /// reader has left, so this conversion never takes ownership or performs
+    /// callback-side ARC traffic.
+    static func readResampledRT(
+        _ opaque: UnsafeMutableRawPointer,
+        destination: UnsafeMutablePointer<Float>,
+        frames: Int
+    ) -> Int {
+        let client = Unmanaged<CaptureClient>.fromOpaque(opaque).takeUnretainedValue()
+        return client.readResampled(destination, frames: frames)
+    }
 }

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.57.5</string>
+	<string>0.58.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.57.5</string>
+	<string>0.58</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/RTSnapshotPublication.swift
+++ b/Sources/iQualize/RTSnapshotPublication.swift
@@ -9,6 +9,12 @@ import IQRingAtomics
 /// retired storage. This is a quiescence protocol, not reference counting:
 /// the callback never retains, releases, allocates, locks, or deallocates a
 /// Swift object.
+///
+/// Publication has one writer. `AudioEngine` performs outer publication on the
+/// main actor, and `BiquadFilterChain` updates are likewise serialized by its
+/// owning main-actor path. Reader entry and processing remain safe while a
+/// publication is in flight; concurrent publishers would need a separate
+/// writer-side serialization boundary.
 struct RTSnapshotPublication {
     var current: UnsafeMutableRawPointer?
     var readers: UInt32
@@ -22,17 +28,17 @@ struct RTSnapshotPublication {
 @inline(__always)
 func rtEnter(_ publication: UnsafeMutablePointer<RTSnapshotPublication>) -> UnsafeMutableRawPointer? {
     withUnsafeMutablePointer(to: &publication.pointee.readers) { readers in
-        _ = iq_fetch_add_acq_rel_u32(readers, 1)
+        _ = iq_enter_snapshot_reader(readers)
     }
     return withUnsafePointer(to: &publication.pointee.current) { current in
-        iq_load_acquire_ptr(current)
+        iq_load_snapshot_ptr(current)
     }
 }
 
 @inline(__always)
 func rtLeave(_ publication: UnsafeMutablePointer<RTSnapshotPublication>) {
     withUnsafeMutablePointer(to: &publication.pointee.readers) { readers in
-        _ = iq_fetch_sub_release_u32(readers, 1)
+        _ = iq_leave_snapshot_reader(readers)
     }
 }
 
@@ -42,7 +48,7 @@ func publishSnapshot(
     _ replacement: UnsafeMutableRawPointer?
 ) -> UnsafeMutableRawPointer? {
     withUnsafeMutablePointer(to: &publication.pointee.current) { current in
-        iq_exchange_acq_rel_ptr(current, replacement)
+        iq_exchange_snapshot_ptr(current, replacement)
     }
 }
 
@@ -50,7 +56,7 @@ func publishSnapshot(
 func waitForSnapshotQuiescence(_ publication: UnsafeMutablePointer<RTSnapshotPublication>) {
     while true {
         let readers = withUnsafePointer(to: &publication.pointee.readers) { pointer in
-            iq_load_acquire_u32(pointer)
+            iq_load_snapshot_readers(pointer)
         }
         if readers == 0 { return }
         usleep(100)

--- a/Sources/iQualize/RTSnapshotPublication.swift
+++ b/Sources/iQualize/RTSnapshotPublication.swift
@@ -1,0 +1,58 @@
+import Darwin
+import IQRingAtomics
+
+/// Lock-free publication state for an opaque, manually managed snapshot.
+///
+/// The render thread enters before loading `current` and leaves only after the
+/// snapshot is no longer referenced. The main actor exchanges a fully
+/// initialized snapshot, waits for `readers == 0`, and only then destroys the
+/// retired storage. This is a quiescence protocol, not reference counting:
+/// the callback never retains, releases, allocates, locks, or deallocates a
+/// Swift object.
+struct RTSnapshotPublication {
+    var current: UnsafeMutableRawPointer?
+    var readers: UInt32
+
+    init() {
+        current = nil
+        readers = 0
+    }
+}
+
+@inline(__always)
+func rtEnter(_ publication: UnsafeMutablePointer<RTSnapshotPublication>) -> UnsafeMutableRawPointer? {
+    withUnsafeMutablePointer(to: &publication.pointee.readers) { readers in
+        _ = iq_fetch_add_acq_rel_u32(readers, 1)
+    }
+    return withUnsafePointer(to: &publication.pointee.current) { current in
+        iq_load_acquire_ptr(current)
+    }
+}
+
+@inline(__always)
+func rtLeave(_ publication: UnsafeMutablePointer<RTSnapshotPublication>) {
+    withUnsafeMutablePointer(to: &publication.pointee.readers) { readers in
+        _ = iq_fetch_sub_release_u32(readers, 1)
+    }
+}
+
+@inline(__always)
+func publishSnapshot(
+    _ publication: UnsafeMutablePointer<RTSnapshotPublication>,
+    _ replacement: UnsafeMutableRawPointer?
+) -> UnsafeMutableRawPointer? {
+    withUnsafeMutablePointer(to: &publication.pointee.current) { current in
+        iq_exchange_acq_rel_ptr(current, replacement)
+    }
+}
+
+/// Wait on the publishing thread only. The audio callback never waits.
+func waitForSnapshotQuiescence(_ publication: UnsafeMutablePointer<RTSnapshotPublication>) {
+    while true {
+        let readers = withUnsafePointer(to: &publication.pointee.readers) { pointer in
+            iq_load_acquire_u32(pointer)
+        }
+        if readers == 0 { return }
+        usleep(100)
+    }
+}

--- a/Sources/iQualize/SpectrumAnalyzer.swift
+++ b/Sources/iQualize/SpectrumAnalyzer.swift
@@ -27,6 +27,7 @@ final class SpectrumAnalyzer: @unchecked Sendable {
     private let imagp: UnsafeMutablePointer<Float>
     private let magnitudes: UnsafeMutablePointer<Float>
     private let dbMags: UnsafeMutablePointer<Float>
+    private let monoMixScale: UnsafeMutablePointer<Float>
 
     // Smoothing state (owned by audio thread — no synchronization needed)
     private let smoothedMagnitudes: UnsafeMutablePointer<Float>
@@ -64,6 +65,8 @@ final class SpectrumAnalyzer: @unchecked Sendable {
         magnitudes.initialize(repeating: 0, count: 1024)
         dbMags = .allocate(capacity: 1024)
         dbMags.initialize(repeating: 0, count: 1024)
+        monoMixScale = .allocate(capacity: 1)
+        monoMixScale.initialize(to: 0)
 
         smoothedMagnitudes = .allocate(capacity: 128)
         smoothedMagnitudes.initialize(repeating: -90.0, count: 128)
@@ -80,6 +83,7 @@ final class SpectrumAnalyzer: @unchecked Sendable {
         imagp.deallocate()
         magnitudes.deallocate()
         dbMags.deallocate()
+        monoMixScale.deallocate()
         smoothedMagnitudes.deallocate()
         peakMagnitudes.deallocate()
         peakHoldCounters.deallocate()
@@ -101,9 +105,10 @@ final class SpectrumAnalyzer: @unchecked Sendable {
             // Zero mono buffer first
             memset(mono, 0, fftSize * MemoryLayout<Float>.size)
             let scale = 1.0 / Float(channelCount)
+            monoMixScale.pointee = scale
             for ch in 0..<channelCount {
                 // mono[i] += channelData[ch][i] * scale
-                vDSP_vsma(channelData[ch], 1, [scale], mono, 1, mono, 1, vDSP_Length(samplesToProcess))
+                vDSP_vsma(channelData[ch], 1, monoMixScale, mono, 1, mono, 1, vDSP_Length(samplesToProcess))
             }
         }
 

--- a/Tests/iQualizeTests/BiquadFilterChainTests.swift
+++ b/Tests/iQualizeTests/BiquadFilterChainTests.swift
@@ -43,4 +43,74 @@ final class BiquadFilterChainTests: XCTestCase {
 
         XCTAssertTrue(buffer.allSatisfy { $0.isFinite })
     }
+
+    func testCoefficientRampCompletesAfterConfiguredFrameCount() {
+        let chain = BiquadFilterChain(bands: [band(1000, gain: 0)], sampleRate: 48000)
+        chain.updateCoefficients(
+            bands: [band(1000, gain: 12)],
+            sampleRate: 48000
+        )
+
+        XCTAssertEqual(chain.rampStateForTesting().frames, BiquadFilterChain.coefficientRampFrames)
+        XCTAssertEqual(chain.rampStateForTesting().position, 0)
+
+        var buffer = [Float](repeating: 0, count: Int(BiquadFilterChain.coefficientRampFrames))
+        buffer[0] = 1
+        buffer.withUnsafeMutableBufferPointer { pointer in
+            chain.process(pointer.baseAddress!, frameCount: pointer.count)
+        }
+
+        let ramp = chain.rampStateForTesting()
+        XCTAssertEqual(ramp.position, BiquadFilterChain.coefficientRampFrames)
+        XCTAssertEqual(ramp.frames, BiquadFilterChain.coefficientRampFrames)
+        XCTAssertTrue(buffer.allSatisfy { $0.isFinite })
+    }
+
+    func testResetPublishesZeroStateWithoutDroppingFilterConfiguration() {
+        let chain = BiquadFilterChain(bands: [band(1000, gain: 6)], sampleRate: 48000)
+        var impulse = [Float](repeating: 0, count: 128)
+        impulse[0] = 1
+        impulse.withUnsafeMutableBufferPointer { pointer in
+            chain.process(pointer.baseAddress!, frameCount: pointer.count)
+        }
+        XCTAssertTrue(impulse.dropFirst().contains { $0 != 0 })
+
+        chain.reset()
+
+        XCTAssertEqual(chain.currentSnapshotCounts().bands, 1)
+        let ramp = chain.rampStateForTesting()
+        XCTAssertEqual(ramp.frames, 0)
+        XCTAssertEqual(ramp.position, 0)
+
+        var silence = [Float](repeating: 0, count: 128)
+        silence.withUnsafeMutableBufferPointer { pointer in
+            chain.process(pointer.baseAddress!, frameCount: pointer.count)
+        }
+        XCTAssertTrue(silence.allSatisfy { $0 == 0 })
+    }
+
+    func testPresetResetStartsWithZeroStateWhileStillRampingCoefficients() {
+        let chain = BiquadFilterChain(bands: [band(1000, gain: 0)], sampleRate: 48000)
+        var impulse = [Float](repeating: 0, count: 128)
+        impulse[0] = 1
+        impulse.withUnsafeMutableBufferPointer { pointer in
+            chain.process(pointer.baseAddress!, frameCount: pointer.count)
+        }
+
+        chain.updateCoefficients(
+            bands: [band(1000, gain: 12)],
+            sampleRate: 48000,
+            resetState: true
+        )
+
+        let ramp = chain.rampStateForTesting()
+        XCTAssertEqual(ramp.frames, BiquadFilterChain.coefficientRampFrames)
+        XCTAssertEqual(ramp.position, 0)
+
+        var silence = [Float](repeating: 0, count: 128)
+        silence.withUnsafeMutableBufferPointer { pointer in
+            chain.process(pointer.baseAddress!, frameCount: pointer.count)
+        }
+        XCTAssertTrue(silence.allSatisfy { $0 == 0 })
+    }
 }

--- a/Tests/iQualizeTests/RenderConfigurationPublicationTests.swift
+++ b/Tests/iQualizeTests/RenderConfigurationPublicationTests.swift
@@ -1,0 +1,264 @@
+import XCTest
+import AVFAudio
+@testable import iQualize
+
+final class RenderConfigurationPublicationTests: XCTestCase {
+
+    private final class FailureBox: @unchecked Sendable {
+        let lock = NSLock()
+        var value = false
+    }
+    private var retainedChains: [BiquadFilterChain] = []
+
+    override func tearDown() {
+        _ = publishRenderConfigurationForTesting(nil)
+        _ = reclaimQuiescentRenderConfigurationsForTesting()
+        retainedChains.removeAll()
+        super.tearDown()
+    }
+
+    private func band(_ frequency: Float, gain: Float = 3.0) -> EQBand {
+        EQBand(frequency: frequency, gain: gain, bandwidth: 1.0, filterType: .parametric)
+    }
+
+    private func bands(_ count: Int) -> [EQBand] {
+        (0..<count).map { band(Float(40 + $0 * 90)) }
+    }
+
+    private func bandCount(_ pointer: UnsafeMutableRawPointer?) -> Int {
+        guard let pointer else { return -1 }
+        return Unmanaged<BiquadFilterChain>.fromOpaque(pointer)
+            .takeUnretainedValue()
+            .currentSnapshotCounts()
+            .bands
+    }
+
+    private func configuration(
+        leftCount: Int,
+        rightCount: Int,
+        inputGain: Float = 1,
+        balanceLeft: Float = 1,
+        balanceRight: Float = 1
+    ) -> RenderConfiguration {
+        let left = BiquadFilterChain(bands: bands(leftCount), sampleRate: 48000)
+        let right = BiquadFilterChain(bands: bands(rightCount), sampleRate: 48000)
+        retainedChains.append(contentsOf: [left, right])
+        return RenderConfiguration(
+            captureClient: nil,
+            channelCount: 2,
+            scratchBuffer: nil,
+            scratchCapacity: 0,
+            balanceLeft: balanceLeft,
+            balanceRight: balanceRight,
+            inputGain: inputGain,
+            volumeCompensation: 1,
+            biquadChainL: left,
+            biquadChainR: right
+        )
+    }
+
+    func testReaderObservesCompleteOldOrNewConfigurationWhileBandCountsAlternate() {
+        let old = configuration(leftCount: 1, rightCount: 4, inputGain: 0.5)
+        XCTAssertEqual(publishRenderConfigurationForTesting(old), 0)
+
+        let held = acquireRenderConfigurationForTesting()
+        XCTAssertEqual(held.configurationForTesting?.inputGain, 0.5)
+        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainL), 1)
+        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainR), 4)
+
+        let new = configuration(leftCount: 40, rightCount: 2, inputGain: 2)
+        XCTAssertEqual(publishRenderConfigurationForTesting(new), 1, "old snapshot must be retired, not reclaimed, while a reader holds it")
+
+        XCTAssertEqual(held.configurationForTesting?.inputGain, 0.5)
+        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainL), 1)
+        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainR), 4)
+        held.releaseRead()
+
+        XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 0)
+        let latest = acquireRenderConfigurationForTesting()
+        defer { latest.releaseRead() }
+        XCTAssertEqual(latest.configurationForTesting?.inputGain, 2)
+        XCTAssertEqual(bandCount(latest.configurationForTesting?.biquadChainL), 40)
+        XCTAssertEqual(bandCount(latest.configurationForTesting?.biquadChainR), 2)
+    }
+
+    func testPublishedConfigurationDoesNotExposeMixedGainAndChainState() {
+        let states: [(Float, Int, Int)] = [(0.25, 1, 3), (1.5, 36, 2), (0.75, 4, 44)]
+
+        for state in states {
+            XCTAssertGreaterThanOrEqual(
+                publishRenderConfigurationForTesting(configuration(leftCount: state.1, rightCount: state.2, inputGain: state.0)),
+                0
+            )
+            let handle = acquireRenderConfigurationForTesting()
+            let snapshot = handle.configurationForTesting
+            let observed = (
+                snapshot?.inputGain ?? -1,
+                bandCount(snapshot?.biquadChainL),
+                bandCount(snapshot?.biquadChainR)
+            )
+            handle.releaseRead()
+            XCTAssertTrue(
+                states.contains { $0.0 == observed.0 && $0.1 == observed.1 && $0.2 == observed.2 },
+                "observed mixed state: \(observed)"
+            )
+        }
+    }
+
+    func testRetirementWaitsForQuiescenceAndReclaimsOffRenderPath() {
+        XCTAssertEqual(publishRenderConfigurationForTesting(configuration(leftCount: 2, rightCount: 2)), 0)
+        let reader = acquireRenderConfigurationForTesting()
+        XCTAssertNotNil(reader.configurationForTesting)
+
+        XCTAssertEqual(publishRenderConfigurationForTesting(configuration(leftCount: 3, rightCount: 3)), 1)
+        XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 1)
+
+        reader.releaseRead()
+        XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 0)
+    }
+
+    func testFixedConfigurationOutputIsUnchangedAcrossEquivalentFreshSnapshots() {
+        let input = (0..<512).map { Float(sin(Double($0) * 0.07)) }
+        var first = input
+        var second = input
+        let bands = [band(125, gain: -2), band(1000, gain: 5), band(8000, gain: 1)]
+
+        first.withUnsafeMutableBufferPointer { ptr in
+            BiquadFilterChain(bands: bands, sampleRate: 48000).process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+        second.withUnsafeMutableBufferPointer { ptr in
+            BiquadFilterChain(bands: bands, sampleRate: 48000).process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.allSatisfy { $0.isFinite })
+    }
+
+    func testThirtyOneBandBoundaryDoesNotRequireOverflowChain() {
+        let config = RenderConfiguration(
+            captureClient: nil,
+            channelCount: 2,
+            scratchBuffer: nil,
+            scratchCapacity: 0,
+            balanceLeft: 1,
+            balanceRight: 1,
+            inputGain: 1,
+            volumeCompensation: 1,
+            biquadChainL: nil,
+            biquadChainR: nil
+        )
+        XCTAssertFalse(config.biquadChainActive)
+
+        let chain = BiquadFilterChain(bands: bands(31), sampleRate: 48000)
+        XCTAssertEqual(chain.currentSnapshotCounts().bands, 31)
+        var buffer = [Float](repeating: 0, count: 128)
+        buffer[0] = 1
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            chain.process(ptr.baseAddress!, frameCount: ptr.count)
+        }
+        XCTAssertTrue(buffer.allSatisfy { $0.isFinite })
+    }
+
+    func testRenderScratchOverflowPolicyRejectsOversizedAndIntegerOverflowingSlices() {
+        XCTAssertTrue(renderScratchCapacityAllows(frameCount: 4096, channelCount: 2, scratchCapacity: 8192))
+        XCTAssertFalse(renderScratchCapacityAllows(frameCount: 4097, channelCount: 2, scratchCapacity: 8192))
+        XCTAssertFalse(renderScratchCapacityAllows(frameCount: Int.max, channelCount: 2, scratchCapacity: Int.max))
+        XCTAssertFalse(renderScratchCapacityAllows(frameCount: -1, channelCount: 2, scratchCapacity: 8192))
+    }
+
+    func testSpectrumAnalyzerProcessesRepeatedStereoBuffersWithoutChangingOutputShape() {
+        let analyzer = SpectrumAnalyzer()
+        let format = AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 2048)!
+        buffer.frameLength = 2048
+        for channel in 0..<2 {
+            let samples = buffer.floatChannelData![channel]
+            for frame in 0..<2048 {
+                samples[frame] = sin(Float(frame) * 0.03)
+            }
+        }
+
+        for _ in 0..<32 {
+            analyzer.process(buffer, sampleRate: 48_000)
+        }
+
+        var magnitudes = [Float](repeating: 0, count: SpectrumData.binCount)
+        var peaks = [Float](repeating: 0, count: SpectrumData.binCount)
+        magnitudes.withUnsafeMutableBufferPointer { magnitudePointer in
+            peaks.withUnsafeMutableBufferPointer { peakPointer in
+                analyzer.spectrumData.read(magnitudePointer.baseAddress!, peaks: peakPointer.baseAddress!)
+            }
+        }
+        XCTAssertEqual(magnitudes.count, SpectrumData.binCount)
+        XCTAssertEqual(peaks.count, SpectrumData.binCount)
+        XCTAssertTrue(magnitudes.allSatisfy(\.isFinite))
+        XCTAssertTrue(peaks.allSatisfy(\.isFinite))
+    }
+
+    func testMoreThanThirtyOneBandsRemainUnlimitedAndFinite() {
+        for count in [32, 64, 96] {
+            let chain = BiquadFilterChain(bands: bands(count), sampleRate: 48000)
+            XCTAssertEqual(chain.currentSnapshotCounts().bands, count)
+            var buffer = [Float](repeating: 0, count: 256)
+            buffer[0] = 1
+            buffer.withUnsafeMutableBufferPointer { ptr in
+                chain.process(ptr.baseAddress!, frameCount: ptr.count)
+            }
+            XCTAssertTrue(buffer.allSatisfy { $0.isFinite }, "non-finite output at \(count) bands")
+            XCTAssertTrue(buffer.contains { $0 != 0 }, "silent output at \(count) bands")
+        }
+    }
+
+    func testAlternatingBandCountsWhileProcessingRemainConsistentAndFinite() {
+        let chain = BiquadFilterChain(bands: bands(1), sampleRate: 48000)
+        let queue = DispatchQueue(label: "iqualize.m3.publication", attributes: .concurrent)
+        let group = DispatchGroup()
+        let failure = FailureBox()
+
+        group.enter()
+        queue.async {
+            for iteration in 0..<400 {
+                let count = iteration.isMultiple(of: 2) ? 1 : 96
+                chain.updateCoefficients(
+                    bands: (0..<count).map {
+                        EQBand(frequency: Float(40 + $0 * 90), gain: 3, bandwidth: 1, filterType: .parametric)
+                    },
+                    sampleRate: 48000
+                )
+            }
+            group.leave()
+        }
+
+        group.enter()
+        queue.async {
+            for _ in 0..<2_000 {
+                let counts = chain.currentSnapshotCounts()
+                if counts.coefficients != counts.state || counts.state != counts.bands {
+                    failure.lock.lock()
+                    failure.value = true
+                    failure.lock.unlock()
+                    break
+                }
+
+                var buffer = [Float](repeating: 0, count: 64)
+                buffer[0] = 1
+                buffer.withUnsafeMutableBufferPointer { pointer in
+                    chain.process(pointer.baseAddress!, frameCount: pointer.count)
+                }
+                if !buffer.allSatisfy(\.isFinite) {
+                    failure.lock.lock()
+                    failure.value = true
+                    failure.lock.unlock()
+                    break
+                }
+            }
+            group.leave()
+        }
+
+        group.wait()
+        failure.lock.lock()
+        let failed = failure.value
+        failure.lock.unlock()
+        XCTAssertFalse(failed)
+    }
+}

--- a/Tests/iQualizeTests/RenderConfigurationPublicationTests.swift
+++ b/Tests/iQualizeTests/RenderConfigurationPublicationTests.swift
@@ -25,7 +25,7 @@ final class RenderConfigurationPublicationTests: XCTestCase {
         (0..<count).map { band(Float(40 + $0 * 90)) }
     }
 
-    private func bandCount(_ pointer: UnsafeMutableRawPointer?) -> Int {
+    private static func bandCount(_ pointer: UnsafeMutableRawPointer?) -> Int {
         guard let pointer else { return -1 }
         return Unmanaged<BiquadFilterChain>.fromOpaque(pointer)
             .takeUnretainedValue()
@@ -63,23 +63,23 @@ final class RenderConfigurationPublicationTests: XCTestCase {
 
         let held = acquireRenderConfigurationForTesting()
         XCTAssertEqual(held.configurationForTesting?.inputGain, 0.5)
-        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainL), 1)
-        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainR), 4)
+        XCTAssertEqual(Self.bandCount(held.configurationForTesting?.biquadChainL), 1)
+        XCTAssertEqual(Self.bandCount(held.configurationForTesting?.biquadChainR), 4)
 
         let new = configuration(leftCount: 40, rightCount: 2, inputGain: 2)
         XCTAssertEqual(publishRenderConfigurationForTesting(new), 1, "old snapshot must be retired, not reclaimed, while a reader holds it")
 
         XCTAssertEqual(held.configurationForTesting?.inputGain, 0.5)
-        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainL), 1)
-        XCTAssertEqual(bandCount(held.configurationForTesting?.biquadChainR), 4)
+        XCTAssertEqual(Self.bandCount(held.configurationForTesting?.biquadChainL), 1)
+        XCTAssertEqual(Self.bandCount(held.configurationForTesting?.biquadChainR), 4)
         held.releaseRead()
 
         XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 0)
         let latest = acquireRenderConfigurationForTesting()
         defer { latest.releaseRead() }
         XCTAssertEqual(latest.configurationForTesting?.inputGain, 2)
-        XCTAssertEqual(bandCount(latest.configurationForTesting?.biquadChainL), 40)
-        XCTAssertEqual(bandCount(latest.configurationForTesting?.biquadChainR), 2)
+        XCTAssertEqual(Self.bandCount(latest.configurationForTesting?.biquadChainL), 40)
+        XCTAssertEqual(Self.bandCount(latest.configurationForTesting?.biquadChainR), 2)
     }
 
     func testPublishedConfigurationDoesNotExposeMixedGainAndChainState() {
@@ -94,8 +94,8 @@ final class RenderConfigurationPublicationTests: XCTestCase {
             let snapshot = handle.configurationForTesting
             let observed = (
                 snapshot?.inputGain ?? -1,
-                bandCount(snapshot?.biquadChainL),
-                bandCount(snapshot?.biquadChainR)
+                Self.bandCount(snapshot?.biquadChainL),
+                Self.bandCount(snapshot?.biquadChainR)
             )
             handle.releaseRead()
             XCTAssertTrue(
@@ -103,6 +103,65 @@ final class RenderConfigurationPublicationTests: XCTestCase {
                 "observed mixed state: \(observed)"
             )
         }
+    }
+
+    func testConcurrentReaderSeesOnlyCompletePublishedConfigurations() {
+        let first = configuration(leftCount: 2, rightCount: 5, inputGain: 0.25)
+        let second = configuration(leftCount: 48, rightCount: 3, inputGain: 1.75)
+        let expected: [(Float, Int, Int)] = [
+            (0.25, 2, 5),
+            (1.75, 48, 3)
+        ]
+        XCTAssertEqual(publishRenderConfigurationForTesting(first), 0)
+
+        let queue = DispatchQueue(label: "iqualize.m3.outer-publication", attributes: .concurrent)
+        let group = DispatchGroup()
+        let failure = FailureBox()
+
+        group.enter()
+        queue.async {
+            for iteration in 0..<1_000 {
+                _ = publishRenderConfigurationForTesting(iteration.isMultiple(of: 2) ? first : second)
+            }
+            group.leave()
+        }
+
+        group.enter()
+        queue.async {
+            for _ in 0..<10_000 {
+                let handle = acquireRenderConfigurationForTesting()
+                guard let snapshot = handle.configurationForTesting else {
+                    handle.releaseRead()
+                    failure.lock.lock()
+                    failure.value = true
+                    failure.lock.unlock()
+                    continue
+                }
+
+                let observed = (
+                    snapshot.inputGain,
+                    Self.bandCount(snapshot.biquadChainL),
+                    Self.bandCount(snapshot.biquadChainR)
+                )
+                handle.releaseRead()
+
+                if !expected.contains(where: {
+                    $0.0 == observed.0 && $0.1 == observed.1 && $0.2 == observed.2
+                }) {
+                    failure.lock.lock()
+                    failure.value = true
+                    failure.lock.unlock()
+                    break
+                }
+            }
+            group.leave()
+        }
+
+        group.wait()
+        failure.lock.lock()
+        let failed = failure.value
+        failure.lock.unlock()
+        XCTAssertFalse(failed)
     }
 
     func testRetirementWaitsForQuiescenceAndReclaimsOffRenderPath() {
@@ -115,6 +174,39 @@ final class RenderConfigurationPublicationTests: XCTestCase {
 
         reader.releaseRead()
         XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 0)
+    }
+
+    func testPublishedSnapshotRetainsChainUntilReaderQuiescesAndReclaims() {
+        weak var weakChain: BiquadFilterChain?
+        do {
+            let chain = BiquadFilterChain(bands: bands(1), sampleRate: 48000)
+            weakChain = chain
+            let configuration = RenderConfiguration(
+                captureClient: nil,
+                channelCount: 2,
+                scratchBuffer: nil,
+                scratchCapacity: 0,
+                balanceLeft: 1,
+                balanceRight: 1,
+                inputGain: 1,
+                volumeCompensation: 1,
+                biquadChainL: chain,
+                biquadChainR: nil
+            )
+            XCTAssertEqual(publishRenderConfigurationForTesting(configuration), 0)
+        }
+
+        XCTAssertNotNil(weakChain)
+        let reader = acquireRenderConfigurationForTesting()
+        XCTAssertNotNil(reader.configurationForTesting?.biquadChainL)
+
+        _ = publishRenderConfigurationForTesting(nil)
+        XCTAssertNotNil(weakChain)
+        XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 1)
+
+        reader.releaseRead()
+        XCTAssertEqual(reclaimQuiescentRenderConfigurationsForTesting(), 0)
+        XCTAssertNil(weakChain)
     }
 
     func testFixedConfigurationOutputIsUnchangedAcrossEquivalentFreshSnapshots() {


### PR DESCRIPTION
## Summary
- Recover and land the M3 real-time audio state architecture from the side worktree.
- Publish complete immutable render configurations with sequentially consistent reader protection and off-render reclamation.
- Preserve live filter state for edits, ramp coefficient changes over 64 frames, and reset state on preset changes.
- Bump the app to 0.58.0 and document the changes in `CHANGELOG.md`.

## Scope
- Render callbacks no longer observe mixed mutable configuration state.
- Render-thread scratch buffers and spectrum scale data are preallocated. Oversized render slices return silence instead of allocating.
- Added publication, filter transition, and concurrent-reader regression coverage.
- No release tag or GitHub release is created by this PR.

Fixes #152
Fixes #164
Fixes #173
Fixes #174

## Test plan
- [x] Focused M3 tests: 22/22 passed.
- [x] Full `swift test`: 146/146 passed.
- [x] `swift build -c release` passed.
- [x] `bash scripts/install.sh` completed.
- [x] Installed app launched successfully and remained running.
- [x] Installed CLI reported version `0.58.0`.
- [x] Manual listening test for zipper noise and preset transitions.
