### PR TITLE
feat: harden capture and persistence boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.59.0] - 2026-08-03
+
+### Added
+- Runtime capture failures now retain structured classifications for permission denial, helper exits, unavailable output devices, transient failures, and terminal protocol failures (#180).
+- The menu bar now shows lifecycle status, offers retry for recoverable failures, and links directly to Audio Capture settings when permission is required (#180).
+
+### Changed
+- The last meaningful capture failure now survives teardown and explicit disable, and clears only after a successful start (#180).
+
+## [0.58.2] - 2026-08-03
+
+### Fixed
+- Capture handshakes now validate the protocol version and shared-memory geometry before mapping, and mismatches fail cleanly (#175).
+- Corrupt persisted preset blobs are backed up and reported instead of being silently discarded (#176).
+- Settings mutations now use one owned store so interleaved writes do not clobber unrelated fields, and corrupt settings data is preserved instead of silently reset (#165, #177).
+
 ## [0.58.1] - 2026-08-03
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,13 @@ let package = Package(
             name: "IQRingAtomics",
             path: "Sources/IQRingAtomics"
         ),
+        // Shared-memory capture contract (#175): the single SharedHeader
+        // definition, the layout version, and handshake-geometry validation
+        // used by both the app (CaptureClient) and the capture helper.
+        .target(
+            name: "IQCaptureProtocol",
+            path: "Sources/IQCaptureProtocol"
+        ),
         // Named "iqualize-cli", not "iqualize" — a same-named target would collide with
         // the "iQualize" app target's binary on macOS's default case-insensitive filesystem.
         // install.sh renames the built binary to "iqualize" when it copies it into place.
@@ -39,6 +46,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Markdown", package: "swift-markdown"),
                 "IQControlProtocol",
+                "IQCaptureProtocol",
                 "IQRingAtomics",
             ],
             path: "Sources/iQualize",
@@ -64,7 +72,7 @@ let package = Package(
         // Continuity (just like Spotify). See docs/CONTINUITY.md.
         .executableTarget(
             name: "iQualizeCapture",
-            dependencies: ["IQRingAtomics"],
+            dependencies: ["IQRingAtomics", "IQCaptureProtocol"],
             path: "Sources/iQualizeCapture",
             linkerSettings: [
                 .linkedFramework("CoreAudio"),
@@ -75,7 +83,7 @@ let package = Package(
         // the test bundle.
         .testTarget(
             name: "iQualizeTests",
-            dependencies: ["iQualize", "IQControlProtocol", "iqualize-cli"],
+            dependencies: ["iQualize", "IQControlProtocol", "IQCaptureProtocol", "iqualize-cli"],
             path: "Tests/iQualizeTests"
         ),
     ],

--- a/Sources/IQCaptureProtocol/CaptureProtocol.swift
+++ b/Sources/IQCaptureProtocol/CaptureProtocol.swift
@@ -1,0 +1,272 @@
+// IQCaptureProtocol — the shared-memory capture contract between the main
+// iQualize app (consumer, Sources/iQualize/CaptureClient.swift) and the
+// iQualizeCapture helper (producer, Sources/iQualizeCapture/main.swift).
+//
+// This target is the single source of truth for the ring layout. Both
+// binaries ship in one bundle, but a stale helper left behind by a partial
+// install must fail diagnosably instead of corrupting memory (#175), so the
+// header and the stdout handshake both carry a layout version and every
+// geometry value is validated before it reaches mmap or index arithmetic.
+
+import Foundation
+
+// MARK: - Startup-failure message
+
+/// The bounded line-protocol envelope used when the helper cannot reach its
+/// readiness handshake. This deliberately carries only machine-readable
+/// fields. Presentation code can classify the stage/code and inspect the raw
+/// OSStatus without inheriting a user-facing string from the helper.
+public struct CaptureStartupFailure: Codable, Equatable, Sendable {
+    public static let messageType = "failure"
+    public static let maxEncodedLineBytes = 512
+    /// The legacy handshake has more fields than a failure line. Keep its
+    /// transport bound separate so adding a longer temporary path does not
+    /// turn an otherwise valid handshake into a malformed failure.
+    public static let maxLineBytes = 4096
+
+    public enum Stage: String, Codable, Sendable {
+        case environment
+        case processTap
+        case tapFormat
+        case sharedMemory
+        case aggregateDevice
+        case ioProc
+    }
+
+    public let stage: Stage
+    /// Stable helper exit code. These are the existing helper's pre-handshake
+    /// exit codes, kept on the wire so older clients can still identify the
+    /// broad failure even when they do not decode this message.
+    public let exitCode: Int32
+    /// A Core Audio OSStatus when the failing operation returned one.
+    public let osStatus: Int32?
+
+    public init(stage: Stage, exitCode: Int32, osStatus: Int32? = nil) {
+        self.stage = stage
+        self.exitCode = exitCode
+        self.osStatus = osStatus
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case messageType
+        case stage
+        case exitCode
+        case osStatus
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard try container.decode(String.self, forKey: .messageType) == Self.messageType else {
+            throw CaptureStartupFailureDecodeError.invalidEnvelope
+        }
+        guard let stage = try? container.decode(Stage.self, forKey: .stage) else {
+            throw CaptureStartupFailureDecodeError.invalidEnvelope
+        }
+        self.stage = stage
+        self.exitCode = try container.decode(Int32.self, forKey: .exitCode)
+        self.osStatus = try container.decodeIfPresent(Int32.self, forKey: .osStatus)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.messageType, forKey: .messageType)
+        try container.encode(stage, forKey: .stage)
+        try container.encode(exitCode, forKey: .exitCode)
+        try container.encodeIfPresent(osStatus, forKey: .osStatus)
+    }
+
+    /// Decodes a startup-failure line when the discriminator is present.
+    /// Returns nil for a legacy handshake line, which has no `type` field.
+    public static func decodeIfPresent(from data: Data) throws -> Self? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CaptureStartupFailureDecodeError.invalidJSON
+        }
+        guard object["messageType"] != nil else { return nil }
+        guard data.count <= Self.maxEncodedLineBytes else {
+            throw CaptureStartupFailureDecodeError.lineTooLong
+        }
+        return try JSONDecoder().decode(Self.self, from: data)
+    }
+
+    /// Encodes a single newline-terminated, size-bounded protocol line.
+    public func encodedLine() throws -> Data {
+        var data = try JSONEncoder().encode(self)
+        data.append(0x0A)
+        guard data.count <= Self.maxEncodedLineBytes else {
+            throw CaptureStartupFailureDecodeError.lineTooLong
+        }
+        return data
+    }
+}
+
+public enum CaptureStartupFailureDecodeError: Error, Equatable, Sendable {
+    case invalidJSON
+    case invalidEnvelope
+    case lineTooLong
+}
+
+// MARK: - Shared-memory header
+
+/// Header at the start of the capture ring's shared-memory region.
+///
+/// Layout is ABI between two separately compiled binaries: `@frozen`, fixed
+/// field order, and covered by CaptureLayoutTests asserting every offset and
+/// the stride. The writer publishes `writeHead` with a release store; the
+/// reader loads it with acquire (IQRingAtomics) — both sides derive their
+/// atomic field pointers from `MemoryLayout.offset(of:)`, so the offsets of
+/// `writeHead` and `readHead` must never move.
+@frozen
+public struct SharedHeader {
+    public var writeHead: UInt64
+    public var readHead: UInt64
+    public var sampleRate: Float64
+    public var channels: UInt32
+    public var capacityFloats: UInt32
+    /// Layout version 1. Occupies the first four bytes of what version-1-era
+    /// builds wrote as zero padding, so a legacy header reads as 0 — treated
+    /// as version 1 (the padding was always zeroed).
+    public var layoutVersion: UInt32
+    public var _reserved0: UInt32
+    public var _reserved1: UInt64
+    public var _reserved2: UInt64
+
+    public init(writeHead: UInt64 = 0,
+                readHead: UInt64 = 0,
+                sampleRate: Float64 = 0,
+                channels: UInt32 = 0,
+                capacityFloats: UInt32 = 0,
+                layoutVersion: UInt32 = CaptureLayout.version) {
+        self.writeHead = writeHead
+        self.readHead = readHead
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.capacityFloats = capacityFloats
+        self.layoutVersion = layoutVersion
+        self._reserved0 = 0
+        self._reserved1 = 0
+        self._reserved2 = 0
+    }
+}
+
+public enum CaptureLayout {
+    /// Current shared-memory layout version. An absent version — in the
+    /// handshake or as a zeroed header field — means a legacy version-1 peer.
+    public static let version: UInt32 = 1
+
+    /// Header size padded to a 64-byte boundary so the sample data starts
+    /// cache-line aligned. Both sides must compute the data offset this way.
+    public static var alignedHeaderSize: Int {
+        (MemoryLayout<SharedHeader>.stride + 63) & ~63
+    }
+}
+
+// MARK: - Handshake validation
+
+public enum CaptureProtocolError: Error, LocalizedError, Equatable, Sendable {
+    case unsupportedLayoutVersion(received: UInt32, supported: UInt32)
+    case invalidGeometry(String)
+    case mappedHeaderMismatch(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedLayoutVersion(let received, let supported):
+            return "Capture helper speaks layout version \(received); this app supports \(supported). The helper binary is likely stale — reinstall the app."
+        case .invalidGeometry(let detail):
+            return "Capture helper sent invalid ring geometry: \(detail)"
+        case .mappedHeaderMismatch(let detail):
+            return "Capture ring header disagrees with the handshake: \(detail)"
+        }
+    }
+}
+
+/// The geometry a helper reports in its handshake line, validated as a unit
+/// before any of it is passed to mmap, bindMemory, a mask computation, or a
+/// division.
+public struct CaptureGeometry: Equatable, Sendable {
+    public var layoutVersion: UInt32
+    public var totalSize: Int
+    public var headerSize: Int
+    public var sampleRate: Float64
+    public var channels: Int
+    public var capacityFloats: Int
+
+    /// `layoutVersion` nil means the field was absent — a legacy version-1
+    /// helper from before the field existed.
+    public init(layoutVersion: UInt32?, totalSize: Int, headerSize: Int,
+                sampleRate: Float64, channels: Int, capacityFloats: Int) {
+        self.layoutVersion = layoutVersion ?? 1
+        self.totalSize = totalSize
+        self.headerSize = headerSize
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.capacityFloats = capacityFloats
+    }
+
+    /// Throws `CaptureProtocolError` on the first violated invariant.
+    /// Every check here guards a specific downstream hazard:
+    /// - version: struct layout skew between binaries
+    /// - channels > 0: divisor in capacityFrames
+    /// - capacityFloats power of two: `mask = capacityFloats - 1` ring indexing
+    /// - divisibility: whole frames only
+    /// - headerSize: data-pointer offset both sides must agree on
+    /// - totalSize: the mmap length must cover header + data exactly
+    public func validate() throws {
+        guard layoutVersion == CaptureLayout.version else {
+            throw CaptureProtocolError.unsupportedLayoutVersion(
+                received: layoutVersion, supported: CaptureLayout.version)
+        }
+        guard sampleRate.isFinite, sampleRate > 0 else {
+            throw CaptureProtocolError.invalidGeometry("sampleRate=\(sampleRate)")
+        }
+        guard channels > 0 else {
+            throw CaptureProtocolError.invalidGeometry("channels=\(channels)")
+        }
+        guard capacityFloats > 0, capacityFloats & (capacityFloats - 1) == 0 else {
+            throw CaptureProtocolError.invalidGeometry(
+                "ringCapacityFloats=\(capacityFloats) is not a power of two")
+        }
+        guard capacityFloats % channels == 0 else {
+            throw CaptureProtocolError.invalidGeometry(
+                "ringCapacityFloats=\(capacityFloats) not divisible by channels=\(channels)")
+        }
+        guard headerSize == CaptureLayout.alignedHeaderSize else {
+            throw CaptureProtocolError.invalidGeometry(
+                "headerSize=\(headerSize), expected \(CaptureLayout.alignedHeaderSize)")
+        }
+        let dataByteResult = capacityFloats.multipliedReportingOverflow(by: MemoryLayout<Float>.size)
+        guard !dataByteResult.overflow else {
+            throw CaptureProtocolError.invalidGeometry(
+                "capacityFloats=\(capacityFloats) overflows the data byte count")
+        }
+        let totalSizeResult = headerSize.addingReportingOverflow(dataByteResult.partialValue)
+        guard !totalSizeResult.overflow, totalSize == totalSizeResult.partialValue else {
+            throw CaptureProtocolError.invalidGeometry(
+                "totalSize=\(totalSize), expected \(totalSizeResult.partialValue)")
+        }
+    }
+
+    /// Cross-checks the mapped header against the validated handshake. The
+    /// two describe the same region through different channels (shared memory
+    /// vs stdout JSON), so any disagreement means the peer is not the binary
+    /// that wrote this handshake — refuse rather than guess. A zero
+    /// `layoutVersion` in the header is the legacy-padding encoding of 1.
+    public func validate(against header: SharedHeader) throws {
+        let headerVersion = header.layoutVersion == 0 ? 1 : header.layoutVersion
+        guard headerVersion == layoutVersion else {
+            throw CaptureProtocolError.mappedHeaderMismatch(
+                "header layoutVersion=\(headerVersion), handshake=\(layoutVersion)")
+        }
+        guard Int(header.channels) == channels else {
+            throw CaptureProtocolError.mappedHeaderMismatch(
+                "header channels=\(header.channels), handshake=\(channels)")
+        }
+        guard Int(header.capacityFloats) == capacityFloats else {
+            throw CaptureProtocolError.mappedHeaderMismatch(
+                "header capacityFloats=\(header.capacityFloats), handshake=\(capacityFloats)")
+        }
+        guard header.sampleRate == sampleRate else {
+            throw CaptureProtocolError.mappedHeaderMismatch(
+                "header sampleRate=\(header.sampleRate), handshake=\(sampleRate)")
+        }
+    }
+}

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -312,7 +312,7 @@ final class AudioEngine {
     private(set) var lifecycleHistory: [AudioLifecycleTransition] = []
     private(set) var outputDeviceName = "Unknown"
     private(set) var outputDeviceUID: String?
-    private(set) var error: String?
+    private(set) var lastFailure: AudioRuntimeFailure?
     /// Unexpected helper terminations since the app launched. This is kept
     /// outside CaptureClient because a recovery creates a fresh client.
     private(set) var captureHelperRestartCount: UInt64 = 0
@@ -346,6 +346,10 @@ final class AudioEngine {
     /// both AudioEngine and PresetStore — kept as a closure so AudioEngine stays decoupled
     /// from the store type, same pattern as `onStateChange`.
     var pinnedPresetProvider: ((String) -> EQPresetData?)?
+    /// Fired after a device change applies a pinned preset, so the owner can
+    /// persist the new selection. AudioEngine itself never writes app
+    /// persistence — same decoupling rationale as `pinnedPresetProvider`.
+    var onPinnedPresetApplied: ((UUID) -> Void)?
 
     // Spectrum analyzers — one per tap point
     let preEqAnalyzer = SpectrumAnalyzer()
@@ -466,11 +470,8 @@ final class AudioEngine {
             publishSnapshot: { @MainActor [weak self] snapshot in
                 self?.applyLifecycleSnapshot(snapshot)
             },
-            publishError: { @MainActor [weak self] message in
-                if let message {
-                    os_log(.error, log: appLog, "audio lifecycle failure: %{public}@", message)
-                }
-                self?.error = message
+            publishFailure: { @MainActor [weak self] failure in
+                self?.lastFailure = failure
             }
         )
     }
@@ -492,8 +493,6 @@ final class AudioEngine {
     // MARK: - Start / Stop
 
     private func startGraph() throws {
-        error = nil
-
         let outputDeviceID = try getDefaultOutputDeviceID()
         outputDeviceName = try getDeviceName(outputDeviceID)
         outputDeviceUID = try? getDeviceUID(outputDeviceID)
@@ -911,9 +910,7 @@ final class AudioEngine {
             outputDeviceChanged = defaultOutputDeviceChanged(previousUID: previousUID, currentUID: uid)
             if outputDeviceChanged, let uid, let pinned = pinnedPresetProvider?(uid) {
                 activePreset = pinned
-                var s = iQualizeState.load()
-                s.selectedPresetID = pinned.id
-                s.save()
+                onPinnedPresetApplied?(pinned.id)
             }
         }
 

--- a/Sources/iQualize/AudioLifecycle.swift
+++ b/Sources/iQualize/AudioLifecycle.swift
@@ -73,7 +73,7 @@ actor AudioLifecycleCoordinator {
     private let stopOperation: MainAction
     private let readiness: MainReadiness
     private let publishSnapshot: @MainActor @Sendable (AudioLifecycleSnapshot) -> Void
-    private let publishError: @MainActor @Sendable (String?) -> Void
+    private let publishFailure: @MainActor @Sendable (AudioRuntimeFailure?) -> Void
     private let sleeper: Sleep
     private let wakePolicy: AudioLifecycleRetryPolicy
     private let helperPolicy: AudioLifecycleRetryPolicy
@@ -105,7 +105,7 @@ actor AudioLifecycleCoordinator {
         stopOperation: @escaping MainAction,
         readiness: @escaping MainReadiness,
         publishSnapshot: @escaping @MainActor @Sendable (AudioLifecycleSnapshot) -> Void,
-        publishError: @escaping @MainActor @Sendable (String?) -> Void,
+        publishFailure: @escaping @MainActor @Sendable (AudioRuntimeFailure?) -> Void = { _ in },
         wakePolicy: AudioLifecycleRetryPolicy = .wake,
         helperPolicy: AudioLifecycleRetryPolicy = .helper,
         historyLimit: Int = 32,
@@ -117,7 +117,7 @@ actor AudioLifecycleCoordinator {
         self.stopOperation = stopOperation
         self.readiness = readiness
         self.publishSnapshot = publishSnapshot
-        self.publishError = publishError
+        self.publishFailure = publishFailure
         self.wakePolicy = wakePolicy
         self.helperPolicy = helperPolicy
         self.historyLimit = max(1, historyLimit)
@@ -266,17 +266,17 @@ actor AudioLifecycleCoordinator {
         }
         resetHelperFailureBudgetIfStable()
         if helperFailureCount >= helperFailureLimit {
-            let message = "Capture helper failed repeatedly. Re-enable capture to try again."
-            await publishError(message)
+            let failure: AudioRuntimeFailure = .terminal(.unknown)
+            await publishFailure(failure)
             await stopOperation()
-            transition(to: .failed, trigger: .helperTermination, outcome: .failed, message: message)
+            transition(to: .failed, trigger: .helperTermination, outcome: .failed)
             return
         }
         helperFailureCount += 1
         if helperFailureWindowStart == nil {
             helperFailureWindowStart = DispatchTime.now().uptimeNanoseconds
         }
-        await publishError("Capture helper terminated unexpectedly.")
+        await publishFailure(.helperExited(.init(status: -1, signaled: false)))
         _ = await recover(trigger: .helperTermination, policy: helperPolicy, requireReadiness: false)
     }
 
@@ -294,21 +294,21 @@ actor AudioLifecycleCoordinator {
         transition(to: .inactive, trigger: trigger)
     }
 
-    private func startOnce(trigger: AudioLifecycleTrigger) async -> String? {
-        guard userEnabled else { return "Capture is disabled." }
+    private func startOnce(trigger: AudioLifecycleTrigger) async -> AudioRuntimeFailure? {
+        guard userEnabled else { return .terminal(.unknown) }
         transition(to: .starting, trigger: trigger)
         do {
             try await startOperation()
-            await publishError(nil)
+            await publishFailure(nil)
             lastSuccessfulStart = DispatchTime.now().uptimeNanoseconds
             transition(to: .running, trigger: trigger)
             return nil
         } catch {
             await stopOperation()
-            let message = error.localizedDescription
-            await publishError(message)
-            transition(to: .failed, trigger: trigger, outcome: .failed, message: message)
-            return message
+            let failure = AudioRuntimeFailureClassifier.classify(error)
+            await publishFailure(failure)
+            transition(to: .failed, trigger: trigger, outcome: .failed)
+            return failure
         }
     }
 
@@ -330,7 +330,7 @@ actor AudioLifecycleCoordinator {
         transition(to: .recovering, trigger: trigger)
         await stopOperation()
 
-        var lastError: String?
+        var lastFailure: AudioRuntimeFailure?
         for attempt in 0...policy.delaysNanoseconds.count {
             guard isCurrentRecovery(generation) else { return false }
             if attempt > 0 {
@@ -341,24 +341,23 @@ actor AudioLifecycleCoordinator {
             if requireReadiness {
                 let ready = await waitForReadiness(policy: policy, generation: generation)
                 if !ready {
-                    lastError = "Default output device is not ready."
+                    lastFailure = .deviceUnavailable(.defaultOutputNotReady)
                     continue
                 }
             }
 
             if let failure = await startOnce(trigger: trigger) {
-                lastError = failure
+                lastFailure = failure
             } else {
                 return true
             }
             if attempt < policy.delaysNanoseconds.count {
-                transition(to: .recovering, trigger: trigger, message: lastError)
+                transition(to: .recovering, trigger: trigger)
             }
         }
 
-        let message = lastError ?? "Audio recovery failed."
-        await publishError(message)
-        transition(to: .failed, trigger: trigger, outcome: .failed, message: message)
+        await publishFailure(lastFailure ?? .terminal(.unknown))
+        transition(to: .failed, trigger: trigger, outcome: .failed)
         return false
     }
 

--- a/Sources/iQualize/AudioRuntimeFailure.swift
+++ b/Sources/iQualize/AudioRuntimeFailure.swift
@@ -1,0 +1,134 @@
+import CoreAudio
+import Foundation
+import IQCaptureProtocol
+
+/// Presentation-neutral runtime capture failure. The cases are the stable public
+/// buckets that UI and automation can switch over without parsing localized text.
+/// Associated values keep diagnostics distinguishable without carrying copy.
+enum AudioRuntimeFailure: Sendable, Equatable {
+    case permissionDenied(PermissionFailure)
+    case helperMissing(HelperMissingFailure)
+    case helperExited(HelperExitFailure)
+    case deviceUnavailable(DeviceUnavailableFailure)
+    case transient(TransientFailure)
+    case terminal(TerminalFailure)
+
+    enum PermissionFailure: Sendable, Equatable {
+        case processTap(status: Int32?)
+    }
+
+    struct HelperMissingFailure: Sendable, Equatable {
+        let path: String
+    }
+
+    struct HelperExitFailure: Sendable, Equatable {
+        let status: Int32
+        let signaled: Bool
+    }
+
+    enum DeviceUnavailableFailure: Sendable, Equatable {
+        case defaultOutputNotReady
+        case coreAudioStatus(Int32)
+    }
+
+    enum TransientFailure: Sendable, Equatable {
+        case handshakeTimeout(seconds: Double)
+        case handshakeRead(errno: Int32)
+        case sharedMemoryOpen(errno: Int32)
+        case sharedMemoryStat(errno: Int32)
+        case sharedMemoryMap(errno: Int32)
+        case sharedMemoryStartup(exitCode: Int32)
+    }
+
+    enum TerminalFailure: Sendable, Equatable {
+        case malformedHandshake
+        case helperStartup(stage: CaptureStartupFailure.Stage, exitCode: Int32, osStatus: Int32?)
+        case invalidCaptureGeometry
+        case captureProtocolViolation
+        case engineUnavailable
+        case renderConfiguration
+        case unknown
+    }
+}
+
+enum AudioRuntimeFailureClassifier {
+    static func classify(_ error: Error) -> AudioRuntimeFailure {
+        if let captureError = error as? CaptureClientError {
+            return classify(captureError)
+        }
+        if let protocolError = error as? CaptureProtocolError {
+            return classify(protocolError)
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == "iQualize" {
+            switch nsError.code {
+            case -200:
+                return .terminal(.engineUnavailable)
+            case -201, -202:
+                return .terminal(.renderConfiguration)
+            case -1:
+                return .deviceUnavailable(.coreAudioStatus(Int32(nsError.code)))
+            default:
+                if nsError.code != 0 {
+                    return .deviceUnavailable(.coreAudioStatus(Int32(nsError.code)))
+                }
+            }
+        }
+
+        // Fallback is deliberately terminal instead of retryable. Unknown Error
+        // values do not expose a stable machine-readable cause, and treating them
+        // as retryable would risk an unbounded recovery loop.
+        return .terminal(.unknown)
+    }
+
+    static func classify(_ error: CaptureClientError) -> AudioRuntimeFailure {
+        switch error {
+        case .helperMissing(let path):
+            return .helperMissing(.init(path: path))
+        case .handshakeTimeout(let seconds):
+            return .transient(.handshakeTimeout(seconds: seconds))
+        case .malformedHandshake:
+            return .terminal(.malformedHandshake)
+        case .helperStartupFailed(let failure):
+            return classify(failure)
+        case .unexpectedExit(let status, let signaled):
+            return .helperExited(.init(status: status, signaled: signaled))
+        case .handshakeReadFailed(let errno):
+            return .transient(.handshakeRead(errno: errno))
+        case .sharedMemoryOpenFailed(let errno):
+            return .transient(.sharedMemoryOpen(errno: errno))
+        case .sharedMemoryStatFailed(let errno):
+            return .transient(.sharedMemoryStat(errno: errno))
+        case .sharedMemoryMapFailed(let errno):
+            return .transient(.sharedMemoryMap(errno: errno))
+        }
+    }
+
+    static func classify(_ error: CaptureProtocolError) -> AudioRuntimeFailure {
+        switch error {
+        case .invalidGeometry:
+            return .terminal(.invalidCaptureGeometry)
+        case .unsupportedLayoutVersion, .mappedHeaderMismatch:
+            return .terminal(.captureProtocolViolation)
+        }
+    }
+
+    static func classify(_ failure: CaptureStartupFailure) -> AudioRuntimeFailure {
+        switch failure.stage {
+        case .processTap:
+            if failure.osStatus == kAudioDevicePermissionsError {
+                return .permissionDenied(.processTap(status: failure.osStatus))
+            }
+            return .terminal(.helperStartup(stage: failure.stage, exitCode: failure.exitCode, osStatus: failure.osStatus))
+        case .tapFormat:
+            return .terminal(.helperStartup(stage: failure.stage, exitCode: failure.exitCode, osStatus: failure.osStatus))
+        case .sharedMemory:
+            return .transient(.sharedMemoryStartup(exitCode: failure.exitCode))
+        case .aggregateDevice, .ioProc:
+            return .deviceUnavailable(.coreAudioStatus(failure.osStatus ?? failure.exitCode))
+        case .environment:
+            return .terminal(.helperStartup(stage: failure.stage, exitCode: failure.exitCode, osStatus: failure.osStatus))
+        }
+    }
+}

--- a/Sources/iQualize/CaptureClient.swift
+++ b/Sources/iQualize/CaptureClient.swift
@@ -8,32 +8,51 @@
 
 import Foundation
 import Darwin
+import IQCaptureProtocol
 import IQRingAtomics
 import os.log
 
 private let clientLog = OSLog(subsystem: "com.iqualize", category: "capture-client")
 
 enum CaptureClientError: Error, LocalizedError, Equatable, Sendable {
+    case helperMissing(path: String)
     case handshakeTimeout(seconds: Double)
+    case malformedHandshake
+    case helperStartupFailed(CaptureStartupFailure)
+    case unexpectedExit(status: Int32, signaled: Bool)
+    case handshakeReadFailed(errno: Int32)
+    case sharedMemoryOpenFailed(errno: Int32)
+    case sharedMemoryStatFailed(errno: Int32)
+    case sharedMemoryMapFailed(errno: Int32)
 
     var errorDescription: String? {
         switch self {
+        case .helperMissing(let path):
+            return "Capture helper is missing or not executable at \(path)."
         case .handshakeTimeout(let seconds):
             return "Capture helper handshake timed out after \(seconds) seconds."
+        case .malformedHandshake:
+            return "Capture helper sent a malformed startup message."
+        case .helperStartupFailed(let failure):
+            return "Capture helper failed during \(failure.stage.rawValue) with exit code \(failure.exitCode)."
+        case .unexpectedExit(let status, let signaled):
+            return signaled
+                ? "Capture helper terminated by signal \(status) before the handshake."
+                : "Capture helper exited with status \(status) before the handshake."
+        case .handshakeReadFailed(let errno):
+            return "Capture helper handshake read failed with errno \(errno)."
+        case .sharedMemoryOpenFailed(let errno):
+            return "Capture helper shared memory open failed with errno \(errno)."
+        case .sharedMemoryStatFailed(let errno):
+            return "Capture helper shared memory stat failed with errno \(errno)."
+        case .sharedMemoryMapFailed(let errno):
+            return "Capture helper shared memory mapping failed with errno \(errno)."
         }
     }
 }
 
-// Must match Sources/iQualizeCapture/main.swift exactly.
-// Internal (not private) so the resampler tests can build a synthetic ring.
-struct SharedHeader {
-    var writeHead: UInt64
-    var readHead: UInt64
-    var sampleRate: Float64
-    var channels: UInt32
-    var capacityFloats: UInt32
-    var _pad: (UInt64, UInt64, UInt32)
-}
+// The shared-memory layout and handshake validation live in IQCaptureProtocol
+// (SharedHeader, CaptureGeometry) — one definition shared with the helper.
 
 final class CaptureClient: @unchecked Sendable {
     static let defaultHandshakeTimeoutNanoseconds: UInt64 = 10_000_000_000
@@ -125,9 +144,7 @@ final class CaptureClient: @unchecked Sendable {
     /// Throws if anything fails — caller should treat as a hard error.
     func start(helperURL: URL) throws {
         guard FileManager.default.isExecutableFile(atPath: helperURL.path) else {
-            throw NSError(domain: "iQualize", code: -100,
-                          userInfo: [NSLocalizedDescriptionKey:
-                                     "Capture helper not found or not executable at \(helperURL.path)"])
+            throw CaptureClientError.helperMissing(path: helperURL.path)
         }
 
         let proc = Process()
@@ -161,33 +178,68 @@ final class CaptureClient: @unchecked Sendable {
                 lineData = lineData.prefix(upTo: newlineIdx)
             }
 
-            let json = try JSONSerialization.jsonObject(with: lineData) as? [String: Any] ?? [:]
+            let helperFailure: CaptureStartupFailure?
+            do {
+                helperFailure = try CaptureStartupFailure.decodeIfPresent(from: lineData)
+            } catch {
+                throw CaptureClientError.malformedHandshake
+            }
+            if let helperFailure {
+                throw CaptureClientError.helperStartupFailed(helperFailure)
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                throw CaptureClientError.malformedHandshake
+            }
             guard let shmPath = json["shmPath"] as? String,
                   let totalSize = json["totalSize"] as? Int,
                   let headerSize = json["headerSize"] as? Int,
                   let sr = json["sampleRate"] as? Double,
                   let ch = json["channels"] as? Int,
                   let capFloats = json["ringCapacityFloats"] as? Int else {
-                throw NSError(domain: "iQualize", code: -103,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "Capture helper sent malformed handshake: \(String(data: lineData, encoding: .utf8) ?? "<binary>")"])
+                throw CaptureClientError.malformedHandshake
             }
+
+            let layoutVersion: UInt32?
+            if let rawLayoutVersion = json["layoutVersion"] {
+                guard let intLayoutVersion = rawLayoutVersion as? Int,
+                      let exactLayoutVersion = UInt32(exactly: intLayoutVersion) else {
+                    throw CaptureProtocolError.invalidGeometry("layoutVersion=\(rawLayoutVersion)")
+                }
+                layoutVersion = exactLayoutVersion
+            } else {
+                layoutVersion = nil
+            }
+
+            // Absent layoutVersion means a legacy version-1 helper. Validate
+            // the version and every geometry value before any of it reaches
+            // mmap, bindMemory, the ring mask, or a division (#175).
+            let geometry = CaptureGeometry(
+                layoutVersion: layoutVersion,
+                totalSize: totalSize, headerSize: headerSize,
+                sampleRate: sr, channels: ch, capacityFloats: capFloats)
+            try geometry.validate()
 
             // Open the file-backed shared memory region the helper created.
             let fd = shmPath.withCString { open($0, O_RDWR) }
             if fd < 0 {
-                throw NSError(domain: "iQualize", code: -104,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "open(\(shmPath)) failed: errno \(errno)"])
+                throw CaptureClientError.sharedMemoryOpenFailed(errno: errno)
             }
             shmFD = fd
+
+            var statBuffer = stat()
+            guard fstat(fd, &statBuffer) == 0 else {
+                throw CaptureClientError.sharedMemoryStatFailed(errno: errno)
+            }
+            guard statBuffer.st_size == off_t(totalSize) else {
+                throw CaptureProtocolError.invalidGeometry(
+                    "fileSize=\(statBuffer.st_size), expected totalSize=\(totalSize)")
+            }
 
             guard let mapped = mmap(nil, size_t(totalSize),
                                     PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
                   mapped != MAP_FAILED else {
-                throw NSError(domain: "iQualize", code: -105,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "mmap failed: errno \(errno)"])
+                throw CaptureClientError.sharedMemoryMapFailed(errno: errno)
             }
             mappedRegion = mapped
             mappedSize = size_t(totalSize)
@@ -199,6 +251,12 @@ final class CaptureClient: @unchecked Sendable {
             // side's cleanup code actually running. Also closes the window where
             // a predictable, world-writable path in /tmp is reachable by name.
             _ = shmPath.withCString { unlink($0) }
+
+            // The handshake and the mapped header describe the same region
+            // through two channels; a disagreement means the shm writer is
+            // not the binary that sent this handshake — refuse to attach.
+            try geometry.validate(
+                against: mapped.bindMemory(to: SharedHeader.self, capacity: 1).pointee)
 
             attach(region: mapped, headerSize: headerSize,
                    capacityFloats: capFloats, sampleRate: sr, channels: UInt32(ch))
@@ -241,9 +299,7 @@ final class CaptureClient: @unchecked Sendable {
             let ready = poll(&descriptor, 1, Int32(timeoutMilliseconds))
             if ready < 0 {
                 if errno == EINTR { continue }
-                throw NSError(domain: "iQualize", code: -106,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "poll(handshake) errno=\(errno)"])
+                throw CaptureClientError.handshakeReadFailed(errno: errno)
             }
             if ready == 0 {
                 throw CaptureClientError.handshakeTimeout(
@@ -251,9 +307,7 @@ final class CaptureClient: @unchecked Sendable {
                 )
             }
             if descriptor.revents & Int16(POLLNVAL) != 0 {
-                throw NSError(domain: "iQualize", code: -106,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "poll(handshake) reported an invalid descriptor"])
+                throw CaptureClientError.handshakeReadFailed(errno: EBADF)
             }
 
             let n = buf.withUnsafeMutableBufferPointer { ptr in
@@ -261,15 +315,17 @@ final class CaptureClient: @unchecked Sendable {
             }
             if n > 0 {
                 lineData.append(buf, count: n)
+                if lineData.count > CaptureStartupFailure.maxLineBytes {
+                    throw CaptureClientError.malformedHandshake
+                }
             } else if n == 0 {
                 process.waitUntilExit()
-                throw NSError(domain: "iQualize", code: -102,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "Capture helper exited before handshake (status=\(process.terminationStatus))"])
+                throw CaptureClientError.unexpectedExit(
+                    status: process.terminationStatus,
+                    signaled: process.terminationReason == .uncaughtSignal
+                )
             } else if errno != EINTR {
-                throw NSError(domain: "iQualize", code: -106,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                         "read(handshake) errno=\(errno)"])
+                throw CaptureClientError.handshakeReadFailed(errno: errno)
             }
         }
         return lineData
@@ -313,6 +369,14 @@ final class CaptureClient: @unchecked Sendable {
             (proc.standardInput as? Pipe)?.fileHandleForWriting.closeFile()
             if proc.isRunning {
                 proc.terminate()
+            }
+            // Bounded grace before SIGKILL: the helper's SIGTERM path unlinks
+            // its shm file and tears down its CoreAudio objects, and an
+            // immediate SIGKILL forfeits that cleanup. Production helpers
+            // exit on stdin-EOF in well under this.
+            let killDeadline = DispatchTime.now().uptimeNanoseconds &+ 500_000_000
+            while proc.isRunning && DispatchTime.now().uptimeNanoseconds < killDeadline {
+                usleep(10_000)
             }
             if proc.isRunning {
                 kill(proc.processIdentifier, SIGKILL)

--- a/Sources/iQualize/DreamUI/DreamViewModel.swift
+++ b/Sources/iQualize/DreamUI/DreamViewModel.swift
@@ -12,6 +12,7 @@ final class DreamViewModel {
 
     let audioEngine: AudioEngine
     let presetStore: PresetStore
+    let settings: SettingsStore
 
     /// Window's undo manager — set by EQWindowController once the window exists.
     @ObservationIgnored
@@ -114,9 +115,10 @@ final class DreamViewModel {
 
     // MARK: - Init
 
-    init(audioEngine: AudioEngine, presetStore: PresetStore) {
+    init(audioEngine: AudioEngine, presetStore: PresetStore, settings: SettingsStore) {
         self.audioEngine = audioEngine
         self.presetStore = presetStore
+        self.settings = settings
         loadPersistedState()
         syncFromAudioEngine(initial: true)
     }
@@ -124,7 +126,7 @@ final class DreamViewModel {
     // MARK: - Persistence
 
     private func loadPersistedState() {
-        let s = iQualizeState.load()
+        let s = settings.state
         if let raw = s.dreamTheme, let t = DreamThemePreference(rawValue: raw) { theme = t }
         snapToSemitone = s.snapToSemitone
         zoomRange = s.zoomRange.flatMap(ZoomRange.init(rawValue:)) ?? .full
@@ -153,37 +155,31 @@ final class DreamViewModel {
     }
 
     func persistSnap() {
-        var s = iQualizeState.load()
-        s.snapToSemitone = snapToSemitone
-        s.save()
+        settings.set(\.snapToSemitone, snapToSemitone)
     }
 
     func persistZoomRange() {
-        var s = iQualizeState.load()
-        s.zoomRange = zoomRange.rawValue
-        s.save()
+        settings.set(\.zoomRange, zoomRange.rawValue)
     }
 
     func persistBandwidthDisplay() {
-        var s = iQualizeState.load()
-        s.showBandwidthAsQ = (bandwidthDisplay == .q)
-        s.save()
+        settings.set(\.showBandwidthAsQ, bandwidthDisplay == .q)
     }
 
     func persistFooterToggles() {
-        var s = iQualizeState.load()
-        s.peakLimiter = peakLimiter
-        s.bypassed = bypass
-        s.autoScale = autoScale
-        s.preEqSpectrumEnabled = preEqEnabled
-        s.postEqSpectrumEnabled = postEqEnabled
-        s.balance = balance
-        s.inputGainDB = inGainDB
-        s.outputGainDB = outGainDB
-        s.maxGainDB = maxGainDB
-        s.splitChannelEnabled = channel != .linked
-        s.activeChannel = channel == .r ? "right" : (channel == .l ? "left" : nil)
-        s.save()
+        settings.update {
+            $0.peakLimiter = peakLimiter
+            $0.bypassed = bypass
+            $0.autoScale = autoScale
+            $0.preEqSpectrumEnabled = preEqEnabled
+            $0.postEqSpectrumEnabled = postEqEnabled
+            $0.balance = balance
+            $0.inputGainDB = inGainDB
+            $0.outputGainDB = outGainDB
+            $0.maxGainDB = maxGainDB
+            $0.splitChannelEnabled = channel != .linked
+            $0.activeChannel = channel == .r ? "right" : (channel == .l ? "left" : nil)
+        }
     }
 
     // MARK: - Audio engine sync
@@ -555,9 +551,7 @@ final class DreamViewModel {
         isModified = false
         syncFromAudioEngine()
         registerUndo(actionName: "Load Preset", oldPreset: oldPreset)
-        var s = iQualizeState.load()
-        s.selectedPresetID = preset.id
-        s.save()
+        settings.set(\.selectedPresetID, preset.id)
     }
 
     func resetToSnapshot() {
@@ -604,9 +598,7 @@ final class DreamViewModel {
         savedSnapshot = preset
         isModified = false
         onTitleShouldUpdate?()
-        var s = iQualizeState.load()
-        s.selectedPresetID = preset.id
-        s.save()
+        settings.set(\.selectedPresetID, preset.id)
     }
 
     /// Reverts the active built-in preset to its shipped original — undoes not just the
@@ -651,9 +643,7 @@ final class DreamViewModel {
         isModified = false
         syncFromAudioEngine()
         registerUndo(actionName: "Save As", oldPreset: old)
-        var s = iQualizeState.load()
-        s.selectedPresetID = newPreset.id
-        s.save()
+        settings.set(\.selectedPresetID, newPreset.id)
     }
 
     /// Confirms before deleting — a built-in is hidden (recoverable from the Preset Browser),
@@ -688,9 +678,7 @@ final class DreamViewModel {
         isModified = false
         syncFromAudioEngine()
         registerUndo(actionName: "Delete Preset", oldPreset: old)
-        var s = iQualizeState.load()
-        s.selectedPresetID = EQPresetData.flat.id
-        s.save()
+        settings.set(\.selectedPresetID, EQPresetData.flat.id)
     }
 
     // MARK: - Undo / Redo

--- a/Sources/iQualize/EQPreset.swift
+++ b/Sources/iQualize/EQPreset.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let stateLog = OSLog(subsystem: "com.iqualize", category: "settings")
 
 // MARK: - State Persistence
 
@@ -71,7 +74,8 @@ struct iQualizeState: Codable {
         zoomRange: nil
     )
 
-    private static let key = "com.iqualize.state"
+    static let key = "com.iqualize.state"
+    static let corruptBackupKeyPrefix = "com.iqualize.state.corruptBackup."
 
     init(captureEnabled: Bool, selectedPresetID: UUID, peakLimiter: Bool, windowOpen: Bool = false, maxGainDB: Float = 12, bypassed: Bool = false, autoScale: Bool = true, preEqSpectrumEnabled: Bool = false, postEqSpectrumEnabled: Bool = false, hideFromDock: Bool = false, startAtLogin: Bool = false, balance: Float = 0.0, splitChannelEnabled: Bool = false, activeChannel: String? = nil, inputGainDB: Float = 0.0, outputGainDB: Float = 0.0, linkGainGlobally: Bool = false, showBandwidthAsQ: Bool = true, preEqLineColorHex: String? = nil, postEqLineColorHex: String? = nil, preEqFillColorHex: String? = nil, postEqFillColorHex: String? = nil, preEqFillEnabled: Bool = false, postEqFillEnabled: Bool = true, dreamTheme: String? = nil, snapToSemitone: Bool = false, zoomRange: String? = nil) {
         self.captureEnabled = captureEnabled
@@ -134,17 +138,42 @@ struct iQualizeState: Codable {
         zoomRange = try? container.decode(String.self, forKey: .zoomRange)
     }
 
-    static func load() -> iQualizeState {
-        guard let data = UserDefaults.standard.data(forKey: key),
-              let state = try? JSONDecoder().decode(iQualizeState.self, from: data) else {
+    // Narrow persistence seam used only by SettingsStore (#177). The old
+    // static `load()`/instance `save()` pair is gone so the whole-struct
+    // read-modify-save pattern can no longer compile; all mutation goes
+    // through the store's per-field setters and `update` transactions.
+    static func readPersisted(from defaults: UserDefaults) -> iQualizeState {
+        guard let data = defaults.data(forKey: key) else {
             return .defaultState
         }
-        return state
+
+        do {
+            return try JSONDecoder().decode(iQualizeState.self, from: data)
+        } catch {
+            preserveCorruptPersistedData(data, error: error, in: defaults)
+            return .defaultState
+        }
     }
 
-    func save() {
+    private static func preserveCorruptPersistedData(_ data: Data, error: Error, in defaults: UserDefaults) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let timestamp = formatter.string(from: Date())
+        var backupKey = corruptBackupKeyPrefix + timestamp
+        var collision = 1
+        while defaults.object(forKey: backupKey) != nil {
+            collision += 1
+            backupKey = "\(corruptBackupKeyPrefix)\(timestamp).\(collision)"
+        }
+
+        defaults.set(data, forKey: backupKey)
+        let message = "failed to decode \(key); preserved \(data.count) bytes under \(backupKey): \(error)"
+        os_log(.error, log: stateLog, "%{public}@", message)
+    }
+
+    func writePersisted(to defaults: UserDefaults) {
         if let data = try? JSONEncoder().encode(self) {
-            UserDefaults.standard.set(data, forKey: iQualizeState.key)
+            defaults.set(data, forKey: iQualizeState.key)
         }
     }
 }

--- a/Sources/iQualize/EQWindowController.swift
+++ b/Sources/iQualize/EQWindowController.swift
@@ -21,6 +21,7 @@ final class EQWindow: ShortcutAwareWindow {
 final class EQWindowController: NSWindowController {
     private let audioEngine: AudioEngine
     private let presetStore: PresetStore
+    private let settings: SettingsStore
     private let viewModel: DreamViewModel
     private let toolbarController: DreamToolbarController
 
@@ -33,10 +34,11 @@ final class EQWindowController: NSWindowController {
         didSet { viewModel.onBypassChanged = onBypassChanged }
     }
 
-    init(audioEngine: AudioEngine, presetStore: PresetStore) {
+    init(audioEngine: AudioEngine, presetStore: PresetStore, settings: SettingsStore) {
         self.audioEngine = audioEngine
         self.presetStore = presetStore
-        self.viewModel = DreamViewModel(audioEngine: audioEngine, presetStore: presetStore)
+        self.settings = settings
+        self.viewModel = DreamViewModel(audioEngine: audioEngine, presetStore: presetStore, settings: settings)
 
         let (window, toolbarController) = DreamHostingView.makeWindow(viewModel: viewModel)
         self.toolbarController = toolbarController
@@ -53,13 +55,11 @@ final class EQWindowController: NSWindowController {
         // Restore active preset. Falls back to Flat if the persisted ID no longer resolves
         // (e.g. it pointed at a built-in that's since been hidden), correcting persisted state
         // so this doesn't repeat on next launch.
-        var state = iQualizeState.load()
-        if let preset = presetStore.preset(for: state.selectedPresetID) {
+        if let preset = presetStore.preset(for: settings.state.selectedPresetID) {
             audioEngine.activePreset = preset
         } else {
             audioEngine.activePreset = .flat
-            state.selectedPresetID = EQPresetData.flat.id
-            state.save()
+            settings.set(\.selectedPresetID, EQPresetData.flat.id)
         }
         viewModel.syncFromAudioEngine(initial: true)
 

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.58.1</string>
+	<string>0.59.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.58.1</string>
+	<string>0.59</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -2,20 +2,28 @@ import AppKit
 import IQControlProtocol
 
 @available(macOS 14.2, *)
+private extension NSUserInterfaceItemIdentifier {
+    static let iqualizeRuntimeStatus = NSUserInterfaceItemIdentifier("com.iqualize.menu.runtime-status")
+    static let iqualizeRetryCapture = NSUserInterfaceItemIdentifier("com.iqualize.menu.retry-capture")
+    static let iqualizePermissionSettings = NSUserInterfaceItemIdentifier("com.iqualize.menu.permission-settings")
+}
+
+@available(macOS 14.2, *)
 @MainActor
 final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     private var statusItem: NSStatusItem!
     private let audioEngine: AudioEngine
     private let presetStore: PresetStore
+    private let settings: SettingsStore
     private var eqWindowController: EQWindowController?
     private var settingsWindowController: SettingsWindowController?
     private var helpWindowController: HelpWindowController?
 
-    init(audioEngine: AudioEngine, presetStore: PresetStore) {
+    init(audioEngine: AudioEngine, presetStore: PresetStore, settings: SettingsStore) {
         self.audioEngine = audioEngine
         self.presetStore = presetStore
+        self.settings = settings
         super.init()
-        var state = iQualizeState.load()
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         let menu = NSMenu()
@@ -32,40 +40,41 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
         audioEngine.pinnedPresetProvider = { [weak presetStore] uid in
             presetStore?.pinnedPreset(forDeviceUID: uid)
         }
+        audioEngine.onPinnedPresetApplied = { [weak self] id in
+            self?.settings.set(\.selectedPresetID, id)
+        }
 
         // Restore saved state — a device pin for the current output takes priority over
         // the last-selected preset, since it's an explicit user choice. Capture starts per
         // the persisted captureEnabled flag (defaults true, so fresh/existing installs
         // still always start; only an explicit `iqualize capture off` persists false).
-        audioEngine.gainIsGlobal = state.linkGainGlobally
+        audioEngine.gainIsGlobal = settings.state.linkGainGlobally
         let startupPreset = audioEngine.outputDeviceUID
             .flatMap { presetStore.pinnedPreset(forDeviceUID: $0) }
-            ?? presetStore.preset(for: state.selectedPresetID)
+            ?? presetStore.preset(for: settings.state.selectedPresetID)
         if let preset = startupPreset {
             audioEngine.activePreset = preset
-            state.selectedPresetID = preset.id
-            state.save()
+            settings.set(\.selectedPresetID, preset.id)
         } else {
             audioEngine.activePreset = .flat
-            state.selectedPresetID = EQPresetData.flat.id
-            state.save()
+            settings.set(\.selectedPresetID, EQPresetData.flat.id)
         }
-        audioEngine.peakLimiter = state.peakLimiter
-        audioEngine.maxGainDB = state.maxGainDB
-        audioEngine.bypassed = state.bypassed
-        audioEngine.balance = state.balance
-        if state.linkGainGlobally {
-            audioEngine.inputGainDB = state.inputGainDB
-            audioEngine.outputGainDB = state.outputGainDB
+        audioEngine.peakLimiter = settings.state.peakLimiter
+        audioEngine.maxGainDB = settings.state.maxGainDB
+        audioEngine.bypassed = settings.state.bypassed
+        audioEngine.balance = settings.state.balance
+        if settings.state.linkGainGlobally {
+            audioEngine.inputGainDB = settings.state.inputGainDB
+            audioEngine.outputGainDB = settings.state.outputGainDB
         }
-        let captureEnabled = state.captureEnabled
+        let captureEnabled = settings.state.captureEnabled
         Task { @MainActor in
             await audioEngine.setEnabled(captureEnabled)
         }
         updateIcon()
 
         // Restore EQ window if it was open when the app last quit
-        if state.windowOpen {
+        if settings.state.windowOpen {
             openEQWindow()
         }
     }
@@ -158,12 +167,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
             menu.addItem(pinItem)
         }
 
-        // Error display
-        if let error = audioEngine.error {
-            let errorItem = NSMenuItem(title: "⚠ \(error)", action: nil, keyEquivalent: "")
-            errorItem.isEnabled = false
-            menu.addItem(errorItem)
-        }
+        addRuntimeStatusSection(to: menu)
 
         menu.addItem(.separator())
 
@@ -220,9 +224,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
         let proceed = { [weak self] in
             guard let self, let preset = self.presetStore.preset(for: id) else { return }
             self.audioEngine.activePreset = preset
-            var s = iQualizeState.load()
-            s.selectedPresetID = preset.id
-            s.save()
+            self.settings.set(\.selectedPresetID, preset.id)
             self.eqWindowController?.syncUIToPreset()
             didApply = true
         }
@@ -241,7 +243,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     @objc private func openSettings(_ sender: NSMenuItem) {
         if settingsWindowController == nil {
             settingsWindowController = SettingsWindowController(
-                audioEngine: audioEngine, presetStore: presetStore, eqWindowController: eqWindowController)
+                audioEngine: audioEngine, presetStore: presetStore, settings: settings, eqWindowController: eqWindowController)
         }
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)
@@ -250,7 +252,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
 
     func openEQWindow() {
         if eqWindowController == nil {
-            eqWindowController = EQWindowController(audioEngine: audioEngine, presetStore: presetStore)
+            eqWindowController = EQWindowController(audioEngine: audioEngine, presetStore: presetStore, settings: settings)
             eqWindowController?.onOpenSettings = { [weak self] in
                 self?.openSettings(NSMenuItem())
             }
@@ -268,25 +270,77 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
         eqWindowController?.showWindow(nil)
         settingsWindowController?.updateEQWindowController(eqWindowController)
         NSApp.activate(ignoringOtherApps: true)
-        var s = iQualizeState.load()
-        s.windowOpen = true
-        s.save()
+        settings.set(\.windowOpen, true)
     }
 
     @objc private func windowDidClose(_ notification: Notification) {
-        var s = iQualizeState.load()
-        s.windowOpen = false
-        s.save()
+        settings.set(\.windowOpen, false)
     }
 
     @objc private func toggleBypass(_ sender: NSMenuItem) {
         toggleBypassFromMenu()
     }
 
+    private func runtimePresentation() -> MenuBarRuntimePresentation {
+        MenuBarRuntimePresentation.make(
+            lifecycleState: audioEngine.lifecycleState,
+            userEnabled: audioEngine.userEnabled,
+            bypassed: audioEngine.bypassed,
+            lastFailure: audioEngine.lastFailure
+        )
+    }
+
+    private func addRuntimeStatusSection(to menu: NSMenu) {
+        let presentation = runtimePresentation()
+
+        let statusItem = NSMenuItem(title: presentation.title, action: nil, keyEquivalent: "")
+        statusItem.identifier = .iqualizeRuntimeStatus
+        statusItem.isEnabled = false
+        statusItem.toolTip = presentation.tooltip
+        statusItem.image = runtimeImage(named: presentation.symbolName, accessibilityDescription: presentation.accessibilityLabel)
+        menu.addItem(statusItem)
+
+        if presentation.showsRetryCapture {
+            let retryItem = NSMenuItem(title: "Retry Capture", action: #selector(retryCapture(_:)), keyEquivalent: "")
+            retryItem.identifier = .iqualizeRetryCapture
+            retryItem.target = self
+            menu.addItem(retryItem)
+        }
+
+        if presentation.showsPermissionSettings {
+            let settingsItem = NSMenuItem(
+                title: "Open Audio Capture Settings",
+                action: #selector(openAudioCaptureSettings(_:)),
+                keyEquivalent: ""
+            )
+            settingsItem.identifier = .iqualizePermissionSettings
+            settingsItem.target = self
+            menu.addItem(settingsItem)
+        }
+    }
+
+    @objc private func retryCapture(_ sender: NSMenuItem) {
+        statusItem.menu?.cancelTracking()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.audioEngine.setEnabled(true)
+            self.updateIcon()
+        }
+    }
+
+    @objc private func openAudioCaptureSettings(_ sender: NSMenuItem) {
+        statusItem.menu?.cancelTracking()
+        let specificURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")!
+        let fallbackURL = URL(string: "x-apple.systempreferences:")!
+        if !NSWorkspace.shared.open(specificURL) {
+            NSWorkspace.shared.open(fallbackURL)
+        }
+    }
+
     func showSettings() {
         if settingsWindowController == nil {
             settingsWindowController = SettingsWindowController(
-                audioEngine: audioEngine, presetStore: presetStore, eqWindowController: eqWindowController)
+                audioEngine: audioEngine, presetStore: presetStore, settings: settings, eqWindowController: eqWindowController)
         }
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)
@@ -301,9 +355,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     /// toggle and the CLI.
     func setBypassed(_ bypassed: Bool) {
         audioEngine.bypassed = bypassed
-        var s = iQualizeState.load()
-        s.bypassed = bypassed
-        s.save()
+        settings.set(\.bypassed, bypassed)
         updateIcon()
         eqWindowController?.syncBypass(bypassed)
         settingsWindowController?.syncBypass(bypassed)
@@ -326,17 +378,13 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     func setInputGain(_ db: Float) {
         if audioEngine.gainIsGlobal {
             audioEngine.inputGainDB = db
-            var s = iQualizeState.load()
-            s.inputGainDB = db
-            s.save()
+            settings.set(\.inputGainDB, db)
         } else {
             var preset = audioEngine.activePreset
             preset.inputGainDB = db
             audioEngine.activePreset = preset
             persistPreset(preset)
-            var s = iQualizeState.load()
-            s.selectedPresetID = preset.id
-            s.save()
+            settings.set(\.selectedPresetID, preset.id)
         }
         eqWindowController?.syncUIToPreset()
     }
@@ -345,17 +393,13 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     func setOutputGain(_ db: Float) {
         if audioEngine.gainIsGlobal {
             audioEngine.outputGainDB = db
-            var s = iQualizeState.load()
-            s.outputGainDB = db
-            s.save()
+            settings.set(\.outputGainDB, db)
         } else {
             var preset = audioEngine.activePreset
             preset.outputGainDB = db
             audioEngine.activePreset = preset
             persistPreset(preset)
-            var s = iQualizeState.load()
-            s.selectedPresetID = preset.id
-            s.save()
+            settings.set(\.selectedPresetID, preset.id)
         }
         eqWindowController?.syncUIToPreset()
     }
@@ -365,17 +409,13 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     func setBalance(_ value: Float) {
         let clamped = min(max(value, -1), 1)
         audioEngine.balance = clamped
-        var s = iQualizeState.load()
-        s.balance = clamped
-        s.save()
+        settings.set(\.balance, clamped)
         eqWindowController?.syncBalance(clamped)
     }
 
     func setPeakLimiter(_ enabled: Bool) {
         audioEngine.peakLimiter = enabled
-        var s = iQualizeState.load()
-        s.peakLimiter = enabled
-        s.save()
+        settings.set(\.peakLimiter, enabled)
         eqWindowController?.syncPeakLimiter(enabled)
     }
 
@@ -390,12 +430,12 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     /// active preset's gain in place on the global -> per-preset transition so it survives
     /// a relaunch.
     func setGainIsGlobal(_ global: Bool) {
-        var s = iQualizeState.load()
         if global {
-            s.inputGainDB = audioEngine.inputGainDB
-            s.outputGainDB = audioEngine.outputGainDB
-            s.linkGainGlobally = true
-            s.save()
+            settings.update {
+                $0.inputGainDB = audioEngine.inputGainDB
+                $0.outputGainDB = audioEngine.outputGainDB
+                $0.linkGainGlobally = true
+            }
             audioEngine.gainIsGlobal = true
         } else {
             audioEngine.gainIsGlobal = false
@@ -404,8 +444,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
             preset.outputGainDB = audioEngine.outputGainDB
             persistPreset(preset)
             audioEngine.activePreset = preset
-            s.linkGainGlobally = false
-            s.save()
+            settings.set(\.linkGainGlobally, false)
         }
         eqWindowController?.syncGainIsGlobal(audioEngine.gainIsGlobal)
         eqWindowController?.syncUIToPreset()
@@ -419,41 +458,35 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     }
 
     // preEqSpectrumEnabled/postEqSpectrumEnabled live only in iQualizeState, not on
-    // AudioEngine — the toggle variants read the current value from persisted state
-    // rather than from audioEngine, unlike peakLimiter/gainIsGlobal/capture.
+    // AudioEngine — the toggle variants read the current value from the settings
+    // store rather than from audioEngine, unlike peakLimiter/gainIsGlobal/capture.
     func setPreEqSpectrum(_ enabled: Bool) {
-        var s = iQualizeState.load()
-        s.preEqSpectrumEnabled = enabled
-        s.save()
+        settings.set(\.preEqSpectrumEnabled, enabled)
         eqWindowController?.syncPreEqSpectrum(enabled)
     }
 
     @discardableResult
     func togglePreEqSpectrum() -> Bool {
-        let newValue = !iQualizeState.load().preEqSpectrumEnabled
+        let newValue = !settings.state.preEqSpectrumEnabled
         setPreEqSpectrum(newValue)
         return newValue
     }
 
     func setPostEqSpectrum(_ enabled: Bool) {
-        var s = iQualizeState.load()
-        s.postEqSpectrumEnabled = enabled
-        s.save()
+        settings.set(\.postEqSpectrumEnabled, enabled)
         eqWindowController?.syncPostEqSpectrum(enabled)
     }
 
     @discardableResult
     func togglePostEqSpectrum() -> Bool {
-        let newValue = !iQualizeState.load().postEqSpectrumEnabled
+        let newValue = !settings.state.postEqSpectrumEnabled
         setPostEqSpectrum(newValue)
         return newValue
     }
 
     func setCapture(_ enabled: Bool) async {
         await audioEngine.setEnabled(enabled)
-        var s = iQualizeState.load()
-        s.captureEnabled = enabled
-        s.save()
+        settings.set(\.captureEnabled, enabled)
         updateIcon()
     }
 
@@ -510,9 +543,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     private func persistBandMutation(_ preset: EQPresetData) {
         audioEngine.activePreset = preset
         persistPreset(preset)
-        var s = iQualizeState.load()
-        s.selectedPresetID = preset.id
-        s.save()
+        settings.set(\.selectedPresetID, preset.id)
         eqWindowController?.syncUIToPreset()
     }
 
@@ -938,8 +969,8 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
             outputDeviceName: audioEngine.outputDeviceName,
             isRunning: audioEngine.isRunning,
             peakLimiter: audioEngine.peakLimiter,
-            preEqSpectrumEnabled: iQualizeState.load().preEqSpectrumEnabled,
-            postEqSpectrumEnabled: iQualizeState.load().postEqSpectrumEnabled,
+            preEqSpectrumEnabled: settings.state.preEqSpectrumEnabled,
+            postEqSpectrumEnabled: settings.state.postEqSpectrumEnabled,
             appVersion: appVersion,
             gitCommit: appGitCommit,
             captureFillFrames: capture?.fillFrames,
@@ -1003,13 +1034,21 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     private func updateIcon() {
         if let button = statusItem.button {
             button.title = ""
-            let symbolName = audioEngine.bypassed ? "slider.vertical.3" : "slider.vertical.3"
-            if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: "iQualize") {
-                let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
-                button.image = image.withSymbolConfiguration(config)
-                button.image?.isTemplate = true
-            }
-            button.appearsDisabled = !audioEngine.isRunning || audioEngine.bypassed
+            let presentation = runtimePresentation()
+            button.image = runtimeImage(named: presentation.symbolName, accessibilityDescription: presentation.accessibilityLabel)
+            button.appearsDisabled = presentation.appearsDisabled
+            button.toolTip = presentation.tooltip
+            button.setAccessibilityLabel(presentation.accessibilityLabel)
         }
+    }
+
+    private func runtimeImage(named symbolName: String, accessibilityDescription: String) -> NSImage? {
+        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityDescription) else {
+            return nil
+        }
+        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+        let configuredImage = image.withSymbolConfiguration(config) ?? image
+        configuredImage.isTemplate = true
+        return configuredImage
     }
 }

--- a/Sources/iQualize/MenuBarRuntimePresentation.swift
+++ b/Sources/iQualize/MenuBarRuntimePresentation.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+struct MenuBarRuntimePresentation: Equatable {
+    enum Status: Equatable {
+        case active
+        case bypassed
+        case stopped
+        case failed
+        case sleeping
+        case starting
+        case recovering
+        case stopping
+    }
+
+    let status: Status
+    let title: String
+    let accessibilityLabel: String
+    let symbolName: String
+    let appearsDisabled: Bool
+    let showsRetryCapture: Bool
+    let showsPermissionSettings: Bool
+
+    var tooltip: String { accessibilityLabel }
+
+    static func make(
+        lifecycleState: AudioLifecycleState,
+        userEnabled: Bool,
+        bypassed: Bool,
+        lastFailure: AudioRuntimeFailure?
+    ) -> MenuBarRuntimePresentation {
+        let status: Status
+        switch lifecycleState {
+        case .failed:
+            status = .failed
+        case .sleeping:
+            status = .sleeping
+        case .starting:
+            status = .starting
+        case .recovering:
+            status = .recovering
+        case .stopping:
+            status = .stopping
+        case .running where bypassed:
+            status = .bypassed
+        case .running:
+            status = .active
+        case .inactive:
+            status = .stopped
+        }
+
+        let showsPermissionSettings = lastFailure?.isPermissionDenied == true
+        let showsRetryCapture = lifecycleState == .failed && lastFailure?.isRetryable == true
+
+        switch status {
+        case .active:
+            return .init(
+                status: status,
+                title: "Status: Active",
+                accessibilityLabel: "iQualize active",
+                symbolName: "slider.vertical.3",
+                appearsDisabled: false,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .bypassed:
+            return .init(
+                status: status,
+                title: "Status: Bypassed",
+                accessibilityLabel: "iQualize bypassed",
+                symbolName: "speaker.slash",
+                appearsDisabled: false,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .stopped:
+            return .init(
+                status: status,
+                title: userEnabled ? "Status: Stopped" : "Status: Off",
+                accessibilityLabel: userEnabled ? "iQualize stopped" : "iQualize off",
+                symbolName: "pause.circle",
+                appearsDisabled: true,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .failed:
+            return .init(
+                status: status,
+                title: failureTitle(for: lastFailure),
+                accessibilityLabel: failureAccessibilityLabel(for: lastFailure),
+                symbolName: "exclamationmark.triangle",
+                appearsDisabled: false,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .sleeping:
+            return .init(
+                status: status,
+                title: "Status: Sleeping",
+                accessibilityLabel: "iQualize sleeping",
+                symbolName: "moon.zzz",
+                appearsDisabled: true,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .starting:
+            return .init(
+                status: status,
+                title: "Status: Starting",
+                accessibilityLabel: "iQualize starting capture",
+                symbolName: "arrow.triangle.2.circlepath",
+                appearsDisabled: false,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .recovering:
+            return .init(
+                status: status,
+                title: "Status: Recovering",
+                accessibilityLabel: "iQualize recovering capture",
+                symbolName: "arrow.clockwise.circle",
+                appearsDisabled: false,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        case .stopping:
+            return .init(
+                status: status,
+                title: "Status: Stopping",
+                accessibilityLabel: "iQualize stopping capture",
+                symbolName: "stop.circle",
+                appearsDisabled: true,
+                showsRetryCapture: showsRetryCapture,
+                showsPermissionSettings: showsPermissionSettings
+            )
+        }
+    }
+
+    private static func failureTitle(for failure: AudioRuntimeFailure?) -> String {
+        guard let failure else { return "Status: Capture Failed" }
+        switch failure {
+        case .permissionDenied:
+            return "Status: Audio Capture Permission Needed"
+        case .helperMissing:
+            return "Status: Capture Helper Missing"
+        case .helperExited:
+            return "Status: Capture Helper Stopped"
+        case .deviceUnavailable:
+            return "Status: Output Device Unavailable"
+        case .transient:
+            return "Status: Capture Interrupted"
+        case .terminal:
+            return "Status: Capture Failed"
+        }
+    }
+
+    private static func failureAccessibilityLabel(for failure: AudioRuntimeFailure?) -> String {
+        guard let failure else { return "iQualize capture failed" }
+        switch failure {
+        case .permissionDenied:
+            return "iQualize needs audio capture permission"
+        case .helperMissing:
+            return "iQualize capture helper missing"
+        case .helperExited:
+            return "iQualize capture helper stopped"
+        case .deviceUnavailable:
+            return "iQualize output device unavailable"
+        case .transient:
+            return "iQualize capture interrupted"
+        case .terminal:
+            return "iQualize capture failed"
+        }
+    }
+}
+
+private extension AudioRuntimeFailure {
+    var isPermissionDenied: Bool {
+        if case .permissionDenied = self { return true }
+        return false
+    }
+
+    var isRetryable: Bool {
+        switch self {
+        case .permissionDenied, .helperExited, .deviceUnavailable, .transient:
+            return true
+        case .helperMissing, .terminal:
+            return false
+        }
+    }
+}

--- a/Sources/iQualize/PresetStore.swift
+++ b/Sources/iQualize/PresetStore.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Observation
+import os.log
+
+private let storeLog = OSLog(subsystem: "com.iqualize", category: "presets")
 
 @available(macOS 14.2, *)
 @Observable
@@ -16,6 +19,11 @@ final class PresetStore {
     /// (stable) id. A built-in with no entry here is still exactly what shipped. Independent
     /// of `hiddenBuiltInPresetIDs` — a built-in can be hidden, overridden, both, or neither.
     private(set) var builtInOverrides: [UUID: EQPresetData] = [:]
+
+    /// Human-readable descriptions of persisted blobs that failed to decode at load time.
+    /// Empty when everything loaded cleanly. The corrupt raw data is preserved under a
+    /// timestamped backup key (see `backUpCorruptBlob`) — never silently discarded.
+    private(set) var loadFailures: [String] = []
 
     var allPresets: [EQPresetData] {
         EQPresetData.builtInPresets
@@ -171,26 +179,57 @@ final class PresetStore {
     }
 
     private func load() {
-        if let data = defaults.data(forKey: Self.key),
-           let presets = try? JSONDecoder().decode([EQPresetData].self, from: data) {
+        if let presets = loadBlob([EQPresetData].self, key: Self.key, describedAs: "Custom presets") {
             customPresets = presets
         }
-        if let data = defaults.data(forKey: Self.favoritesKey),
-           let ids = try? JSONDecoder().decode([UUID].self, from: data) {
+        if let ids = loadBlob([UUID].self, key: Self.favoritesKey, describedAs: "Favorite presets") {
             favoritePresetIDs = ids
         }
-        if let data = defaults.data(forKey: Self.hiddenBuiltInsKey),
-           let ids = try? JSONDecoder().decode([UUID].self, from: data) {
+        if let ids = loadBlob([UUID].self, key: Self.hiddenBuiltInsKey, describedAs: "Hidden built-in presets") {
             hiddenBuiltInPresetIDs = ids
         }
-        if let data = defaults.data(forKey: Self.devicePinsKey),
-           let pins = try? JSONDecoder().decode([String: UUID].self, from: data) {
+        if let pins = loadBlob([String: UUID].self, key: Self.devicePinsKey, describedAs: "Per-device preset pins") {
             pinnedPresetIDByDeviceUID = pins
         }
-        if let data = defaults.data(forKey: Self.builtInOverridesKey),
-           let overrides = try? JSONDecoder().decode([UUID: EQPresetData].self, from: data) {
+        if let overrides = loadBlob([UUID: EQPresetData].self, key: Self.builtInOverridesKey, describedAs: "Built-in preset edits") {
             builtInOverrides = overrides
         }
+    }
+
+    /// Decodes one persisted blob. A missing key is normal (fresh install) and returns nil
+    /// silently. A decode failure preserves the raw bytes under a timestamped backup key,
+    /// logs, records a user-facing message in `loadFailures`, and returns nil so the caller
+    /// keeps its default — the damaged original is never the only copy when a later
+    /// `persist*()` overwrites the primary key.
+    private func loadBlob<T: Decodable>(_ type: T.Type, key: String, describedAs description: String) -> T? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            let backupKey = backUpCorruptBlob(data, key: key)
+            os_log(.error, log: storeLog,
+                   "failed to decode %{public}@ (%{public}@): %{public}@ — raw data preserved under %{public}@",
+                   key, description, String(describing: error), backupKey)
+            loadFailures.append("\(description) couldn't be read — original data preserved")
+            return nil
+        }
+    }
+
+    /// Writes the corrupt raw bytes under `<key>.corrupt.<ISO8601 timestamp>`. Backup keys
+    /// are disjoint from every `persist*()` key, so later saves can never clobber them.
+    /// Returns the backup key used.
+    private func backUpCorruptBlob(_ data: Data, key: String) -> String {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        var backupKey = "\(key).corrupt.\(timestamp)"
+        // A stored object at the candidate key means an earlier corruption was already
+        // preserved this second — suffix rather than overwrite an existing backup.
+        var n = 2
+        while defaults.object(forKey: backupKey) != nil {
+            backupKey = "\(key).corrupt.\(timestamp).\(n)"
+            n += 1
+        }
+        defaults.set(data, forKey: backupKey)
+        return backupKey
     }
 
     private func persist() {

--- a/Sources/iQualize/SettingsStore.swift
+++ b/Sources/iQualize/SettingsStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+// MARK: - Owned Settings Store
+
+/// The single owner of persisted app settings (#177). Holds one in-memory
+/// `iQualizeState` and persists it after every mutation.
+///
+/// Every write goes through a per-field setter or a synchronous `update`
+/// transaction on the same live instance, so a write that happens while a
+/// modal spins a nested run loop (or while a caller is suspended at an await)
+/// mutates the state the enclosing code will persist from — nothing is
+/// snapshotted and written back stale. This replaces the old whole-struct
+/// read-modify-write pattern, whose write clobbered any write made in between.
+///
+/// The persisted format is unchanged: same UserDefaults key, same JSON encoder,
+/// same decoder with its per-field fallbacks.
+@MainActor
+final class SettingsStore {
+    private(set) var state: iQualizeState
+    private let defaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        defaults = userDefaults
+        state = iQualizeState.readPersisted(from: userDefaults)
+    }
+
+    /// Mutates one field of the live instance and persists.
+    func set<T>(_ keyPath: WritableKeyPath<iQualizeState, T>, _ value: T) {
+        state[keyPath: keyPath] = value
+        persist()
+    }
+
+    /// Multi-field transaction for genuinely coupled writes (e.g. the
+    /// global/per-preset gain switch, the footer-toggle batch). The closure is
+    /// synchronous and non-escaping, so a transaction cannot straddle an await
+    /// or a modal by construction.
+    func update(_ mutate: (inout iQualizeState) -> Void) {
+        mutate(&state)
+        persist()
+    }
+
+    private func persist() {
+        state.writePersisted(to: defaults)
+    }
+}

--- a/Sources/iQualize/SettingsWindowController.swift
+++ b/Sources/iQualize/SettingsWindowController.swift
@@ -6,6 +6,7 @@ import ServiceManagement
 final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let audioEngine: AudioEngine
     private let presetStore: PresetStore
+    private let settings: SettingsStore
     private weak var eqWindowController: EQWindowController?
 
     private var peakLimiterCheckbox: NSButton!
@@ -30,9 +31,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private var linkGainCheckbox: NSButton!
     private var installCLIButton: NSButton!
 
-    init(audioEngine: AudioEngine, presetStore: PresetStore, eqWindowController: EQWindowController?) {
+    init(audioEngine: AudioEngine, presetStore: PresetStore, settings: SettingsStore, eqWindowController: EQWindowController?) {
         self.audioEngine = audioEngine
         self.presetStore = presetStore
+        self.settings = settings
         self.eqWindowController = eqWindowController
 
         let window = ShortcutAwareWindow(
@@ -61,7 +63,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
-        let state = iQualizeState.load()
+        let state = settings.state
         peakLimiterCheckbox.state = audioEngine.peakLimiter ? .on : .off
         maxGainPicker.selectItem(withTag: Int(audioEngine.maxGainDB))
         autoScaleCheckbox.state = state.autoScale ? .on : .off
@@ -92,7 +94,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func buildContent() -> NSView {
-        let state = iQualizeState.load()
+        let state = settings.state
 
         let mainStack = NSStackView()
         mainStack.orientation = .vertical
@@ -316,21 +318,19 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 
     @objc private func togglePeakLimiter(_ sender: NSButton) {
         audioEngine.peakLimiter = sender.state == .on
-        var state = iQualizeState.load()
-        state.peakLimiter = audioEngine.peakLimiter
-        state.save()
+        settings.set(\.peakLimiter, audioEngine.peakLimiter)
         eqWindowController?.syncPeakLimiter(audioEngine.peakLimiter)
     }
 
     @objc private func toggleLinkGainGlobally(_ sender: NSButton) {
         let makeGlobal = sender.state == .on
-        var state = iQualizeState.load()
         if makeGlobal {
             // Per-preset -> Global: current per-preset gain becomes the new shared baseline.
-            state.inputGainDB = audioEngine.inputGainDB
-            state.outputGainDB = audioEngine.outputGainDB
-            state.linkGainGlobally = true
-            state.save()
+            settings.update {
+                $0.inputGainDB = audioEngine.inputGainDB
+                $0.outputGainDB = audioEngine.outputGainDB
+                $0.linkGainGlobally = true
+            }
             audioEngine.gainIsGlobal = true
         } else {
             // Global -> Per-preset: seed the active preset with the current global gain,
@@ -345,8 +345,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
                 presetStore.saveCustomPreset(preset)
             }
             audioEngine.activePreset = preset
-            state.linkGainGlobally = false
-            state.save()
+            settings.set(\.linkGainGlobally, false)
         }
         eqWindowController?.syncGainIsGlobal(audioEngine.gainIsGlobal)
         eqWindowController?.syncUIToPreset()
@@ -355,130 +354,98 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     @objc private func maxGainChanged(_ sender: NSPopUpButton) {
         guard let item = sender.selectedItem else { return }
         audioEngine.maxGainDB = Float(item.tag)
-        var state = iQualizeState.load()
-        state.maxGainDB = audioEngine.maxGainDB
-        state.save()
+        settings.set(\.maxGainDB, audioEngine.maxGainDB)
         eqWindowController?.syncMaxGain(audioEngine.maxGainDB)
     }
 
     @objc private func toggleAutoScale(_ sender: NSButton) {
         let on = sender.state == .on
         maxGainPicker.isEnabled = !on
-        var state = iQualizeState.load()
-        state.autoScale = on
-        state.save()
+        settings.set(\.autoScale, on)
         eqWindowController?.syncAutoScale(on)
     }
 
     @objc private func togglePreEqSpectrum(_ sender: NSButton) {
         let on = sender.state == .on
-        var state = iQualizeState.load()
-        state.preEqSpectrumEnabled = on
-        state.save()
+        settings.set(\.preEqSpectrumEnabled, on)
         eqWindowController?.syncPreEqSpectrum(on)
     }
 
     @objc private func togglePostEqSpectrum(_ sender: NSButton) {
         let on = sender.state == .on
-        var state = iQualizeState.load()
-        state.postEqSpectrumEnabled = on
-        state.save()
+        settings.set(\.postEqSpectrumEnabled, on)
         eqWindowController?.syncPostEqSpectrum(on)
     }
 
     @objc private func preEqLineColorChanged(_ sender: NSColorWell) {
         let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
-        var state = iQualizeState.load()
-        state.preEqLineColorHex = srgb.srgbHexRGB
-        state.save()
+        settings.set(\.preEqLineColorHex, srgb.srgbHexRGB)
         eqWindowController?.syncPreEqLineColor(srgb)
     }
 
     @objc private func postEqLineColorChanged(_ sender: NSColorWell) {
         let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
-        var state = iQualizeState.load()
-        state.postEqLineColorHex = srgb.srgbHexRGB
-        state.save()
+        settings.set(\.postEqLineColorHex, srgb.srgbHexRGB)
         eqWindowController?.syncPostEqLineColor(srgb)
     }
 
     @objc private func resetPreEqLineColor(_ sender: NSButton) {
-        var state = iQualizeState.load()
-        state.preEqLineColorHex = nil
-        state.save()
+        settings.set(\.preEqLineColorHex, nil)
         preEqLineColorWell.color = .systemCyan
         eqWindowController?.syncPreEqLineColor(.systemCyan)
     }
 
     @objc private func resetPostEqLineColor(_ sender: NSButton) {
-        var state = iQualizeState.load()
-        state.postEqLineColorHex = nil
-        state.save()
+        settings.set(\.postEqLineColorHex, nil)
         postEqLineColorWell.color = .systemOrange
         eqWindowController?.syncPostEqLineColor(.systemOrange)
     }
 
     @objc private func togglePreEqFill(_ sender: NSButton) {
         let on = sender.state == .on
-        var state = iQualizeState.load()
-        state.preEqFillEnabled = on
-        state.save()
+        settings.set(\.preEqFillEnabled, on)
         eqWindowController?.syncPreEqFillEnabled(on)
     }
 
     @objc private func togglePostEqFill(_ sender: NSButton) {
         let on = sender.state == .on
-        var state = iQualizeState.load()
-        state.postEqFillEnabled = on
-        state.save()
+        settings.set(\.postEqFillEnabled, on)
         eqWindowController?.syncPostEqFillEnabled(on)
     }
 
     @objc private func preEqFillColorChanged(_ sender: NSColorWell) {
         let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
-        var state = iQualizeState.load()
-        state.preEqFillColorHex = srgb.srgbHexRGB
-        state.save()
+        settings.set(\.preEqFillColorHex, srgb.srgbHexRGB)
         eqWindowController?.syncPreEqFillColor(srgb)
     }
 
     @objc private func postEqFillColorChanged(_ sender: NSColorWell) {
         let srgb = sender.color.usingColorSpace(.sRGB) ?? sender.color
-        var state = iQualizeState.load()
-        state.postEqFillColorHex = srgb.srgbHexRGB
-        state.save()
+        settings.set(\.postEqFillColorHex, srgb.srgbHexRGB)
         eqWindowController?.syncPostEqFillColor(srgb)
     }
 
     @objc private func resetPreEqFillColor(_ sender: NSButton) {
-        var state = iQualizeState.load()
-        state.preEqFillColorHex = nil
-        state.save()
+        settings.set(\.preEqFillColorHex, nil)
         preEqFillColorWell.color = .systemCyan
         eqWindowController?.syncPreEqFillColor(.systemCyan)
     }
 
     @objc private func resetPostEqFillColor(_ sender: NSButton) {
-        var state = iQualizeState.load()
-        state.postEqFillColorHex = nil
-        state.save()
+        settings.set(\.postEqFillColorHex, nil)
         postEqFillColorWell.color = .systemOrange
         eqWindowController?.syncPostEqFillColor(.systemOrange)
     }
 
     @objc private func bandwidthModeChanged(_ sender: NSSegmentedControl) {
         let asQ = sender.selectedSegment == 0
-        var state = iQualizeState.load()
-        state.showBandwidthAsQ = asQ
-        state.save()
+        settings.set(\.showBandwidthAsQ, asQ)
         eqWindowController?.syncBandwidthMode(asQ: asQ)
     }
 
     @objc private func themeChanged(_ sender: NSSegmentedControl) {
         let preference = Self.themePreference(for: sender.selectedSegment)
-        var state = iQualizeState.load()
-        state.dreamTheme = preference.rawValue
-        state.save()
+        settings.set(\.dreamTheme, preference.rawValue)
         eqWindowController?.syncTheme(preference)
     }
 
@@ -500,11 +467,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     }
 
     @objc private func toggleHideFromDock(_ sender: NSButton) {
-        var state = iQualizeState.load()
-        state.hideFromDock = sender.state == .on
-        state.save()
-        NSApp.setActivationPolicy(state.hideFromDock ? .accessory : .regular)
-        if !state.hideFromDock {
+        let hide = sender.state == .on
+        settings.set(\.hideFromDock, hide)
+        NSApp.setActivationPolicy(hide ? .accessory : .regular)
+        if !hide {
             NSApp.activate(ignoringOtherApps: true)
         }
     }
@@ -523,9 +489,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
             alert.runModal()
         }
         sender.state = SMAppService.mainApp.status == .enabled ? .on : .off
-        var state = iQualizeState.load()
-        state.startAtLogin = SMAppService.mainApp.status == .enabled
-        state.save()
+        settings.set(\.startAtLogin, SMAppService.mainApp.status == .enabled)
     }
 
     // MARK: - Command Line Tool

--- a/Sources/iQualize/iQualizeApp.swift
+++ b/Sources/iQualize/iQualizeApp.swift
@@ -9,6 +9,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var audioEngine: AudioEngine!
     private var presetStore: PresetStore!
     private var cliControlServer: CLIControlServer!
+    private let settings: SettingsStore
+
+    init(settings: SettingsStore) {
+        self.settings = settings
+        super.init()
+    }
     private var terminationInProgress = false
     var isRealQuit = false
 
@@ -21,17 +27,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
         audioEngine = AudioEngine()
         presetStore = PresetStore()
-        menuBarController = MenuBarController(audioEngine: audioEngine, presetStore: presetStore)
+        menuBarController = MenuBarController(audioEngine: audioEngine, presetStore: presetStore, settings: settings)
 
         cliControlServer = CLIControlServer(handler: menuBarController)
         cliControlServer.start()
 
         // Sync login item state (user may have changed it in System Settings)
-        var launchState = iQualizeState.load()
         let systemEnabled = SMAppService.mainApp.status == .enabled
-        if launchState.startAtLogin != systemEnabled {
-            launchState.startAtLogin = systemEnabled
-            launchState.save()
+        if settings.state.startAtLogin != systemEnabled {
+            settings.set(\.startAtLogin, systemEnabled)
         }
 
         // Sleep/wake handling
@@ -77,10 +81,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             window.close()
         }
         NSApp.setActivationPolicy(.accessory)
-        var state = iQualizeState.load()
-        state.hideFromDock = true
-        state.windowOpen = false
-        state.save()
+        settings.update {
+            $0.hideFromDock = true
+            $0.windowOpen = false
+        }
         return .terminateCancel
     }
 
@@ -229,9 +233,9 @@ struct iQualizeMain {
     static func main() {
         if #available(macOS 14.2, *) {
             let app = NSApplication.shared
-            let launchState = iQualizeState.load()
-            app.setActivationPolicy(launchState.hideFromDock ? .accessory : .regular)
-            let delegate = AppDelegate()
+            let settings = SettingsStore()
+            app.setActivationPolicy(settings.state.hideFromDock ? .accessory : .regular)
+            let delegate = AppDelegate(settings: settings)
             appDelegate = delegate
             app.delegate = delegate
             app.run()

--- a/Sources/iQualizeCapture/main.swift
+++ b/Sources/iQualizeCapture/main.swift
@@ -17,21 +17,16 @@ import CoreAudio
 import AudioToolbox
 import Darwin
 import Foundation
+import IQCaptureProtocol
 import IQRingAtomics
 import os.log
 
 private let capLog = OSLog(subsystem: "com.iqualize", category: "capture-helper")
 
 // MARK: - Shared layout
-
-struct SharedHeader {
-    var writeHead: UInt64 = 0
-    var readHead: UInt64 = 0
-    var sampleRate: Float64 = 0
-    var channels: UInt32 = 0
-    var capacityFloats: UInt32 = 0
-    var _pad: (UInt64, UInt64, UInt32) = (0, 0, 0)
-}
+//
+// SharedHeader and the layout version live in IQCaptureProtocol — one
+// definition shared with the app's CaptureClient (#175).
 
 // MARK: - State (all nonisolated for the IOProc + signal handlers)
 
@@ -68,11 +63,33 @@ func stderrLog(_ s: String) {
     FileHandle.standardError.write((s + "\n").data(using: .utf8)!)
 }
 
-func caCheckExit(_ status: OSStatus, _ msg: String, code: Int32) {
+func writeStartupFailure(_ failure: CaptureStartupFailure) {
+    guard let lineData = try? failure.encodedLine() else { return }
+    lineData.withUnsafeBytes { buf in
+        var remaining = buf.count
+        var p = buf.baseAddress!
+        while remaining > 0 {
+            let n = write(STDOUT_FILENO, p, remaining)
+            if n <= 0 { break }
+            remaining -= n
+            p = p.advanced(by: n)
+        }
+    }
+    fsync(STDOUT_FILENO)
+}
+
+func failStartup(_ failure: CaptureStartupFailure) -> Never {
+    writeStartupFailure(failure)
+    cleanupOnce()
+    exit(failure.exitCode)
+}
+
+func caCheckExit(_ status: OSStatus, stage: CaptureStartupFailure.Stage,
+                 _ msg: String, exitCode: Int32) {
     if status != noErr {
         stderrLog("[capture] \(msg): OSStatus \(status)")
-        cleanupOnce()
-        exit(code)
+        failStartup(CaptureStartupFailure(stage: stage, exitCode: exitCode,
+                                          osStatus: Int32(status)))
     }
 }
 
@@ -329,7 +346,7 @@ func run() {
     os_log(.default, log: capLog, "about to create process tap")
     caCheckExit(
         AudioHardwareCreateProcessTap(tapDesc, &tapID),
-        "Failed to create process tap", code: 10
+        stage: .processTap, "Failed to create process tap", exitCode: 10
     )
     tapDescription = tapDesc
     os_log(.default, log: capLog, "tap created id=%{public}d", tapID)
@@ -344,7 +361,7 @@ func run() {
     var formatSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
     caCheckExit(
         AudioObjectGetPropertyData(tapID, &formatAddr, 0, nil, &formatSize, &tapFormat),
-        "Failed to read tap format", code: 11
+        stage: .tapFormat, "Failed to read tap format", exitCode: 11
     )
     let sampleRate = tapFormat.mSampleRate
     let channels = tapFormat.mChannelsPerFrame
@@ -356,7 +373,7 @@ func run() {
     dataMask = UInt64(dataFloatsPow2 - 1)
 
     // 4. Allocate shared memory
-    let headerSize = (MemoryLayout<SharedHeader>.stride + 63) & ~63
+    let headerSize = CaptureLayout.alignedHeaderSize
     let dataBytes = dataFloatsPow2 * MemoryLayout<Float>.size
     shmTotalSize = size_t(headerSize + dataBytes)
 
@@ -364,19 +381,19 @@ func run() {
     shmFD = shmPath.withCString { open($0, O_CREAT | O_RDWR, 0o666) }
     if shmFD < 0 {
         stderrLog("[capture] open(\(shmPath)) failed: errno=\(errno)")
-        cleanupOnce(); exit(20)
+        failStartup(CaptureStartupFailure(stage: .sharedMemory, exitCode: 20))
     }
     // Belt-and-suspenders for cross-process access between differently
     // signed binaries: explicit fchmod after creation.
     _ = fchmod(shmFD, 0o666)
     if ftruncate(shmFD, off_t(shmTotalSize)) != 0 {
         stderrLog("[capture] ftruncate failed: errno=\(errno)")
-        cleanupOnce(); exit(21)
+        failStartup(CaptureStartupFailure(stage: .sharedMemory, exitCode: 21))
     }
     guard let mapped = mmap(nil, shmTotalSize, PROT_READ | PROT_WRITE, MAP_SHARED, shmFD, 0),
           mapped != MAP_FAILED else {
         stderrLog("[capture] mmap failed: errno=\(errno)")
-        cleanupOnce(); exit(22)
+        failStartup(CaptureStartupFailure(stage: .sharedMemory, exitCode: 22))
     }
 
     headerPtr = mapped.bindMemory(to: SharedHeader.self, capacity: 1)
@@ -384,7 +401,8 @@ func run() {
         writeHead: 0, readHead: 0,
         sampleRate: sampleRate,
         channels: channels,
-        capacityFloats: UInt32(dataFloatsPow2)
+        capacityFloats: UInt32(dataFloatsPow2),
+        layoutVersion: CaptureLayout.version
     )
     writeHeadFieldPtr = mapped
         .advanced(by: MemoryLayout<SharedHeader>.offset(of: \.writeHead)!)
@@ -409,7 +427,7 @@ func run() {
     ]
     caCheckExit(
         AudioHardwareCreateAggregateDevice(aggDesc as CFDictionary, &aggID),
-        "Failed to create aggregate", code: 30
+        stage: .aggregateDevice, "Failed to create aggregate", exitCode: 30
     )
 
     // Wait for device alive
@@ -458,11 +476,11 @@ func run() {
 
     caCheckExit(
         AudioDeviceCreateIOProcIDWithBlock(&procID, aggID, nil, ioBlock),
-        "Failed to create IOProc", code: 31
+        stage: .ioProc, "Failed to create IOProc", exitCode: 31
     )
     caCheckExit(
         AudioDeviceStart(aggID, procID),
-        "Failed to start aggregate", code: 32
+        stage: .ioProc, "Failed to start aggregate", exitCode: 32
     )
     os_log(.default, log: capLog, "aggregate started, about to handshake")
 
@@ -475,6 +493,7 @@ func run() {
         "sampleRate": sampleRate,
         "channels": Int(channels),
         "ringCapacityFloats": dataFloatsPow2,
+        "layoutVersion": Int(CaptureLayout.version),
     ]
     let jsonData = try! JSONSerialization.data(withJSONObject: handshake, options: [])
     var lineData = jsonData
@@ -554,5 +573,5 @@ if #available(macOS 14.2, *) {
     dispatchMain()
 } else {
     stderrLog("[capture] requires macOS 14.2+")
-    exit(99)
+    failStartup(CaptureStartupFailure(stage: .environment, exitCode: 99))
 }

--- a/Tests/iQualizeTests/AudioLifecycleTests.swift
+++ b/Tests/iQualizeTests/AudioLifecycleTests.swift
@@ -11,7 +11,8 @@ private final class LifecycleProbe {
     var readinessChecks = 0
     var ready = true
     var readyAfterChecks: Int?
-    var publishedErrors: [String?] = []
+    var publishedFailures: [AudioRuntimeFailure?] = []
+    var nextError: Error?
 
     func start() throws {
         starts += 1
@@ -20,6 +21,9 @@ private final class LifecycleProbe {
         defer { activeOperations -= 1 }
         if failuresRemaining > 0 {
             failuresRemaining -= 1
+            if let nextError {
+                throw nextError
+            }
             throw NSError(domain: "LifecycleTests", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "synthetic startup failure"])
         }
@@ -107,7 +111,7 @@ final class AudioLifecycleTests: XCTestCase {
             stopOperation: { @MainActor in probe.stop() },
             readiness: { @MainActor in probe.isReady() },
             publishSnapshot: { @MainActor _ in },
-            publishError: { @MainActor message in probe.publishedErrors.append(message) },
+            publishFailure: { @MainActor failure in probe.publishedFailures.append(failure) },
             wakePolicy: wakePolicy,
             helperPolicy: helperPolicy,
             historyLimit: historyLimit,
@@ -115,7 +119,7 @@ final class AudioLifecycleTests: XCTestCase {
         )
     }
 
-    func testFailedStartCleansUpAndPreservesError() async {
+    func testFailedStartCleansUpAndPublishesTypedFailure() async {
         let probe = await MainActor.run { LifecycleProbe() }
         await MainActor.run { probe.failuresRemaining = 1 }
         let coordinator = makeCoordinator(probe: probe)
@@ -123,12 +127,67 @@ final class AudioLifecycleTests: XCTestCase {
         await coordinator.setUserEnabled(true)
 
         let snapshot = await coordinator.snapshot()
-        let values = await MainActor.run { (probe.starts, probe.stops, probe.publishedErrors) }
+        let values = await MainActor.run { (probe.starts, probe.stops, probe.publishedFailures) }
         XCTAssertEqual(snapshot.state, .failed)
         XCTAssertTrue(snapshot.userEnabled)
         XCTAssertEqual(values.0, 1)
         XCTAssertEqual(values.1, 1)
-        XCTAssertTrue(values.2.contains("synthetic startup failure"))
+        XCTAssertEqual(values.2.last!, .terminal(.unknown))
+    }
+
+    func testFailedStartPublishesTypedFailureAndDisablePreservesIt() async {
+        let probe = await MainActor.run { LifecycleProbe() }
+        await MainActor.run {
+            probe.failuresRemaining = 1
+            probe.nextError = CaptureClientError.helperMissing(path: "/missing/iQualizeCapture")
+        }
+        let coordinator = makeCoordinator(probe: probe)
+
+        await coordinator.setUserEnabled(true)
+        await coordinator.setUserEnabled(false)
+
+        let snapshot = await coordinator.snapshot()
+        let failures = await MainActor.run { probe.publishedFailures }
+        XCTAssertEqual(snapshot.state, .inactive)
+        XCTAssertEqual(failures.last!, .helperMissing(.init(path: "/missing/iQualizeCapture")))
+    }
+
+    func testNewerFailureReplacesPreviousFailure() async {
+        let probe = await MainActor.run { LifecycleProbe() }
+        let coordinator = makeCoordinator(probe: probe)
+
+        await MainActor.run {
+            probe.failuresRemaining = 1
+            probe.nextError = CaptureClientError.helperMissing(path: "/missing/iQualizeCapture")
+        }
+        await coordinator.setUserEnabled(true)
+
+        await MainActor.run {
+            probe.failuresRemaining = 1
+            probe.nextError = CaptureClientError.unexpectedExit(status: 9, signaled: true)
+        }
+        await coordinator.setUserEnabled(true)
+
+        let failures = await MainActor.run { probe.publishedFailures }
+        XCTAssertEqual(failures.compactMap { $0 }.last, .helperExited(.init(status: 9, signaled: true)))
+    }
+
+    func testSuccessfulRetryClearsTypedFailure() async {
+        let probe = await MainActor.run { LifecycleProbe() }
+        let coordinator = makeCoordinator(probe: probe)
+
+        await MainActor.run {
+            probe.failuresRemaining = 1
+            probe.nextError = CaptureClientError.handshakeTimeout(seconds: 0.25)
+        }
+        await coordinator.setUserEnabled(true)
+        await MainActor.run { probe.nextError = nil }
+        await coordinator.wake()
+
+        let snapshot = await coordinator.snapshot()
+        let failures = await MainActor.run { probe.publishedFailures }
+        XCTAssertEqual(snapshot.state, .running)
+        XCTAssertNil(failures.last!)
     }
 
     func testHelperRecoveryRetriesAndReturnsToRunning() async {
@@ -164,12 +223,11 @@ final class AudioLifecycleTests: XCTestCase {
         await coordinator.helperTerminated()
 
         let snapshot = await coordinator.snapshot()
-        let stops = await MainActor.run { probe.stops }
+        let values = await MainActor.run { (probe.stops, probe.publishedFailures) }
         XCTAssertEqual(snapshot.state, .failed)
-        XCTAssertGreaterThanOrEqual(stops, 4)
-        XCTAssertTrue(snapshot.history.contains {
-            $0.outcome == .failed && $0.message?.contains("failed repeatedly") == true
-        })
+        XCTAssertGreaterThanOrEqual(values.0, 4)
+        XCTAssertTrue(snapshot.history.contains { $0.outcome == .failed && $0.message == nil })
+        XCTAssertEqual(values.1.last!, .terminal(.unknown))
     }
 
     func testWakeWaitsForReadinessAndRetries() async {

--- a/Tests/iQualizeTests/AudioRuntimeFailureClassifierTests.swift
+++ b/Tests/iQualizeTests/AudioRuntimeFailureClassifierTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import CoreAudio
+import IQCaptureProtocol
+@testable import iQualize
+
+final class AudioRuntimeFailureClassifierTests: XCTestCase {
+    func testClassifiesCaptureClientErrorsWithoutLocalizedDescription() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(CaptureClientError.helperMissing(path: "/app/iQualizeCapture")),
+            .helperMissing(.init(path: "/app/iQualizeCapture"))
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(CaptureClientError.unexpectedExit(status: 9, signaled: true)),
+            .helperExited(.init(status: 9, signaled: true))
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(CaptureClientError.handshakeTimeout(seconds: 1.5)),
+            .transient(.handshakeTimeout(seconds: 1.5))
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(CaptureClientError.malformedHandshake),
+            .terminal(.malformedHandshake)
+        )
+    }
+
+    func testClassifiesProcessTapPermissionStatus() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .processTap, exitCode: 10, osStatus: kAudioDevicePermissionsError)
+            ),
+            .permissionDenied(.processTap(status: kAudioDevicePermissionsError))
+        )
+    }
+
+    func testClassifiesProcessTapNonPermissionStatusAsHelperStartup() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .processTap, exitCode: 10, osStatus: -54)
+            ),
+            .terminal(.helperStartup(stage: .processTap, exitCode: 10, osStatus: -54))
+        )
+    }
+
+    func testClassifiesProcessTapNilStatusAsHelperStartup() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .processTap, exitCode: 10, osStatus: nil)
+            ),
+            .terminal(.helperStartup(stage: .processTap, exitCode: 10, osStatus: nil))
+        )
+    }
+
+    func testClassifiesStructuredStartupFailures() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .aggregateDevice, exitCode: 30, osStatus: -200)
+            ),
+            .deviceUnavailable(.coreAudioStatus(-200))
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .ioProc, exitCode: 40, osStatus: -201)
+            ),
+            .deviceUnavailable(.coreAudioStatus(-201))
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .sharedMemory, exitCode: 20, osStatus: nil)
+            ),
+            .transient(.sharedMemoryStartup(exitCode: 20))
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureStartupFailure(stage: .tapFormat, exitCode: 11, osStatus: -201)
+            ),
+            .terminal(.helperStartup(stage: .tapFormat, exitCode: 11, osStatus: -201))
+        )
+    }
+
+    func testClassifiesCaptureProtocolErrors() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureProtocolError.invalidGeometry("channels=0")
+            ),
+            .terminal(.invalidCaptureGeometry)
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureProtocolError.unsupportedLayoutVersion(received: 2, supported: 1)
+            ),
+            .terminal(.captureProtocolViolation)
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                CaptureProtocolError.mappedHeaderMismatch("header channels=1, handshake=2")
+            ),
+            .terminal(.captureProtocolViolation)
+        )
+    }
+
+    func testClassifiesNSErrorFallbacksConservatively() {
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                NSError(domain: "iQualize", code: -201, userInfo: [:])
+            ),
+            .terminal(.renderConfiguration)
+        )
+        XCTAssertEqual(
+            AudioRuntimeFailureClassifier.classify(
+                NSError(domain: "Other", code: 1, userInfo: [:])
+            ),
+            .terminal(.unknown)
+        )
+    }
+}

--- a/Tests/iQualizeTests/CaptureClientHandshakeTests.swift
+++ b/Tests/iQualizeTests/CaptureClientHandshakeTests.swift
@@ -1,4 +1,6 @@
+import Darwin
 import XCTest
+import IQCaptureProtocol
 @testable import iQualize
 
 final class CaptureClientHandshakeTests: XCTestCase {
@@ -20,10 +22,99 @@ final class CaptureClientHandshakeTests: XCTestCase {
     }
 
     private func makeHelper(body: String) throws -> URL {
-        let url = temporaryDirectory.appendingPathComponent("helper.sh")
+        let url = temporaryDirectory.appendingPathComponent("helper-\(UUID().uuidString).sh")
         try "#!/bin/sh\nset -e\n\(body)\n".write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
         return url
+    }
+
+    private func ringHelper(
+        layoutVersion: Int? = Int(CaptureLayout.version),
+        totalSize: Int = 4160,
+        headerSize: Int = CaptureLayout.alignedHeaderSize,
+        sampleRate: Double = 48000,
+        channels: Int = 2,
+        ringCapacityFloats: Int = 1024,
+        headerLayoutVersion: Int? = Int(CaptureLayout.version),
+        headerSampleRate: Double? = nil,
+        headerChannels: Int? = nil,
+        headerCapacityFloats: Int? = nil,
+        fileSize: Int? = nil
+    ) throws -> (helper: URL, shmPath: URL) {
+        let shmPath = temporaryDirectory.appendingPathComponent("ring-\(UUID().uuidString).bin")
+        var fields = [
+            "shmPath": shmPath.path,
+            "totalSize": totalSize,
+            "headerSize": headerSize,
+            "sampleRate": sampleRate,
+            "channels": channels,
+            "ringCapacityFloats": ringCapacityFloats,
+        ] as [String: Any]
+        if let layoutVersion {
+            fields["layoutVersion"] = layoutVersion
+        }
+        let handshakeData = try JSONSerialization.data(withJSONObject: fields, options: [.sortedKeys])
+        let handshake = String(data: handshakeData, encoding: .utf8)!
+
+        let hVersion = headerLayoutVersion ?? 0
+        let hSampleRate = headerSampleRate ?? sampleRate
+        let hChannels = headerChannels ?? channels
+        let hCapacityFloats = headerCapacityFloats ?? ringCapacityFloats
+        let actualFileSize = fileSize ?? totalSize
+        let body = #"""
+            path='__PATH__'
+            cleanup() { rm -f "$path"; }
+            trap cleanup EXIT HUP INT TERM
+            /usr/bin/python3 - <<'PY'
+            import struct
+            path = '__PATH__'
+            total_size = __TOTAL_SIZE__
+            header_size = __HEADER_SIZE__
+            capacity = max(__HEADER_CAPACITY__, 0)
+            header = struct.pack('<QQdIIIIQQ', 0, 0, __HEADER_SAMPLE_RATE__, __HEADER_CHANNELS__, capacity, __HEADER_VERSION__, 0, 0, 0)
+            header = header + bytes(max(header_size - len(header), 0))
+            data_size = max(total_size - len(header), 0)
+            with open(path, 'wb') as f:
+                f.write(header[:total_size])
+                if data_size:
+                    f.write(bytes(data_size))
+            PY
+            printf '__HANDSHAKE__\n'
+            while read line; do :; done
+            """#
+            .replacingOccurrences(of: "__PATH__", with: shmPath.path.replacingOccurrences(of: "'", with: "'\\''"))
+            .replacingOccurrences(of: "__TOTAL_SIZE__", with: String(actualFileSize))
+            .replacingOccurrences(of: "__HEADER_SIZE__", with: String(headerSize))
+            .replacingOccurrences(of: "__HEADER_SAMPLE_RATE__", with: String(hSampleRate))
+            .replacingOccurrences(of: "__HEADER_CHANNELS__", with: String(hChannels))
+            .replacingOccurrences(of: "__HEADER_CAPACITY__", with: String(hCapacityFloats))
+            .replacingOccurrences(of: "__HEADER_VERSION__", with: String(hVersion))
+            .replacingOccurrences(of: "__HANDSHAKE__", with: handshake.replacingOccurrences(of: "'", with: "'\\''"))
+        return (try makeHelper(body: body), shmPath)
+    }
+
+    private func assertStartFails(
+        helper: URL,
+        shmPath: URL? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        verify: (Error) -> Void
+    ) {
+        let client = CaptureClient(handshakeTimeoutNanoseconds: 5_000_000_000)
+        XCTAssertThrowsError(try client.start(helperURL: helper), file: file, line: line) { error in
+            verify(error)
+        }
+        XCTAssertEqual(client.sampleRate, 0, file: file, line: line)
+        XCTAssertEqual(client.channels, 0, file: file, line: line)
+        if let shmPath {
+            // Give the helper's EXIT trap time to remove the file after the
+            // client closes stdin / terminates it on failed start. The helper
+            // may still be unwinding CoreAudio cleanup when stop() returns.
+            for _ in 0..<200 where FileManager.default.fileExists(atPath: shmPath.path) {
+                usleep(10_000)
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: shmPath.path), file: file, line: line)
+        }
     }
 
     func testHandshakeTimeoutTerminatesAHelperThatNeverWrites() throws {
@@ -52,19 +143,217 @@ final class CaptureClientHandshakeTests: XCTestCase {
         }
     }
 
-    func testCompleteHandshakeWithinTheDeadlineMapsAndStopsCleanly() throws {
-        let helper = try makeHelper(body: #"""
-            path="${TMPDIR:-/tmp}/iqualize-test-shm-$$"
-            dd if=/dev/zero of="$path" bs=4096 count=1 2>/dev/null
-            sleep 0.05
-            printf '{"shmPath":"%s","totalSize":4096,"headerSize":64,"sampleRate":48000,"channels":2,"ringCapacityFloats":1024}\n' "$path"
-            while read line; do :; done
-            """#)
-        let client = CaptureClient(handshakeTimeoutNanoseconds: 500_000_000)
+    func testStartupFailureLineDecodesWithStageExitCodeAndOSStatus() throws {
+        let failure = CaptureStartupFailure(stage: .processTap, exitCode: 10, osStatus: -1)
+        let line = try failure.encodedLine()
+        XCTAssertEqual(
+            try CaptureStartupFailure.decodeIfPresent(from: Data(line.dropLast())),
+            failure
+        )
+        XCTAssertNil(try CaptureStartupFailure.decodeIfPresent(
+            from: Data(#"{"shmPath":"/tmp/legacy"}"#.utf8)
+        ))
+    }
 
-        try client.start(helperURL: helper)
+    func testStructuredHelperFailureIsTypedAndLeavesNoOrphan() throws {
+        let shmPath = temporaryDirectory.appendingPathComponent("structured-failure.bin")
+        let failure = CaptureStartupFailure(stage: .processTap, exitCode: 10, osStatus: -1)
+        let wire = String(data: try failure.encodedLine(), encoding: .utf8)!
+            .trimmingCharacters(in: .newlines)
+        let body = #"""
+            path='__PATH__'
+            trap 'rm -f "$path"' EXIT HUP INT TERM
+            touch "$path"
+            printf '%s\n' '__WIRE__'
+            while read line; do :; done
+            """#
+            .replacingOccurrences(of: "__PATH__", with: shmPath.path)
+            .replacingOccurrences(of: "__WIRE__", with: wire)
+
+        assertStartFails(helper: try makeHelper(body: body), shmPath: shmPath) { error in
+            guard case .helperStartupFailed(let received) = error as? CaptureClientError else {
+                return XCTFail("expected a structured helper failure, got \(error)")
+            }
+            XCTAssertEqual(received, failure)
+        }
+    }
+
+    func testMissingMalformedAndUnexpectedHelperExitsRemainDistinct() throws {
+        let missing = temporaryDirectory.appendingPathComponent("missing-helper")
+        XCTAssertThrowsError(try CaptureClient(handshakeTimeoutNanoseconds: 50_000_000)
+            .start(helperURL: missing)) { error in
+            guard case .helperMissing = error as? CaptureClientError else {
+                return XCTFail("expected missing helper, got \(error)")
+            }
+        }
+
+        let malformed = try makeHelper(body: "echo '{\"messageType\":\"failure\"}'; sleep 30")
+        XCTAssertThrowsError(try CaptureClient(handshakeTimeoutNanoseconds: 5_000_000_000)
+            .start(helperURL: malformed)) { error in
+            guard case .malformedHandshake = error as? CaptureClientError else {
+                return XCTFail("expected malformed handshake, got \(error)")
+            }
+        }
+
+        let unexpected = try makeHelper(body: "exit 37")
+        XCTAssertThrowsError(try CaptureClient(handshakeTimeoutNanoseconds: 5_000_000_000)
+            .start(helperURL: unexpected)) { error in
+            guard case .unexpectedExit(let status, let signaled) = error as? CaptureClientError else {
+                return XCTFail("expected unexpected exit, got \(error)")
+            }
+            XCTAssertEqual(status, 37)
+            XCTAssertFalse(signaled)
+        }
+    }
+
+    func testCompleteHandshakeWithinTheDeadlineMapsAndStopsCleanly() throws {
+        let fixture = try ringHelper()
+        let client = CaptureClient(handshakeTimeoutNanoseconds: 5_000_000_000)
+
+        try client.start(helperURL: fixture.helper)
+        XCTAssertEqual(client.sampleRate, 48000)
+        XCTAssertEqual(client.channels, 2)
+        XCTAssertEqual(client.capacityFloats, 1024)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.shmPath.path))
+        client.stop()
+    }
+
+    func testAbsentLayoutVersionIsAcceptedAsLegacyVersionOne() throws {
+        let fixture = try ringHelper(layoutVersion: nil, headerLayoutVersion: 0)
+        let client = CaptureClient(handshakeTimeoutNanoseconds: 5_000_000_000)
+
+        try client.start(helperURL: fixture.helper)
         XCTAssertEqual(client.sampleRate, 48000)
         XCTAssertEqual(client.channels, 2)
         client.stop()
+    }
+
+    func testChannelsZeroFailsBeforeMappingAndLeavesNoOrphan() throws {
+        let fixture = try ringHelper(channels: 0, headerChannels: 0)
+        assertStartFails(helper: fixture.helper, shmPath: fixture.shmPath) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("channels=0"))
+        }
+    }
+
+    func testNonPowerOfTwoCapacityFailsBeforeMappingAndLeavesNoOrphan() throws {
+        let fixture = try ringHelper(totalSize: 4164, ringCapacityFloats: 1025, headerCapacityFloats: 1025)
+        assertStartFails(helper: fixture.helper, shmPath: fixture.shmPath) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("not a power of two"))
+        }
+    }
+
+    func testInconsistentHandshakeGeometryFailsBeforeMappingAndLeavesNoOrphan() throws {
+        let fixture = try ringHelper(totalSize: 4096)
+        assertStartFails(helper: fixture.helper, shmPath: fixture.shmPath) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("totalSize=4096"))
+        }
+    }
+
+    func testUnsupportedLayoutVersionFailsBeforeMappingAndLeavesNoOrphan() throws {
+        let fixture = try ringHelper(layoutVersion: 2, headerLayoutVersion: 2)
+        assertStartFails(helper: fixture.helper, shmPath: fixture.shmPath) { error in
+            guard case CaptureProtocolError.unsupportedLayoutVersion(let received, let supported) = error else {
+                return XCTFail("expected unsupported version, got \(error)")
+            }
+            XCTAssertEqual(received, 2)
+            XCTAssertEqual(supported, CaptureLayout.version)
+        }
+    }
+
+    func testBackingFileSizeMismatchFailsBeforeMappingAndLeavesNoOrphan() throws {
+        let fixture = try ringHelper(fileSize: 4096)
+        assertStartFails(helper: fixture.helper, shmPath: fixture.shmPath) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("fileSize=4096"))
+        }
+    }
+
+    func testMappedHeaderMismatchFailsAndUnlinksMappingFile() throws {
+        let fixture = try ringHelper(headerChannels: 1)
+        assertStartFails(helper: fixture.helper, shmPath: fixture.shmPath) { error in
+            guard case CaptureProtocolError.mappedHeaderMismatch(let detail) = error else {
+                return XCTFail("expected mapped header mismatch, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("channels"))
+        }
+    }
+
+    func testRejectsInvalidSampleRate() {
+        XCTAssertThrowsError(try CaptureGeometry(layoutVersion: CaptureLayout.version,
+                                                totalSize: 4160,
+                                                headerSize: CaptureLayout.alignedHeaderSize,
+                                                sampleRate: .infinity,
+                                                channels: 2,
+                                                capacityFloats: 1024).validate()) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("sampleRate"))
+        }
+    }
+
+    func testRejectsCapacityNotDivisibleByChannels() {
+        XCTAssertThrowsError(try CaptureGeometry(layoutVersion: CaptureLayout.version,
+                                                totalSize: 4160,
+                                                headerSize: CaptureLayout.alignedHeaderSize,
+                                                sampleRate: 48000,
+                                                channels: 3,
+                                                capacityFloats: 1024).validate()) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("not divisible"))
+        }
+    }
+
+    func testRejectsUnalignedHeaderSize() {
+        XCTAssertThrowsError(try CaptureGeometry(layoutVersion: CaptureLayout.version,
+                                                totalSize: 4156,
+                                                headerSize: 60,
+                                                sampleRate: 48000,
+                                                channels: 2,
+                                                capacityFloats: 1024).validate()) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("headerSize=60"))
+        }
+    }
+
+    func testRejectsOverflowingTotalSize() {
+        let overflowingCapacity = Int(1) << (Int.bitWidth - 2)
+        XCTAssertThrowsError(try CaptureGeometry(layoutVersion: CaptureLayout.version,
+                                                totalSize: Int.max,
+                                                headerSize: CaptureLayout.alignedHeaderSize,
+                                                sampleRate: 48000,
+                                                channels: 1,
+                                                capacityFloats: overflowingCapacity).validate()) { error in
+            guard case CaptureProtocolError.invalidGeometry(let detail) = error else {
+                return XCTFail("expected invalid geometry, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("overflow"))
+        }
+    }
+
+    func testSharedHeaderLayoutOffsetsRemainStable() {
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.writeHead), 0)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.readHead), 8)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.sampleRate), 16)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.channels), 24)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.capacityFloats), 28)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.layoutVersion), 32)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.stride, 56)
+        XCTAssertEqual(CaptureLayout.alignedHeaderSize, 64)
     }
 }

--- a/Tests/iQualizeTests/CaptureClientResampleTests.swift
+++ b/Tests/iQualizeTests/CaptureClientResampleTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import IQCaptureProtocol
 @testable import iQualize
 
 /// End-to-end tests of CaptureClient.readResampled (#133) against a synthetic
@@ -36,8 +37,7 @@ final class CaptureClientResampleTests: XCTestCase {
             header.pointee = SharedHeader(
                 writeHead: 0, readHead: 0,
                 sampleRate: sampleRate, channels: 2,
-                capacityFloats: UInt32(capacityFloats),
-                _pad: (0, 0, 0))
+                capacityFloats: UInt32(capacityFloats))
             data = region.advanced(by: headerSize)
                 .bindMemory(to: Float.self, capacity: capacityFloats)
             data.initialize(repeating: 0, count: capacityFloats)

--- a/Tests/iQualizeTests/CaptureLayoutTests.swift
+++ b/Tests/iQualizeTests/CaptureLayoutTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+import IQCaptureProtocol
+
+/// Locks the shared-memory ABI (#175). SharedHeader is mapped by two
+/// separately compiled binaries, and both derive atomic field pointers from
+/// MemoryLayout.offset(of:) — a silent layout change would corrupt memory,
+/// so every offset and the stride are pinned here.
+final class CaptureLayoutTests: XCTestCase {
+
+    func testSharedHeaderFieldOffsetsAreStable() {
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.writeHead), 0)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.readHead), 8)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.sampleRate), 16)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.channels), 24)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.capacityFloats), 28)
+        // layoutVersion occupies the first four bytes of what legacy builds
+        // wrote as zero padding — a legacy header therefore reads version 0.
+        XCTAssertEqual(MemoryLayout<SharedHeader>.offset(of: \.layoutVersion), 32)
+    }
+
+    func testSharedHeaderStrideMatchesLegacyLayout() {
+        // Legacy struct: 2×UInt64 + Float64 + 2×UInt32 + (UInt64, UInt64, UInt32)
+        // = 56 bytes payload, 8-byte aligned → stride 56. The data offset is
+        // separately padded to 64 bytes by CaptureLayout.alignedHeaderSize.
+        XCTAssertEqual(MemoryLayout<SharedHeader>.stride, 56)
+        XCTAssertEqual(MemoryLayout<SharedHeader>.alignment, 8)
+    }
+
+    func testAlignedHeaderSizeIsCacheLinePadded() {
+        XCTAssertEqual(CaptureLayout.alignedHeaderSize, 64)
+        XCTAssertEqual(CaptureLayout.alignedHeaderSize % 64, 0)
+    }
+
+    func testDefaultInitZeroesReservedFieldsAndSetsCurrentVersion() {
+        let header = SharedHeader()
+        XCTAssertEqual(header.layoutVersion, CaptureLayout.version)
+        XCTAssertEqual(header._reserved0, 0)
+        XCTAssertEqual(header._reserved1, 0)
+        XCTAssertEqual(header._reserved2, 0)
+    }
+
+    // MARK: - CaptureGeometry.validate()
+
+    private func geometry(layoutVersion: UInt32? = 1, totalSize: Int = 4160,
+                          headerSize: Int = 64, sampleRate: Float64 = 48000,
+                          channels: Int = 2, capacityFloats: Int = 1024) -> CaptureGeometry {
+        CaptureGeometry(layoutVersion: layoutVersion, totalSize: totalSize,
+                        headerSize: headerSize, sampleRate: sampleRate,
+                        channels: channels, capacityFloats: capacityFloats)
+    }
+
+    func testValidGeometryPasses() throws {
+        try geometry().validate()
+    }
+
+    func testAbsentVersionDefaultsToOne() throws {
+        try geometry(layoutVersion: nil).validate()
+    }
+
+    func testUnknownVersionThrows() {
+        XCTAssertThrowsError(try geometry(layoutVersion: 2).validate()) { error in
+            XCTAssertEqual(error as? CaptureProtocolError,
+                           .unsupportedLayoutVersion(received: 2, supported: 1))
+        }
+    }
+
+    func testZeroChannelsThrows() {
+        XCTAssertThrowsError(try geometry(channels: 0).validate())
+    }
+
+    func testNonPowerOfTwoCapacityThrows() {
+        XCTAssertThrowsError(try geometry(totalSize: 64 + 1000 * 4,
+                                          capacityFloats: 1000).validate())
+    }
+
+    func testZeroCapacityThrows() {
+        XCTAssertThrowsError(try geometry(totalSize: 64, capacityFloats: 0).validate())
+    }
+
+    func testCapacityNotDivisibleByChannelsThrows() {
+        // 8 floats, 3 channels: pow2 but not whole frames.
+        XCTAssertThrowsError(try geometry(totalSize: 64 + 8 * 4, channels: 3,
+                                          capacityFloats: 8).validate())
+    }
+
+    func testWrongHeaderSizeThrows() {
+        XCTAssertThrowsError(try geometry(totalSize: 128 + 1024 * 4,
+                                          headerSize: 128).validate())
+    }
+
+    func testInconsistentTotalSizeThrows() {
+        XCTAssertThrowsError(try geometry(totalSize: 4096).validate())
+    }
+
+    func testNonPositiveSampleRateThrows() {
+        XCTAssertThrowsError(try geometry(sampleRate: 0).validate())
+        XCTAssertThrowsError(try geometry(sampleRate: -48000).validate())
+        XCTAssertThrowsError(try geometry(sampleRate: .nan).validate())
+    }
+
+    // MARK: - Mapped-header cross-check
+
+    func testMatchingMappedHeaderPasses() throws {
+        let header = SharedHeader(sampleRate: 48000, channels: 2,
+                                  capacityFloats: 1024, layoutVersion: 1)
+        try geometry().validate(against: header)
+    }
+
+    func testLegacyZeroVersionHeaderTreatedAsOne() throws {
+        let header = SharedHeader(sampleRate: 48000, channels: 2,
+                                  capacityFloats: 1024, layoutVersion: 0)
+        try geometry().validate(against: header)
+    }
+
+    func testMappedHeaderChannelMismatchThrows() {
+        let header = SharedHeader(sampleRate: 48000, channels: 4,
+                                  capacityFloats: 1024, layoutVersion: 1)
+        XCTAssertThrowsError(try geometry().validate(against: header)) { error in
+            guard case .mappedHeaderMismatch = error as? CaptureProtocolError else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+    }
+}

--- a/Tests/iQualizeTests/EQPresetTests.swift
+++ b/Tests/iQualizeTests/EQPresetTests.swift
@@ -123,4 +123,87 @@ final class iQualizeStateTests: XCTestCase {
         XCTAssertEqual(decoded.selectedPresetID, original.selectedPresetID)
         XCTAssertEqual(decoded.peakLimiter, original.peakLimiter)
     }
+
+    func testGarbagePersistedStateFallsBackAndPreservesBackup() {
+        let defaults = makeIsolatedDefaults()
+        let garbage = Data([0x00, 0xFF, 0x12, 0x34])
+        defaults.set(garbage, forKey: iQualizeState.key)
+
+        let state = iQualizeState.readPersisted(from: defaults)
+
+        XCTAssertEqual(state.selectedPresetID, iQualizeState.defaultState.selectedPresetID)
+        XCTAssertEqual(defaults.data(forKey: iQualizeState.key), garbage)
+        XCTAssertEqual(corruptBackups(in: defaults).map(\.value), [garbage])
+    }
+
+    func testTruncatedPersistedStateFallsBackAndPreservesBackup() throws {
+        let defaults = makeIsolatedDefaults()
+        let valid = try JSONEncoder().encode(iQualizeState(captureEnabled: false, selectedPresetID: EQPresetData.vocalClarity.id, peakLimiter: false))
+        let truncated = valid.prefix(max(1, valid.count / 2))
+        defaults.set(Data(truncated), forKey: iQualizeState.key)
+
+        let state = iQualizeState.readPersisted(from: defaults)
+
+        XCTAssertEqual(state.captureEnabled, iQualizeState.defaultState.captureEnabled)
+        XCTAssertEqual(defaults.data(forKey: iQualizeState.key), Data(truncated))
+        XCTAssertEqual(corruptBackups(in: defaults).map(\.value), [Data(truncated)])
+    }
+
+    @MainActor
+    func testCorruptBackupSurvivesLaterSettingsStoreWrite() {
+        let defaults = makeIsolatedDefaults()
+        let garbage = Data("not-json".utf8)
+        defaults.set(garbage, forKey: iQualizeState.key)
+
+        let store = SettingsStore(userDefaults: defaults)
+        store.set(\.captureEnabled, false)
+
+        XCTAssertEqual(corruptBackups(in: defaults).map(\.value), [garbage])
+        let persisted = iQualizeState.readPersisted(from: defaults)
+        XCTAssertFalse(persisted.captureEnabled)
+    }
+
+    func testValidPersistedStateLoadsWithoutBackup() throws {
+        let defaults = makeIsolatedDefaults()
+        let original = iQualizeState(captureEnabled: false, selectedPresetID: EQPresetData.bassBoost.id, peakLimiter: false)
+        defaults.set(try JSONEncoder().encode(original), forKey: iQualizeState.key)
+
+        let state = iQualizeState.readPersisted(from: defaults)
+
+        XCTAssertFalse(state.captureEnabled)
+        XCTAssertEqual(state.selectedPresetID, EQPresetData.bassBoost.id)
+        XCTAssertFalse(state.peakLimiter)
+        XCTAssertTrue(corruptBackups(in: defaults).isEmpty)
+    }
+
+    func testMissingPersistedStateFallsBackWithoutBackup() {
+        let defaults = makeIsolatedDefaults()
+
+        let state = iQualizeState.readPersisted(from: defaults)
+
+        XCTAssertEqual(state.selectedPresetID, iQualizeState.defaultState.selectedPresetID)
+        XCTAssertNil(defaults.data(forKey: iQualizeState.key))
+        XCTAssertTrue(corruptBackups(in: defaults).isEmpty)
+    }
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suiteName = "iQualizeStateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+
+    private func corruptBackups(in defaults: UserDefaults) -> [(key: String, value: Data)] {
+        defaults.dictionaryRepresentation()
+            .compactMap { key, value in
+                guard key.hasPrefix(iQualizeState.corruptBackupKeyPrefix), let data = value as? Data else {
+                    return nil
+                }
+                return (key, data)
+            }
+            .sorted { $0.key < $1.key }
+    }
 }

--- a/Tests/iQualizeTests/MenuBarRuntimePresentationTests.swift
+++ b/Tests/iQualizeTests/MenuBarRuntimePresentationTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import iQualize
+
+final class MenuBarRuntimePresentationTests: XCTestCase {
+    func testMapsAllLifecycleStatesToStablePresentation() {
+        let active = presentation(.running, userEnabled: true, bypassed: false)
+        XCTAssertEqual(active.status, .active)
+        XCTAssertEqual(active.title, "Status: Active")
+        XCTAssertEqual(active.symbolName, "slider.vertical.3")
+        XCTAssertFalse(active.appearsDisabled)
+
+        let bypassed = presentation(.running, userEnabled: true, bypassed: true)
+        XCTAssertEqual(bypassed.status, .bypassed)
+        XCTAssertEqual(bypassed.title, "Status: Bypassed")
+        XCTAssertEqual(bypassed.symbolName, "speaker.slash")
+        XCTAssertFalse(bypassed.appearsDisabled)
+
+        let stopped = presentation(.inactive, userEnabled: false, bypassed: false)
+        XCTAssertEqual(stopped.status, .stopped)
+        XCTAssertEqual(stopped.title, "Status: Off")
+        XCTAssertEqual(stopped.symbolName, "pause.circle")
+        XCTAssertTrue(stopped.appearsDisabled)
+
+        let userEnabledStopped = presentation(.inactive, userEnabled: true, bypassed: false)
+        XCTAssertEqual(userEnabledStopped.title, "Status: Stopped")
+
+        XCTAssertEqual(presentation(.starting).status, .starting)
+        XCTAssertEqual(presentation(.starting).title, "Status: Starting")
+        XCTAssertEqual(presentation(.starting).symbolName, "arrow.triangle.2.circlepath")
+        XCTAssertFalse(presentation(.starting).appearsDisabled)
+
+        XCTAssertEqual(presentation(.recovering).status, .recovering)
+        XCTAssertEqual(presentation(.recovering).title, "Status: Recovering")
+        XCTAssertEqual(presentation(.recovering).symbolName, "arrow.clockwise.circle")
+        XCTAssertFalse(presentation(.recovering).appearsDisabled)
+
+        XCTAssertEqual(presentation(.sleeping).status, .sleeping)
+        XCTAssertEqual(presentation(.sleeping).title, "Status: Sleeping")
+        XCTAssertEqual(presentation(.sleeping).symbolName, "moon.zzz")
+        XCTAssertTrue(presentation(.sleeping).appearsDisabled)
+
+        XCTAssertEqual(presentation(.stopping).status, .stopping)
+        XCTAssertEqual(presentation(.stopping).title, "Status: Stopping")
+        XCTAssertEqual(presentation(.stopping).symbolName, "stop.circle")
+        XCTAssertTrue(presentation(.stopping).appearsDisabled)
+    }
+
+    func testFailureTakesPrecedenceOverBypassAndDoesNotExposeDiagnostics() {
+        let result = presentation(
+            .failed,
+            userEnabled: true,
+            bypassed: true,
+            failure: .helperMissing(.init(path: "/Applications/iQualize.app/Contents/MacOS/iQualizeCapture"))
+        )
+
+        XCTAssertEqual(result.status, .failed)
+        XCTAssertEqual(result.title, "Status: Capture Helper Missing")
+        XCTAssertEqual(result.accessibilityLabel, "iQualize capture helper missing")
+        XCTAssertEqual(result.symbolName, "exclamationmark.triangle")
+        XCTAssertFalse(result.appearsDisabled)
+        XCTAssertFalse(result.title.contains("/Applications"))
+        XCTAssertFalse(result.accessibilityLabel.contains("/Applications"))
+    }
+
+    func testRetryAffordanceOnlyAppearsForRetryableFailedStates() {
+        XCTAssertTrue(presentation(.failed, failure: .transient(.handshakeTimeout(seconds: 30))).showsRetryCapture)
+        XCTAssertTrue(presentation(.failed, failure: .deviceUnavailable(.coreAudioStatus(-200))).showsRetryCapture)
+        XCTAssertTrue(presentation(.failed, failure: .helperExited(.init(status: 9, signaled: true))).showsRetryCapture)
+
+        XCTAssertTrue(presentation(.failed, failure: .permissionDenied(.processTap(status: -54))).showsRetryCapture)
+        XCTAssertFalse(presentation(.failed, failure: .helperMissing(.init(path: "/tmp/helper"))).showsRetryCapture)
+        XCTAssertFalse(presentation(.failed, failure: .terminal(.unknown)).showsRetryCapture)
+        XCTAssertFalse(presentation(.recovering, failure: .transient(.handshakeTimeout(seconds: 30))).showsRetryCapture)
+    }
+
+    func testPermissionSettingsAffordanceOnlyAppearsForPermissionDeniedFailure() {
+        let permission = presentation(.failed, failure: .permissionDenied(.processTap(status: -54)))
+        XCTAssertTrue(permission.showsPermissionSettings)
+        XCTAssertEqual(permission.title, "Status: Audio Capture Permission Needed")
+        XCTAssertFalse(permission.title.contains("-54"))
+        XCTAssertFalse(permission.accessibilityLabel.contains("-54"))
+
+        XCTAssertFalse(presentation(.failed, failure: .transient(.handshakeRead(errno: 54))).showsPermissionSettings)
+        XCTAssertFalse(presentation(.failed, failure: .terminal(.helperStartup(stage: .environment, exitCode: 2, osStatus: -1))).showsPermissionSettings)
+    }
+
+    private func presentation(
+        _ lifecycleState: AudioLifecycleState,
+        userEnabled: Bool = true,
+        bypassed: Bool = false,
+        failure: AudioRuntimeFailure? = nil
+    ) -> MenuBarRuntimePresentation {
+        MenuBarRuntimePresentation.make(
+            lifecycleState: lifecycleState,
+            userEnabled: userEnabled,
+            bypassed: bypassed,
+            lastFailure: failure
+        )
+    }
+}

--- a/Tests/iQualizeTests/PresetStoreTests.swift
+++ b/Tests/iQualizeTests/PresetStoreTests.swift
@@ -203,4 +203,136 @@ final class PresetStoreTests: XCTestCase {
         store.unpinPreset(fromDeviceUID: "dev")
         XCTAssertNil(store.pinnedPresetID(forDeviceUID: "dev"))
     }
+
+    // MARK: - corrupt persisted data recovery (issue #176)
+
+    /// The five persisted blob keys, matching PresetStore's private constants.
+    private static let blobKeys = [
+        "com.iqualize.customPresets",
+        "com.iqualize.favoritePresetIDs",
+        "com.iqualize.hiddenBuiltInPresetIDs",
+        "com.iqualize.pinnedPresetsByDevice",
+        "com.iqualize.builtInOverrides",
+    ]
+
+    private func backupKeys(for key: String) -> [String] {
+        defaults.dictionaryRepresentation().keys
+            .filter { $0.hasPrefix("\(key).corrupt.") }
+            .sorted()
+    }
+
+    func testGarbageCustomPresetsPreservedUnderBackupKey() {
+        let garbage = Data("not json at all".utf8)
+        defaults.set(garbage, forKey: "com.iqualize.customPresets")
+
+        let store = makeStore()
+
+        XCTAssertTrue(store.customPresets.isEmpty)
+        XCTAssertEqual(store.loadFailures.count, 1)
+        let backups = backupKeys(for: "com.iqualize.customPresets")
+        XCTAssertEqual(backups.count, 1)
+        XCTAssertEqual(defaults.data(forKey: backups[0]), garbage)
+    }
+
+    func testTruncatedJSONPreservedUnderBackupKey() {
+        let truncated = Data("[{\"name\":".utf8)
+        defaults.set(truncated, forKey: "com.iqualize.customPresets")
+
+        let store = makeStore()
+
+        XCTAssertTrue(store.customPresets.isEmpty)
+        XCTAssertEqual(store.loadFailures.count, 1)
+        let backups = backupKeys(for: "com.iqualize.customPresets")
+        XCTAssertEqual(backups.count, 1)
+        XCTAssertEqual(defaults.data(forKey: backups[0]), truncated)
+    }
+
+    func testLaterSaveDoesNotTouchBackup() {
+        let garbage = Data("garbage".utf8)
+        defaults.set(garbage, forKey: "com.iqualize.customPresets")
+        let store = makeStore()
+        let backups = backupKeys(for: "com.iqualize.customPresets")
+        XCTAssertEqual(backups.count, 1)
+
+        store.saveCustomPreset(makePreset(name: "New After Corruption"))
+
+        // Backup bytes untouched, primary key now holds the new valid array.
+        XCTAssertEqual(defaults.data(forKey: backups[0]), garbage)
+        XCTAssertEqual(backupKeys(for: "com.iqualize.customPresets"), backups)
+        let reloaded = makeStore()
+        XCTAssertEqual(reloaded.customPresets.map(\.name), ["New After Corruption"])
+    }
+
+    func testCascadingSaveDoesNotClobberBackupOfOtherKey() {
+        // deleteCustomPreset persists favorites and pins too — a corrupt favorites
+        // blob must already be backed up before that cascade overwrites the key.
+        let garbage = Data("]}[".utf8)
+        defaults.set(garbage, forKey: "com.iqualize.favoritePresetIDs")
+        let store = makeStore()
+        let preset = makePreset(name: "Doomed")
+        store.saveCustomPreset(preset)
+
+        store.deleteCustomPreset(id: preset.id)
+
+        let backups = backupKeys(for: "com.iqualize.favoritePresetIDs")
+        XCTAssertEqual(backups.count, 1)
+        XCTAssertEqual(defaults.data(forKey: backups[0]), garbage)
+    }
+
+    func testValidDataLoadsUnchangedWithNoFailuresAndNoBackups() throws {
+        let preset = makePreset(name: "Valid")
+        defaults.set(try JSONEncoder().encode([preset]), forKey: "com.iqualize.customPresets")
+        defaults.set(try JSONEncoder().encode([preset.id]), forKey: "com.iqualize.favoritePresetIDs")
+        defaults.set(try JSONEncoder().encode([EQPresetData.bassBoost.id]), forKey: "com.iqualize.hiddenBuiltInPresetIDs")
+        defaults.set(try JSONEncoder().encode(["dev": preset.id]), forKey: "com.iqualize.pinnedPresetsByDevice")
+        var edited = EQPresetData.flat
+        edited.name = "Flat (edited)"
+        defaults.set(try JSONEncoder().encode([EQPresetData.flat.id: edited]), forKey: "com.iqualize.builtInOverrides")
+
+        let store = makeStore()
+
+        XCTAssertTrue(store.loadFailures.isEmpty)
+        XCTAssertEqual(store.customPresets.map(\.name), ["Valid"])
+        XCTAssertEqual(store.favoritePresetIDs, [preset.id])
+        XCTAssertEqual(store.hiddenBuiltInPresetIDs, [EQPresetData.bassBoost.id])
+        XCTAssertEqual(store.pinnedPresetIDByDeviceUID, ["dev": preset.id])
+        XCTAssertEqual(store.builtInOverrides[EQPresetData.flat.id]?.name, "Flat (edited)")
+        for key in Self.blobKeys {
+            XCTAssertTrue(backupKeys(for: key).isEmpty, "unexpected backup for \(key)")
+        }
+    }
+
+    func testEachBlobBackedUpIndependently() {
+        let garbage = Data("\u{FF}\u{FE}broken".utf8)
+        for corruptKey in Self.blobKeys {
+            defaults.removePersistentDomain(forName: suiteName)
+            defaults.set(garbage, forKey: corruptKey)
+
+            let store = makeStore()
+
+            XCTAssertEqual(store.loadFailures.count, 1, "one failure expected for \(corruptKey)")
+            let backups = backupKeys(for: corruptKey)
+            XCTAssertEqual(backups.count, 1, "one backup expected for \(corruptKey)")
+            XCTAssertEqual(defaults.data(forKey: backups[0]), garbage)
+            for other in Self.blobKeys where other != corruptKey {
+                XCTAssertTrue(backupKeys(for: other).isEmpty, "no backup expected for \(other)")
+            }
+        }
+    }
+
+    func testAllBlobsCorruptReportsFiveFailures() {
+        for key in Self.blobKeys {
+            defaults.set(Data("junk-\(key)".utf8), forKey: key)
+        }
+
+        let store = makeStore()
+
+        XCTAssertEqual(store.loadFailures.count, 5)
+        for key in Self.blobKeys {
+            XCTAssertEqual(backupKeys(for: key).count, 1, "backup missing for \(key)")
+        }
+        // Store still functions on defaults.
+        XCTAssertTrue(store.customPresets.isEmpty)
+        XCTAssertFalse(store.allPresets.isEmpty)
+    }
 }

--- a/Tests/iQualizeTests/SettingsStoreTests.swift
+++ b/Tests/iQualizeTests/SettingsStoreTests.swift
@@ -1,0 +1,279 @@
+import XCTest
+@testable import iQualize
+
+/// Tests for the owned settings store (#177): per-field isolation, interleaved
+/// (modal-style) writes, persisted-format compatibility, and decode fallbacks.
+@MainActor
+final class SettingsStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    // setUp/tearDown are async so the override can stay MainActor-isolated —
+    // the synchronous overrides inherit nonisolated from XCTestCase and can't
+    // touch this class's isolated stored properties.
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "SettingsStoreTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        try await super.tearDown()
+    }
+
+    private static let key = "com.iqualize.state"
+
+    private func persistedState() throws -> iQualizeState {
+        let data = try XCTUnwrap(defaults.data(forKey: Self.key))
+        return try JSONDecoder().decode(iQualizeState.self, from: data)
+    }
+
+    private func persistedJSON() throws -> [String: Any] {
+        let data = try XCTUnwrap(defaults.data(forKey: Self.key))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func seed(_ state: iQualizeState) throws {
+        defaults.set(try JSONEncoder().encode(state), forKey: Self.key)
+    }
+
+    // MARK: - Defaults and decode fallbacks
+
+    func testMissingBlobYieldsDefaults() {
+        let store = SettingsStore(userDefaults: defaults)
+        XCTAssertEqual(store.state, iQualizeState.defaultState)
+    }
+
+    func testEmptyJSONObjectYieldsDefaults() {
+        defaults.set(Data("{}".utf8), forKey: Self.key)
+        let store = SettingsStore(userDefaults: defaults)
+        XCTAssertEqual(store.state, iQualizeState.defaultState)
+    }
+
+    func testGarbageBlobYieldsDefaults() {
+        defaults.set(Data([0x00, 0x01, 0x02]), forKey: Self.key)
+        let store = SettingsStore(userDefaults: defaults)
+        XCTAssertEqual(store.state, iQualizeState.defaultState)
+    }
+
+    func testPartialBlobDecodesWithPerFieldFallbacks() {
+        // Only two fields present — everything else must fall back per field,
+        // not fail the whole decode.
+        let json = """
+        {"bypassed": true, "maxGainDB": 6}
+        """
+        defaults.set(Data(json.utf8), forKey: Self.key)
+        let store = SettingsStore(userDefaults: defaults)
+        XCTAssertTrue(store.state.bypassed)
+        XCTAssertEqual(store.state.maxGainDB, 6)
+        XCTAssertTrue(store.state.captureEnabled)
+        XCTAssertTrue(store.state.peakLimiter)
+        XCTAssertEqual(store.state.selectedPresetID, EQPresetData.flat.id)
+    }
+
+    /// The documented `captureEnabled` naming rationale: legacy blobs carry an
+    /// explicit `"isEnabled": false` from before the flag was consulted. Because
+    /// the field is named `captureEnabled` (not a repurposed `isEnabled`), the
+    /// legacy key is ignored and the fallback `true` applies.
+    func testLegacyIsEnabledKeyDoesNotDisableCapture() {
+        let json = """
+        {"isEnabled": false, "peakLimiter": true}
+        """
+        defaults.set(Data(json.utf8), forKey: Self.key)
+        let store = SettingsStore(userDefaults: defaults)
+        XCTAssertTrue(store.state.captureEnabled)
+    }
+
+    // MARK: - Per-field isolation
+
+    func testSetterPersistsOnlyItsOwnFieldEffect() throws {
+        var seeded = iQualizeState.defaultState
+        seeded.balance = 0.25
+        seeded.maxGainDB = 9
+        seeded.preEqLineColorHex = "#112233"
+        seeded.snapToSemitone = true
+        try seed(seeded)
+
+        let store = SettingsStore(userDefaults: defaults)
+        store.set(\.bypassed, true)
+
+        let reloaded = try persistedState()
+        XCTAssertTrue(reloaded.bypassed)
+        XCTAssertEqual(reloaded.balance, 0.25)
+        XCTAssertEqual(reloaded.maxGainDB, 9)
+        XCTAssertEqual(reloaded.preEqLineColorHex, "#112233")
+        XCTAssertTrue(reloaded.snapToSemitone)
+    }
+
+    func testOptionalFieldCanBeSetAndCleared() throws {
+        let store = SettingsStore(userDefaults: defaults)
+        store.set(\.dreamTheme, "dark")
+        XCTAssertEqual(try persistedState().dreamTheme, "dark")
+        store.set(\.dreamTheme, nil)
+        XCTAssertNil(try persistedState().dreamTheme)
+    }
+
+    // MARK: - Interleaved / modal-style writes
+
+    /// The bug #177 fixes: with the old load-modify-save pattern, a write made
+    /// while a modal spins the run loop was clobbered when the enclosing code
+    /// saved its stale snapshot. With one owned instance, both writes land.
+    func testWriteDuringModalSurvivesEnclosingWrite() throws {
+        let store = SettingsStore(userDefaults: defaults)
+
+        // Enclosing operation reads state, then a "modal" runs and another
+        // writer mutates a different field, then the enclosing operation
+        // completes its own write.
+        XCTAssertFalse(store.state.bypassed)
+        // Simulated modal-interleaved write (e.g. CLI handler on the main actor):
+        store.set(\.balance, 0.5)
+        // Enclosing operation resumes and writes its field:
+        store.set(\.bypassed, true)
+
+        let reloaded = try persistedState()
+        XCTAssertTrue(reloaded.bypassed)
+        XCTAssertEqual(reloaded.balance, 0.5)
+    }
+
+    func testWriteInsideUpdateTransactionSeesLiveState() throws {
+        let store = SettingsStore(userDefaults: defaults)
+        store.set(\.inputGainDB, -3)
+        store.update {
+            // Transaction sees the earlier write and adds to the same instance.
+            XCTAssertEqual($0.inputGainDB, -3)
+            $0.outputGainDB = 2
+            $0.linkGainGlobally = true
+        }
+        let reloaded = try persistedState()
+        XCTAssertEqual(reloaded.inputGainDB, -3)
+        XCTAssertEqual(reloaded.outputGainDB, 2)
+        XCTAssertTrue(reloaded.linkGainGlobally)
+    }
+
+    // MARK: - Round-trip compatibility
+
+    func testExistingBlobDecodesIdenticallyThroughStore() throws {
+        var state = iQualizeState.defaultState
+        state.captureEnabled = false
+        state.selectedPresetID = EQPresetData.bassBoost.id
+        state.peakLimiter = false
+        state.windowOpen = true
+        state.maxGainDB = 18
+        state.bypassed = true
+        state.autoScale = false
+        state.preEqSpectrumEnabled = true
+        state.postEqSpectrumEnabled = true
+        state.hideFromDock = true
+        state.startAtLogin = true
+        state.balance = -0.5
+        state.splitChannelEnabled = true
+        state.activeChannel = "right"
+        state.inputGainDB = -6
+        state.outputGainDB = 3
+        state.linkGainGlobally = true
+        state.showBandwidthAsQ = false
+        state.preEqLineColorHex = "#AABBCC"
+        state.postEqLineColorHex = "#DDEEFF"
+        state.preEqFillColorHex = "#001122"
+        state.postEqFillColorHex = "#334455"
+        state.preEqFillEnabled = true
+        state.postEqFillEnabled = false
+        state.dreamTheme = "light"
+        state.snapToSemitone = true
+        state.zoomRange = "bass"
+        try seed(state)
+
+        let store = SettingsStore(userDefaults: defaults)
+        XCTAssertEqual(store.state, state)
+    }
+
+    func testAllFieldsRoundTripThroughSetters() throws {
+        let store = SettingsStore(userDefaults: defaults)
+        let presetID = UUID()
+        store.set(\.captureEnabled, false)
+        store.set(\.selectedPresetID, presetID)
+        store.set(\.peakLimiter, false)
+        store.set(\.windowOpen, true)
+        store.set(\.maxGainDB, 24)
+        store.set(\.bypassed, true)
+        store.set(\.autoScale, false)
+        store.set(\.preEqSpectrumEnabled, true)
+        store.set(\.postEqSpectrumEnabled, true)
+        store.set(\.hideFromDock, true)
+        store.set(\.startAtLogin, true)
+        store.set(\.balance, 0.75)
+        store.set(\.splitChannelEnabled, true)
+        store.set(\.activeChannel, "left")
+        store.set(\.inputGainDB, -12)
+        store.set(\.outputGainDB, 6)
+        store.set(\.linkGainGlobally, true)
+        store.set(\.showBandwidthAsQ, false)
+        store.set(\.preEqLineColorHex, "#010203")
+        store.set(\.postEqLineColorHex, "#040506")
+        store.set(\.preEqFillColorHex, "#070809")
+        store.set(\.postEqFillColorHex, "#0A0B0C")
+        store.set(\.preEqFillEnabled, true)
+        store.set(\.postEqFillEnabled, false)
+        store.set(\.dreamTheme, "dark")
+        store.set(\.snapToSemitone, true)
+        store.set(\.zoomRange, "treble")
+
+        // A fresh store over the same defaults sees the identical state.
+        let reloaded = SettingsStore(userDefaults: defaults)
+        XCTAssertEqual(reloaded.state, store.state)
+        XCTAssertEqual(reloaded.state.selectedPresetID, presetID)
+    }
+
+    /// The persisted keys are the property names — no renames, no key mapping.
+    func testPersistedKeysUnchanged() throws {
+        let store = SettingsStore(userDefaults: defaults)
+        store.set(\.bypassed, true)
+        let json = try persistedJSON()
+        let expectedKeys: Set<String> = [
+            "captureEnabled", "selectedPresetID", "peakLimiter", "windowOpen",
+            "maxGainDB", "bypassed", "autoScale", "preEqSpectrumEnabled",
+            "postEqSpectrumEnabled", "hideFromDock", "startAtLogin", "balance",
+            "splitChannelEnabled", "inputGainDB", "outputGainDB",
+            "linkGainGlobally", "showBandwidthAsQ", "preEqFillEnabled",
+            "postEqFillEnabled", "snapToSemitone",
+        ]
+        // Optional nil fields are omitted by JSONEncoder; assert the
+        // non-optional keys are all present under their exact names.
+        XCTAssertTrue(expectedKeys.isSubset(of: Set(json.keys)),
+                      "missing keys: \(expectedKeys.subtracting(json.keys))")
+    }
+}
+
+extension iQualizeState: Swift.Equatable {
+    public static func == (lhs: iQualizeState, rhs: iQualizeState) -> Bool {
+        lhs.captureEnabled == rhs.captureEnabled
+            && lhs.selectedPresetID == rhs.selectedPresetID
+            && lhs.peakLimiter == rhs.peakLimiter
+            && lhs.windowOpen == rhs.windowOpen
+            && lhs.maxGainDB == rhs.maxGainDB
+            && lhs.bypassed == rhs.bypassed
+            && lhs.autoScale == rhs.autoScale
+            && lhs.preEqSpectrumEnabled == rhs.preEqSpectrumEnabled
+            && lhs.postEqSpectrumEnabled == rhs.postEqSpectrumEnabled
+            && lhs.hideFromDock == rhs.hideFromDock
+            && lhs.startAtLogin == rhs.startAtLogin
+            && lhs.balance == rhs.balance
+            && lhs.splitChannelEnabled == rhs.splitChannelEnabled
+            && lhs.activeChannel == rhs.activeChannel
+            && lhs.inputGainDB == rhs.inputGainDB
+            && lhs.outputGainDB == rhs.outputGainDB
+            && lhs.linkGainGlobally == rhs.linkGainGlobally
+            && lhs.showBandwidthAsQ == rhs.showBandwidthAsQ
+            && lhs.preEqLineColorHex == rhs.preEqLineColorHex
+            && lhs.postEqLineColorHex == rhs.postEqLineColorHex
+            && lhs.preEqFillColorHex == rhs.preEqFillColorHex
+            && lhs.postEqFillColorHex == rhs.postEqFillColorHex
+            && lhs.preEqFillEnabled == rhs.preEqFillEnabled
+            && lhs.postEqFillEnabled == rhs.postEqFillEnabled
+            && lhs.dreamTheme == rhs.dreamTheme
+            && lhs.snapToSemitone == rhs.snapToSemitone
+            && lhs.zoomRange == rhs.zoomRange
+    }
+}


### PR DESCRIPTION
## Summary

The capture IPC contract now has one shared, versioned layout with bounded geometry validation and typed helper startup failures. Persisted preset and settings blobs preserve corrupt bytes instead of silently overwriting them, and settings writes go through one owned store.

Runtime capture failures now retain typed classifications through lifecycle transitions. The menu bar presents stable lifecycle status, retry, and permission-settings actions without exposing raw diagnostics.

Fixes #165
Fixes #175
Fixes #176
Fixes #177
Fixes #180

## Scope

- Adds the `IQCaptureProtocol` target shared by the app and capture helper.
- Adds persistence recovery for corrupt preset and settings data.
- Adds `SettingsStore` ownership for persisted settings mutations.
- Adds typed runtime failure classification and menu bar presentation.
- Bumps the app to `0.59.0` and updates `CHANGELOG.md`.
- Deliberately excludes the unrelated audit planning documents from this PR.

## Test plan

- [x] `swift test`: 217 tests passed, 0 failures.
- [x] Focused M4/M5 protocol, lifecycle, classifier, presentation, persistence, and settings tests passed.
- [x] `swift build` passed with zero warning diagnostics.
- [x] `swift build -c release` passed.
- [x] `git diff --check`, plist validation, and final read-only integration review passed.
- [x] `scripts/install.sh` completed, the app launched, and the installed signature verified.
- [x] Installed CLI checks exercised capture off/on, bypass on/off, preset transitions, and system-audio playback. Final state was capture on, bypass off, with zero underruns.
- [ ] Forced permission-denial, missing-helper, and direct visual menu interaction checks were not run.
