### PR TITLE
docs(release): add v0.58.0 prerelease highlights

### DIFF
--- a/.github/release-notes/highlights/v0.58.0.md
+++ b/.github/release-notes/highlights/v0.58.0.md
@@ -1,0 +1,6 @@
+<!-- title: v0.58.0 prerelease — Real-time audio state publication -->
+## Highlights
+
+- **Render callbacks now see complete configurations.** Audio settings publish as immutable snapshots with sequentially consistent reader protection and off-render reclamation, so a callback observes the old or new configuration instead of mixed state during updates (#164, #173).
+- **EQ edits transition without zippering.** Live biquad edits reuse filter state and ramp coefficient changes over 64 frames. Preset switches reset filter state cleanly, while explicit resets publish a fresh zero-state snapshot (#174).
+- **The real-time callback no longer grows buffers.** Render scratch storage and spectrum scale data are preallocated. Oversized render slices return silence instead of allocating, while unlimited EQ band counts remain supported (#152).


### PR DESCRIPTION
## Summary
- Add the curated highlights consumed by the v0.58.0 prerelease workflow.

## Scope
- Release notes only. No source or version changes.
- No tag or GitHub release is created by this PR.

## Test plan
- [x] `git diff --check`
- [x] Verified the highlights file uses the required title directive and `## Highlights` section.