### PR TITLE
docs: add v0.59.0 prerelease highlights

### DIFF
--- a/.github/release-notes/highlights/v0.59.0-prerelease.md
+++ b/.github/release-notes/highlights/v0.59.0-prerelease.md
@@ -1,0 +1,8 @@
+<!-- title: v0.59.0 prerelease — Hardened capture and persistence boundaries -->
+<!-- song: Balthazar & JackRock — Prana Flow — https://music.apple.com/de/album/prana-flow/1842149655?i=1842149656 -->
+## Highlights
+
+- **Capture failures are now classifiable.** The shared capture IPC layout is versioned and validated before mapping, while structured helper startup signals distinguish permission, helper, device, transient, and terminal failures (#175, #180).
+- **Corrupt state is preserved.** Invalid preset and settings blobs are backed up and logged instead of being silently discarded or overwritten (#165, #176).
+- **Settings writes have one owner.** `SettingsStore` removes read-modify-write races so interleaved UI updates do not clobber unrelated fields (#177).
+- **The menu bar reports actionable runtime state.** Lifecycle status, retry, and Audio Capture settings actions replace the old raw error presentation (#180).


### PR DESCRIPTION
## Summary

Adds the curated highlights and release song for the v0.59.0 prerelease.

## Test plan

- [x] Release title, song directive, and highlights parse with release-highlights.sh.
- [x] Source commit is the merged v0.59.0 implementation from PR #197.
