### PR TITLE
fix(release): include v0.58.0 prerelease highlights

### DIFF
--- a/.github/release-notes/highlights/v0.58.0-prerelease.md
+++ b/.github/release-notes/highlights/v0.58.0-prerelease.md
@@ -1,0 +1,7 @@
+<!-- title: v0.58.0 prerelease — Real-time audio state publication -->
+<!-- song: Black Pumas — Know You Better — https://music.apple.com/de/album/know-you-better/1457164821?i=1457165078 -->
+## Highlights
+
+- **Render callbacks now see complete configurations.** Audio settings publish as immutable snapshots with sequentially consistent reader protection and off-render reclamation, so a callback observes the old or new configuration instead of mixed state during updates (#164, #173).
+- **EQ edits transition without zippering.** Live biquad edits reuse filter state and ramp coefficient changes over 64 frames. Preset switches reset filter state cleanly, while explicit resets publish a fresh zero-state snapshot (#174).
+- **The real-time callback no longer grows buffers.** Render scratch storage and spectrum scale data are preallocated. Oversized render slices return silence instead of allocating, while unlimited EQ band counts remain supported (#152).


### PR DESCRIPTION
## Summary
- Add the tag-specific highlights file expected by the release workflow.
- Restore the curated title, highlights, and Black Pumas song sign-off for the already-published prerelease.

## Scope
- Release metadata only. No source or version changes.

## Test plan
- [x] `git diff --check`
- [x] Verified the file name matches `v0.58.0-prerelease.md`.
- [ ] Update the existing GitHub prerelease notes after this PR merges.