### PR TITLE
docs(release): add v0.58.0 release song

### DIFF
--- a/.github/release-notes/highlights/v0.58.0.md
+++ b/.github/release-notes/highlights/v0.58.0.md
@@ -1,4 +1,5 @@
 <!-- title: v0.58.0 prerelease — Real-time audio state publication -->
+<!-- song: Black Pumas — Know You Better — https://music.apple.com/de/album/know-you-better/1457164821?i=1457165078 -->
 ## Highlights
 
 - **Render callbacks now see complete configurations.** Audio settings publish as immutable snapshots with sequentially consistent reader protection and off-render reclamation, so a callback observes the old or new configuration instead of mixed state during updates (#164, #173).


### PR DESCRIPTION
## Summary
- Add the requested song sign-off to the v0.58.0 prerelease highlights.

## Scope
- Release notes only. No source or version changes.
- No tag or GitHub release is created by this PR.

## Test plan
- [x] `git diff --check`
- [x] Song directive is the second line and uses the Apple Music link.