### PR TITLE
Fix stale OPRA details when search is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.58.1] - 2026-08-03
+
+### Fixed
+- Clearing the OPRA browser search now clears the stale EQ profile list from the detail pane (#195).
+
 ## [0.58.0] - 2026-08-02
 
 ### Changed

--- a/Sources/iQualize/DreamUI/PresetBrowserView.swift
+++ b/Sources/iQualize/DreamUI/PresetBrowserView.swift
@@ -49,15 +49,16 @@ struct PresetBrowserView: View {
         OPRASearch.filter(products, matching: query)
     }
 
-    /// The selection to keep after `query` changes: the current `selection` when it still
-    /// appears in the filtered results, otherwise `nil`. Clearing a query that still contains
-    /// the selection preserves it (#155).
+    /// The selection to keep after `query` changes: a non-empty query keeps the current
+    /// `selection` when it still appears in the filtered results, otherwise `nil`. Clearing the
+    /// query ends the active search context, so it also clears the detail selection (#195).
     static func validatedSelection(
         _ selection: String?,
         in products: [OPRAProductEntry],
         matching query: String
     ) -> String? {
         guard let selection else { return nil }
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
         return filter(products, matching: query).contains { $0.id == selection } ? selection : nil
     }
 
@@ -116,7 +117,7 @@ struct PresetBrowserView: View {
         // Editing the search can filter the selected product out of the sidebar. The
         // detail pane derives from `filteredProducts`, so a dropped selection already
         // falls back to the placeholder, but clear the id too so the selection doesn't
-        // silently reappear when the query is cleared again (#155).
+        // silently reappear when the query changes again (#155, #195).
         .onChange(of: searchText) {
             selectedProductID = Self.validatedSelection(
                 selectedProductID, in: products, matching: searchText)

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.58.0</string>
+	<string>0.58.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.58</string>
+	<string>0.58.1</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Tests/iQualizeTests/PresetBrowserSelectionTests.swift
+++ b/Tests/iQualizeTests/PresetBrowserSelectionTests.swift
@@ -30,11 +30,18 @@ final class PresetBrowserSelectionTests: XCTestCase {
         XCTAssertEqual(result, "sony-1000")
     }
 
-    // Clearing the query preserves a still-valid selection rather than discarding it.
-    func testSelectionRetainedWhenQueryCleared() {
+    // Clearing the query ends the active search context and clears the detail selection.
+    func testSelectionClearedWhenQueryCleared() {
         let result = PresetBrowserView.validatedSelection(
             "sony-1000", in: catalog, matching: "")
-        XCTAssertEqual(result, "sony-1000")
+        XCTAssertNil(result)
+    }
+
+    // Whitespace-only queries are treated like an empty search.
+    func testSelectionClearedWhenQueryContainsOnlyWhitespace() {
+        let result = PresetBrowserView.validatedSelection(
+            "sony-1000", in: catalog, matching: "   ")
+        XCTAssertNil(result)
     }
 
     // A nil selection stays nil regardless of query.


### PR DESCRIPTION
## Summary

The OPRA browser kept the selected product in `selectedProductID` when the search query was cleared. Because the product remained in the full catalog, its old EQ profiles stayed visible in the detail pane.

Clearing an empty or whitespace-only search now clears the detail selection. Non-empty queries still retain a selection when it remains in the filtered results.

Fixes #195

## Scope

- Update OPRA selection validation in `Sources/iQualize/DreamUI/PresetBrowserView.swift`.
- Add empty and whitespace-only query regression tests.
- Bump the app version to 0.58.1 and document the fix in `CHANGELOG.md`.

## Test plan

- [x] `swift test --filter PresetBrowserSelectionTests`
- [x] `swift test` with 147 tests passing
- [x] `git diff --check`
- [x] `bash scripts/install.sh` and launch verification with `pgrep -x iQualize`
- [x] Manual installed-app check: search `AKG K371`, select it, clear the search, and confirm the old product and EQ rows disappear from the right pane
