### PR TITLE
feat(audio): add runtime diagnostics telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to iQualize will be documented in this file.
 
+## [0.60.0] - 2026-08-03
+
+### Added
+- Runtime status telemetry now has focused regression coverage for lifecycle, stream format, output device, last failure, and capture-helper restart updates.
+
+### Changed
+- Prepared the M5 release metadata for the 0.60.0 minor release.
+
+### Fixed
+- Active stream format clearing is now covered to ensure output-device telemetry and the last meaningful failure are preserved.
+
 ## [0.59.0] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,10 @@ All notable changes to iQualize will be documented in this file.
 ## [0.60.0] - 2026-08-03
 
 ### Added
-- Runtime status telemetry now has focused regression coverage for lifecycle, stream format, output device, last failure, and capture-helper restart updates.
+- Runtime diagnostics now report precise capture, render, and output-device telemetry across the shared CLI and UI availability surfaces.
 
 ### Changed
-- Prepared the M5 release metadata for the 0.60.0 minor release.
-
-### Fixed
-- Active stream format clearing is now covered to ensure output-device telemetry and the last meaningful failure are preserved.
+- Availability reporting now preserves unavailable values explicitly and keeps diagnostics read-only, so status inspection does not mutate capture state.
 
 ## [0.59.0] - 2026-08-03
 

--- a/Sources/IQControlProtocol/CLIControlMessages.swift
+++ b/Sources/IQControlProtocol/CLIControlMessages.swift
@@ -163,8 +163,22 @@ public struct CLIStatusPayload: Codable, Sendable {
     /// Unexpected capture-helper terminations since the app launched.
     /// Optional so older apps and newer CLIs remain forward-compatible.
     public var captureHelperRestarts: UInt64?
+    /// Shared audio runtime diagnostics. All fields are optional so newer CLIs
+    /// continue to decode responses from older apps, and older CLIs ignore them.
+    public var runtimeLifecycleState: String?
+    public var runtimeCaptureSampleRate: Double?
+    public var runtimeCaptureChannelCount: UInt32?
+    public var runtimeRenderSampleRate: Double?
+    public var runtimeRenderChannelCount: UInt32?
+    public var runtimeDSPSampleRate: Double?
+    public var runtimeOutputDeviceUID: String?
+    public var runtimeOutputDeviceNominalSampleRate: Double?
+    public var runtimeOutputDeviceChannelCount: UInt32?
+    public var runtimeRatesDiffer: Bool?
+    public var runtimeResamplingActive: Bool?
+    public var runtimeUnavailableReason: String?
 
-    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool, peakLimiter: Bool, preEqSpectrumEnabled: Bool, postEqSpectrumEnabled: Bool, appVersion: String? = nil, gitCommit: String? = nil, captureFillFrames: Int? = nil, captureDriftPpm: Double? = nil, captureUnderruns: UInt64? = nil, captureOverrunResyncs: UInt64? = nil, captureHelperRestarts: UInt64? = nil) {
+    public init(bypassed: Bool, activePresetID: UUID, activePresetName: String, inputGainDB: Float, outputGainDB: Float, balance: Float, gainIsGlobal: Bool, outputDeviceName: String, isRunning: Bool, peakLimiter: Bool, preEqSpectrumEnabled: Bool, postEqSpectrumEnabled: Bool, appVersion: String? = nil, gitCommit: String? = nil, captureFillFrames: Int? = nil, captureDriftPpm: Double? = nil, captureUnderruns: UInt64? = nil, captureOverrunResyncs: UInt64? = nil, captureHelperRestarts: UInt64? = nil, runtimeLifecycleState: String? = nil, runtimeCaptureSampleRate: Double? = nil, runtimeCaptureChannelCount: UInt32? = nil, runtimeRenderSampleRate: Double? = nil, runtimeRenderChannelCount: UInt32? = nil, runtimeDSPSampleRate: Double? = nil, runtimeOutputDeviceUID: String? = nil, runtimeOutputDeviceNominalSampleRate: Double? = nil, runtimeOutputDeviceChannelCount: UInt32? = nil, runtimeRatesDiffer: Bool? = nil, runtimeResamplingActive: Bool? = nil, runtimeUnavailableReason: String? = nil) {
         self.bypassed = bypassed
         self.activePresetID = activePresetID
         self.activePresetName = activePresetName
@@ -184,6 +198,18 @@ public struct CLIStatusPayload: Codable, Sendable {
         self.captureUnderruns = captureUnderruns
         self.captureOverrunResyncs = captureOverrunResyncs
         self.captureHelperRestarts = captureHelperRestarts
+        self.runtimeLifecycleState = runtimeLifecycleState
+        self.runtimeCaptureSampleRate = runtimeCaptureSampleRate
+        self.runtimeCaptureChannelCount = runtimeCaptureChannelCount
+        self.runtimeRenderSampleRate = runtimeRenderSampleRate
+        self.runtimeRenderChannelCount = runtimeRenderChannelCount
+        self.runtimeDSPSampleRate = runtimeDSPSampleRate
+        self.runtimeOutputDeviceUID = runtimeOutputDeviceUID
+        self.runtimeOutputDeviceNominalSampleRate = runtimeOutputDeviceNominalSampleRate
+        self.runtimeOutputDeviceChannelCount = runtimeOutputDeviceChannelCount
+        self.runtimeRatesDiffer = runtimeRatesDiffer
+        self.runtimeResamplingActive = runtimeResamplingActive
+        self.runtimeUnavailableReason = runtimeUnavailableReason
     }
 }
 

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -312,6 +312,7 @@ final class AudioEngine {
     private(set) var lifecycleHistory: [AudioLifecycleTransition] = []
     private(set) var outputDeviceName = "Unknown"
     private(set) var outputDeviceUID: String?
+    private(set) var runtimeStatus: AudioRuntimeStatus = .initial
     private(set) var lastFailure: AudioRuntimeFailure?
     /// Unexpected helper terminations since the app launched. This is kept
     /// outside CaptureClient because a recovery creates a fresh client.
@@ -444,13 +445,7 @@ final class AudioEngine {
     }
 
     init() {
-        do {
-            let deviceID = try getDefaultOutputDeviceID()
-            outputDeviceName = try getDeviceName(deviceID)
-            outputDeviceUID = try? getDeviceUID(deviceID)
-        } catch {
-            outputDeviceName = "Unknown"
-        }
+        refreshOutputDeviceTelemetry()
         installDeviceChangeListener()
 
         lifecycleCoordinator = AudioLifecycleCoordinator(
@@ -472,6 +467,7 @@ final class AudioEngine {
             },
             publishFailure: { @MainActor [weak self] failure in
                 self?.lastFailure = failure
+                self?.publishRuntimeStatus()
             }
         )
     }
@@ -493,9 +489,7 @@ final class AudioEngine {
     // MARK: - Start / Stop
 
     private func startGraph() throws {
-        let outputDeviceID = try getDefaultOutputDeviceID()
-        outputDeviceName = try getDeviceName(outputDeviceID)
-        outputDeviceUID = try? getDeviceUID(outputDeviceID)
+        refreshOutputDeviceTelemetry()
 
         // 1. Launch the capture helper — it owns the CATap, tap-only aggregate,
         //    and IOProc in a separate process. We just consume its shared-memory
@@ -506,6 +500,7 @@ final class AudioEngine {
         client.onUnexpectedTermination = { [weak self] in
             guard let self else { return }
             self.captureHelperRestartCount &+= 1
+            self.publishRuntimeStatus()
             Task { @MainActor in
                 guard let lifecycleCoordinator = self.lifecycleCoordinator else { return }
                 await lifecycleCoordinator.helperTerminated()
@@ -519,6 +514,9 @@ final class AudioEngine {
         let channels = client.channels
         self.outputSampleRate = sampleRate
         renderChannelCount = channels
+        let captureFormat = AudioRuntimeStatus.StreamFormat(sampleRate: sampleRate, channelCount: channels)
+        let renderFormat = AudioRuntimeStatus.StreamFormat(sampleRate: sampleRate, channelCount: channels)
+        publishRuntimeStatus(captureFormat: captureFormat, renderFormat: renderFormat, dspSampleRate: sampleRate)
 
         os_log(.default, log: appLog,
                "capture helper sr: %{public}.0f  ch: %{public}u  output: %{public}@",
@@ -692,7 +690,45 @@ final class AudioEngine {
         userEnabled = snapshot.userEnabled
         lifecycleHistory = snapshot.history
         isRunning = snapshot.state == .running
+        publishRuntimeStatus()
         onStateChange?()
+    }
+
+    private func refreshOutputDeviceTelemetry() {
+        do {
+            let outputDevice = try getDefaultOutputDevice()
+            outputDeviceName = outputDevice.name
+            outputDeviceUID = outputDevice.uid
+            runtimeStatus = runtimeStatus.updatingOutputDevice(outputDevice)
+        } catch {
+            outputDeviceName = "Unknown"
+            outputDeviceUID = nil
+            runtimeStatus = runtimeStatus.updatingOutputDevice(nil)
+        }
+    }
+
+    private func publishRuntimeStatus(
+        captureFormat: AudioRuntimeStatus.StreamFormat? = nil,
+        renderFormat: AudioRuntimeStatus.StreamFormat? = nil,
+        dspSampleRate: Double? = nil,
+        clearActiveStreamFormats: Bool = false
+    ) {
+        var next = runtimeStatus.updatingLifecycle(
+            state: lifecycleState,
+            userEnabled: userEnabled,
+            lastFailure: lastFailure,
+            captureHelperRestartCount: captureHelperRestartCount
+        )
+        if clearActiveStreamFormats {
+            next = next.clearingActiveStreamFormats()
+        } else if captureFormat != nil || renderFormat != nil || dspSampleRate != nil {
+            next = next.updatingFormats(
+                captureFormat: captureFormat ?? next.captureFormat,
+                renderFormat: renderFormat ?? next.renderFormat,
+                dspSampleRate: dspSampleRate ?? next.dspSampleRate
+            )
+        }
+        runtimeStatus = next
     }
 
     /// Releases every resource acquired by start(), including resources from a
@@ -701,6 +737,7 @@ final class AudioEngine {
     /// exception when removeTap(onBus:) is called on an empty bus.
     private func teardown() {
         isRunning = false
+        publishRuntimeStatus(clearActiveStreamFormats: true)
 
         if let configChangeObserver {
             NotificationCenter.default.removeObserver(configChangeObserver)
@@ -899,19 +936,13 @@ final class AudioEngine {
     }
 
     private func handleDeviceChange() {
-        var outputDeviceChanged = false
-        if let deviceID = try? getDefaultOutputDeviceID() {
-            let previousUID = outputDeviceUID
-            if let name = try? getDeviceName(deviceID) {
-                outputDeviceName = name
-            }
-            let uid = try? getDeviceUID(deviceID)
-            outputDeviceUID = uid
-            outputDeviceChanged = defaultOutputDeviceChanged(previousUID: previousUID, currentUID: uid)
-            if outputDeviceChanged, let uid, let pinned = pinnedPresetProvider?(uid) {
-                activePreset = pinned
-                onPinnedPresetApplied?(pinned.id)
-            }
+        let previousUID = outputDeviceUID
+        refreshOutputDeviceTelemetry()
+        let uid = outputDeviceUID
+        let outputDeviceChanged = defaultOutputDeviceChanged(previousUID: previousUID, currentUID: uid)
+        if outputDeviceChanged, let uid, let pinned = pinnedPresetProvider?(uid) {
+            activePreset = pinned
+            onPinnedPresetApplied?(pinned.id)
         }
 
         guard outputDeviceChanged else {

--- a/Sources/iQualize/AudioEngine.swift
+++ b/Sources/iQualize/AudioEngine.swift
@@ -444,6 +444,13 @@ final class AudioEngine {
         captureClient?.telemetrySnapshot()
     }
 
+    /// Reads the immutable runtime status and lock-free capture counters without
+    /// touching the graph. Diagnostics callers may invoke this while playback is
+    /// active; it never starts, stops, or rebuilds audio resources.
+    func runtimeDiagnosticsSnapshot() -> AudioRuntimeDiagnosticsSnapshot {
+        AudioRuntimeDiagnosticsSnapshot(status: runtimeStatus, captureTelemetry: captureTelemetry())
+    }
+
     init() {
         refreshOutputDeviceTelemetry()
         installDeviceChangeListener()
@@ -729,6 +736,16 @@ final class AudioEngine {
             )
         }
         runtimeStatus = next
+
+        let capture = next.captureFormat.map { "\($0.sampleRate)Hz/\($0.channelCount)ch" } ?? "Unavailable"
+        let render = next.renderFormat.map { "\($0.sampleRate)Hz/\($0.channelCount)ch" } ?? "Unavailable"
+        let output = next.outputDevice.map {
+            "\($0.name)/\($0.nominalSampleRate.map { String($0) } ?? "Unavailable")Hz/\($0.outputChannelCount.map(String.init) ?? "Unavailable")ch"
+        } ?? "Unavailable"
+        os_log(.debug, log: appLog,
+               "runtime status state=%{public}@ capture=%{public}@ render=%{public}@ dsp=%{public}@ output=%{public}@",
+               next.lifecycleState.rawValue, capture, render,
+               next.dspSampleRate.map { String($0) } ?? "Unavailable", output)
     }
 
     /// Releases every resource acquired by start(), including resources from a

--- a/Sources/iQualize/AudioRuntimeStatus.swift
+++ b/Sources/iQualize/AudioRuntimeStatus.swift
@@ -1,0 +1,146 @@
+import CoreAudio
+import Foundation
+
+/// Immutable, point-in-time runtime telemetry for the audio stack.
+///
+/// Keep the meanings distinct:
+/// - captureFormat describes the helper/tap stream consumed by iQualize.
+/// - renderFormat describes the AVAudioEngine source/render graph format.
+/// - dspSampleRate is the rate used for EQ/biquad coefficients.
+/// - outputDevice describes the current system default output hardware.
+///
+/// The hardware output device's nominal sample rate is telemetry only. DSP
+/// coefficients must continue to use dspSampleRate, which is derived from the
+/// capture/render stream.
+struct AudioRuntimeStatus: Sendable, Equatable {
+    struct StreamFormat: Sendable, Equatable {
+        let sampleRate: Double
+        let channelCount: UInt32
+
+        init(sampleRate: Double, channelCount: UInt32) {
+            self.sampleRate = sampleRate
+            self.channelCount = channelCount
+        }
+    }
+
+    let lifecycleState: AudioLifecycleState
+    let userEnabled: Bool
+    let isRunning: Bool
+    let captureFormat: StreamFormat?
+    let renderFormat: StreamFormat?
+    let dspSampleRate: Double?
+    let outputDevice: CoreAudioOutputDevice?
+    let lastFailure: AudioRuntimeFailure?
+    let captureHelperRestartCount: UInt64
+
+    static let initial = AudioRuntimeStatus(
+        lifecycleState: .inactive,
+        userEnabled: false,
+        isRunning: false,
+        captureFormat: nil,
+        renderFormat: nil,
+        dspSampleRate: nil,
+        outputDevice: nil,
+        lastFailure: nil,
+        captureHelperRestartCount: 0
+    )
+
+    init(
+        lifecycleState: AudioLifecycleState,
+        userEnabled: Bool,
+        isRunning: Bool,
+        captureFormat: StreamFormat?,
+        renderFormat: StreamFormat?,
+        dspSampleRate: Double?,
+        outputDevice: CoreAudioOutputDevice?,
+        lastFailure: AudioRuntimeFailure?,
+        captureHelperRestartCount: UInt64
+    ) {
+        self.lifecycleState = lifecycleState
+        self.userEnabled = userEnabled
+        self.isRunning = isRunning
+        self.captureFormat = captureFormat
+        self.renderFormat = renderFormat
+        self.dspSampleRate = dspSampleRate
+        self.outputDevice = outputDevice
+        self.lastFailure = lastFailure
+        self.captureHelperRestartCount = captureHelperRestartCount
+    }
+
+    func updatingLifecycle(
+        state: AudioLifecycleState,
+        userEnabled: Bool,
+        lastFailure: AudioRuntimeFailure? = nil,
+        captureHelperRestartCount: UInt64? = nil
+    ) -> AudioRuntimeStatus {
+        AudioRuntimeStatus(
+            lifecycleState: state,
+            userEnabled: userEnabled,
+            isRunning: state == .running,
+            captureFormat: captureFormat,
+            renderFormat: renderFormat,
+            dspSampleRate: dspSampleRate,
+            outputDevice: outputDevice,
+            lastFailure: lastFailure,
+            captureHelperRestartCount: captureHelperRestartCount ?? self.captureHelperRestartCount
+        )
+    }
+
+    func updatingFormats(
+        captureFormat: StreamFormat?,
+        renderFormat: StreamFormat?,
+        dspSampleRate: Double?
+    ) -> AudioRuntimeStatus {
+        AudioRuntimeStatus(
+            lifecycleState: lifecycleState,
+            userEnabled: userEnabled,
+            isRunning: isRunning,
+            captureFormat: captureFormat,
+            renderFormat: renderFormat,
+            dspSampleRate: dspSampleRate,
+            outputDevice: outputDevice,
+            lastFailure: lastFailure,
+            captureHelperRestartCount: captureHelperRestartCount
+        )
+    }
+
+    func updatingOutputDevice(_ outputDevice: CoreAudioOutputDevice?) -> AudioRuntimeStatus {
+        AudioRuntimeStatus(
+            lifecycleState: lifecycleState,
+            userEnabled: userEnabled,
+            isRunning: isRunning,
+            captureFormat: captureFormat,
+            renderFormat: renderFormat,
+            dspSampleRate: dspSampleRate,
+            outputDevice: outputDevice,
+            lastFailure: lastFailure,
+            captureHelperRestartCount: captureHelperRestartCount
+        )
+    }
+
+    func clearingActiveStreamFormats() -> AudioRuntimeStatus {
+        updatingFormats(captureFormat: nil, renderFormat: nil, dspSampleRate: nil)
+    }
+}
+
+struct CoreAudioOutputDevice: Sendable, Equatable {
+    let id: AudioDeviceID
+    let name: String
+    let uid: String?
+    let nominalSampleRate: Double?
+    let outputChannelCount: UInt32?
+
+    init(
+        id: AudioDeviceID,
+        name: String,
+        uid: String?,
+        nominalSampleRate: Double?,
+        outputChannelCount: UInt32? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.uid = uid
+        self.nominalSampleRate = nominalSampleRate
+        self.outputChannelCount = outputChannelCount
+    }
+}

--- a/Sources/iQualize/AudioRuntimeStatus.swift
+++ b/Sources/iQualize/AudioRuntimeStatus.swift
@@ -144,3 +144,16 @@ struct CoreAudioOutputDevice: Sendable, Equatable {
         self.outputChannelCount = outputChannelCount
     }
 }
+
+/// Read-only view assembled off the audio callback. Both the diagnostics window
+/// and the CLI status surface consume this same snapshot so they cannot drift in
+/// how they interpret effective formats versus live capture telemetry.
+struct AudioRuntimeDiagnosticsSnapshot: Sendable {
+    let status: AudioRuntimeStatus
+    let captureTelemetry: CaptureClient.Telemetry?
+
+    init(status: AudioRuntimeStatus, captureTelemetry: CaptureClient.Telemetry? = nil) {
+        self.status = status
+        self.captureTelemetry = captureTelemetry
+    }
+}

--- a/Sources/iQualize/CoreAudioHelpers.swift
+++ b/Sources/iQualize/CoreAudioHelpers.swift
@@ -83,3 +83,55 @@ func getDeviceUID(_ deviceID: AudioDeviceID) throws -> String {
 func getDeviceName(_ deviceID: AudioDeviceID) throws -> String {
     try getCFStringProperty(deviceID, kAudioObjectPropertyName, "Failed to get device name")
 }
+
+func getDeviceNominalSampleRate(_ deviceID: AudioDeviceID) throws -> Double {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyNominalSampleRate,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var sampleRate = Float64(0)
+    var size = UInt32(MemoryLayout<Float64>.size)
+    try caCheck(
+        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &sampleRate),
+        "Failed to get device nominal sample rate"
+    )
+    return sampleRate
+}
+
+func getDeviceOutputChannelCount(_ deviceID: AudioDeviceID) throws -> UInt32 {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyStreamConfiguration,
+        mScope: kAudioDevicePropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var size: UInt32 = 0
+    try caCheck(
+        AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size),
+        "Failed to get device output stream configuration size"
+    )
+    let bufferListPointer = UnsafeMutableRawPointer.allocate(
+        byteCount: Int(size),
+        alignment: MemoryLayout<AudioBufferList>.alignment
+    )
+    defer { bufferListPointer.deallocate() }
+    try caCheck(
+        AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, bufferListPointer),
+        "Failed to get device output stream configuration"
+    )
+    let bufferList = UnsafeMutableAudioBufferListPointer(
+        bufferListPointer.assumingMemoryBound(to: AudioBufferList.self)
+    )
+    return bufferList.reduce(UInt32(0)) { $0 + $1.mNumberChannels }
+}
+
+func getDefaultOutputDevice() throws -> CoreAudioOutputDevice {
+    let deviceID = try getDefaultOutputDeviceID()
+    return CoreAudioOutputDevice(
+        id: deviceID,
+        name: try getDeviceName(deviceID),
+        uid: try? getDeviceUID(deviceID),
+        nominalSampleRate: try? getDeviceNominalSampleRate(deviceID),
+        outputChannelCount: try? getDeviceOutputChannelCount(deviceID)
+    )
+}

--- a/Sources/iQualize/DiagnosticsWindowController.swift
+++ b/Sources/iQualize/DiagnosticsWindowController.swift
@@ -11,10 +11,7 @@ final class DiagnosticsWindowController: NSWindowController, NSWindowDelegate {
 
     convenience init(audioEngine: AudioEngine) {
         self.init(snapshotProvider: {
-            RuntimeDiagnosticsSnapshot(
-                status: audioEngine.runtimeStatus,
-                captureTelemetry: audioEngine.captureTelemetry()
-            )
+            audioEngine.runtimeDiagnosticsSnapshot()
         })
     }
 
@@ -90,8 +87,8 @@ final class DiagnosticsWindowController: NSWindowController, NSWindowDelegate {
         })
         grid.rowSpacing = 8
         grid.columnSpacing = 12
-        grid.column(at: 0).xPlacement = .trailing
-        grid.column(at: 1).xPlacement = .leading
+        grid.column(at: 0).xPlacement = NSGridCell.Placement.trailing
+        grid.column(at: 1).xPlacement = NSGridCell.Placement.leading
         grid.column(at: 1).width = 360
         mainStack.addArrangedSubview(grid)
 

--- a/Sources/iQualize/DiagnosticsWindowController.swift
+++ b/Sources/iQualize/DiagnosticsWindowController.swift
@@ -1,0 +1,132 @@
+import AppKit
+
+@available(macOS 14.2, *)
+@MainActor
+final class DiagnosticsWindowController: NSWindowController, NSWindowDelegate {
+    typealias SnapshotProvider = @MainActor () -> RuntimeDiagnosticsSnapshot
+
+    private let snapshotProvider: SnapshotProvider
+    private var valueLabels: [String: NSTextField] = [:]
+    private var diagnosticReport = ""
+
+    convenience init(audioEngine: AudioEngine) {
+        self.init(snapshotProvider: {
+            RuntimeDiagnosticsSnapshot(
+                status: audioEngine.runtimeStatus,
+                captureTelemetry: audioEngine.captureTelemetry()
+            )
+        })
+    }
+
+    init(snapshotProvider: @escaping SnapshotProvider) {
+        self.snapshotProvider = snapshotProvider
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 0),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: true
+        )
+        window.title = "Diagnostics"
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        super.init(window: window)
+        window.delegate = self
+
+        let contentView = buildContent()
+        window.contentView = contentView
+        refresh()
+
+        let fitting = contentView.fittingSize
+        window.setContentSize(NSSize(width: max(fitting.width, 560), height: fitting.height))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func refresh() {
+        let presentation = RuntimeDiagnosticsPresentation.make(snapshot: snapshotProvider())
+        diagnosticReport = presentation.report
+        for row in presentation.rows {
+            valueLabels[row.label]?.stringValue = row.value
+        }
+    }
+
+    private func buildContent() -> NSView {
+        let mainStack = NSStackView()
+        mainStack.orientation = .vertical
+        mainStack.alignment = .leading
+        mainStack.spacing = 16
+        mainStack.edgeInsets = NSEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let title = NSTextField(labelWithString: "Runtime Diagnostics")
+        title.font = .systemFont(ofSize: 17, weight: .semibold)
+        mainStack.addArrangedSubview(title)
+
+        let subtitle = NSTextField(labelWithString: "Read-only audio runtime telemetry. Refresh rereads the current snapshot only.")
+        subtitle.font = .systemFont(ofSize: 12)
+        subtitle.textColor = .secondaryLabelColor
+        subtitle.lineBreakMode = .byWordWrapping
+        subtitle.maximumNumberOfLines = 2
+        mainStack.addArrangedSubview(subtitle)
+
+        let grid = NSGridView(views: RuntimeDiagnosticsPresentation.make(snapshot: .init(status: .initial)).rows.map { row in
+            let label = NSTextField(labelWithString: row.label + ":")
+            label.font = .systemFont(ofSize: 13, weight: .semibold)
+            label.alignment = .right
+            label.setContentHuggingPriority(.required, for: .horizontal)
+
+            let value = NSTextField(labelWithString: RuntimeDiagnosticsPresentation.unavailable)
+            value.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+            value.textColor = .labelColor
+            value.lineBreakMode = .byWordWrapping
+            value.maximumNumberOfLines = 0
+            value.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            valueLabels[row.label] = value
+
+            return [label, value]
+        })
+        grid.rowSpacing = 8
+        grid.columnSpacing = 12
+        grid.column(at: 0).xPlacement = .trailing
+        grid.column(at: 1).xPlacement = .leading
+        grid.column(at: 1).width = 360
+        mainStack.addArrangedSubview(grid)
+
+        let buttonRow = NSStackView()
+        buttonRow.orientation = .horizontal
+        buttonRow.alignment = .centerY
+        buttonRow.spacing = 8
+
+        let refreshButton = NSButton(title: "Refresh", target: self, action: #selector(refreshButtonPressed(_:)))
+        refreshButton.bezelStyle = .rounded
+        buttonRow.addArrangedSubview(refreshButton)
+
+        let copyButton = NSButton(title: "Copy Diagnostic Report", target: self, action: #selector(copyDiagnosticReport(_:)))
+        copyButton.bezelStyle = .rounded
+        buttonRow.addArrangedSubview(copyButton)
+
+        mainStack.addArrangedSubview(buttonRow)
+
+        let container = NSView()
+        container.addSubview(mainStack)
+        NSLayoutConstraint.activate([
+            mainStack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            mainStack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            mainStack.topAnchor.constraint(equalTo: container.topAnchor),
+            mainStack.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+        return container
+    }
+
+    @objc private func refreshButtonPressed(_ sender: NSButton) {
+        refresh()
+    }
+
+    @objc private func copyDiagnosticReport(_ sender: NSButton) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(diagnosticReport, forType: .string)
+    }
+}

--- a/Sources/iQualize/Info.plist
+++ b/Sources/iQualize/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.59.0</string>
+	<string>0.60.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.59</string>
+	<string>0.60</string>
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -958,6 +958,15 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
 
     func statusSnapshot() -> CLIStatusPayload {
         let capture = audioEngine.captureTelemetry()
+        let runtime = audioEngine.runtimeStatus
+        let runtimeRatesDiffer = Self.runtimeRatesDiffer(
+            captureSampleRate: runtime.captureFormat?.sampleRate,
+            renderSampleRate: runtime.renderFormat?.sampleRate,
+            dspSampleRate: runtime.dspSampleRate,
+            outputSampleRate: runtime.outputDevice?.nominalSampleRate
+        )
+        let driftActive = (capture?.driftPpm).map { abs($0) > 0.1 }
+        let runtimeResamplingActive = runtimeRatesDiffer.map { $0 || (driftActive ?? false) } ?? driftActive
         return CLIStatusPayload(
             bypassed: audioEngine.bypassed,
             activePresetID: audioEngine.activePreset.id,
@@ -977,8 +986,43 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
             captureDriftPpm: capture?.driftPpm,
             captureUnderruns: capture?.underruns,
             captureOverrunResyncs: capture?.overrunResyncs,
-            captureHelperRestarts: audioEngine.captureHelperRestartCount
+            captureHelperRestarts: audioEngine.captureHelperRestartCount,
+            runtimeLifecycleState: runtime.lifecycleState.rawValue,
+            runtimeCaptureSampleRate: runtime.captureFormat?.sampleRate,
+            runtimeCaptureChannelCount: runtime.captureFormat?.channelCount,
+            runtimeRenderSampleRate: runtime.renderFormat?.sampleRate,
+            runtimeRenderChannelCount: runtime.renderFormat?.channelCount,
+            runtimeDSPSampleRate: runtime.dspSampleRate,
+            runtimeOutputDeviceUID: runtime.outputDevice?.uid,
+            runtimeOutputDeviceNominalSampleRate: runtime.outputDevice?.nominalSampleRate,
+            runtimeOutputDeviceChannelCount: runtime.outputDevice?.outputChannelCount,
+            runtimeRatesDiffer: runtimeRatesDiffer,
+            runtimeResamplingActive: runtimeResamplingActive,
+            runtimeUnavailableReason: runtimeUnavailableReason(from: runtime)
         )
+    }
+
+    private static func runtimeRatesDiffer(
+        captureSampleRate: Double?,
+        renderSampleRate: Double?,
+        dspSampleRate: Double?,
+        outputSampleRate: Double?
+    ) -> Bool? {
+        let rates = [captureSampleRate, renderSampleRate, dspSampleRate, outputSampleRate].compactMap { $0 }
+        guard rates.count >= 2 else { return nil }
+        guard let first = rates.first else { return nil }
+        return rates.dropFirst().contains { abs($0 - first) > 0.5 }
+    }
+
+    private func runtimeUnavailableReason(from runtime: AudioRuntimeStatus) -> String? {
+        guard runtime.lifecycleState != .running else { return nil }
+        let title = MenuBarRuntimePresentation.make(
+            lifecycleState: runtime.lifecycleState,
+            userEnabled: runtime.userEnabled,
+            bypassed: audioEngine.bypassed,
+            lastFailure: runtime.lastFailure
+        ).title
+        return title.replacingOccurrences(of: "Status: ", with: "")
     }
 
     func listPresetSummaries() -> [CLIPresetSummary] {

--- a/Sources/iQualize/MenuBarController.swift
+++ b/Sources/iQualize/MenuBarController.swift
@@ -18,6 +18,7 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     private var eqWindowController: EQWindowController?
     private var settingsWindowController: SettingsWindowController?
     private var helpWindowController: HelpWindowController?
+    private var diagnosticsWindowController: DiagnosticsWindowController?
 
     init(audioEngine: AudioEngine, presetStore: PresetStore, settings: SettingsStore) {
         self.audioEngine = audioEngine
@@ -33,7 +34,9 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
 
         // Rebuild menu on device changes
         audioEngine.onStateChange = { [weak self] in
-            self?.updateIcon()
+            guard let self else { return }
+            self.updateIcon()
+            self.diagnosticsWindowController?.refresh()
         }
 
         // Recall the preset pinned to a device the moment we switch to it.
@@ -106,6 +109,11 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
         settingsItem.keyEquivalentModifierMask = [.command]
         settingsItem.target = self
         menu.addItem(settingsItem)
+
+        let diagnosticsItem = NSMenuItem(title: "Diagnostics…",
+                                         action: #selector(openDiagnostics(_:)), keyEquivalent: "")
+        diagnosticsItem.target = self
+        menu.addItem(diagnosticsItem)
 
         menu.addItem(.separator())
 
@@ -248,6 +256,19 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
         settingsWindowController?.updateEQWindowController(eqWindowController)
         settingsWindowController?.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func openDiagnostics(_ sender: NSMenuItem) {
+        if diagnosticsWindowController == nil {
+            diagnosticsWindowController = DiagnosticsWindowController(audioEngine: audioEngine)
+        }
+        diagnosticsWindowController?.refresh()
+        diagnosticsWindowController?.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func showDiagnostics() {
+        openDiagnostics(NSMenuItem())
     }
 
     func openEQWindow() {
@@ -957,8 +978,9 @@ final class MenuBarController: NSObject, NSMenuDelegate, CLICommandHandling {
     }
 
     func statusSnapshot() -> CLIStatusPayload {
-        let capture = audioEngine.captureTelemetry()
-        let runtime = audioEngine.runtimeStatus
+        let diagnostics = audioEngine.runtimeDiagnosticsSnapshot()
+        let capture = diagnostics.captureTelemetry
+        let runtime = diagnostics.status
         let runtimeRatesDiffer = Self.runtimeRatesDiffer(
             captureSampleRate: runtime.captureFormat?.sampleRate,
             renderSampleRate: runtime.renderFormat?.sampleRate,

--- a/Sources/iQualize/RuntimeDiagnosticsPresentation.swift
+++ b/Sources/iQualize/RuntimeDiagnosticsPresentation.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+struct RuntimeDiagnosticsSnapshot: Sendable {
+    let status: AudioRuntimeStatus
+    let captureTelemetry: CaptureClient.Telemetry?
+
+    init(status: AudioRuntimeStatus, captureTelemetry: CaptureClient.Telemetry? = nil) {
+        self.status = status
+        self.captureTelemetry = captureTelemetry
+    }
+}
+
+struct RuntimeDiagnosticsPresentation: Equatable {
+    struct Row: Equatable {
+        let label: String
+        let value: String
+    }
+
+    let rows: [Row]
+    let report: String
+
+    static let unavailable = "Unavailable"
+
+    static func make(snapshot: RuntimeDiagnosticsSnapshot) -> RuntimeDiagnosticsPresentation {
+        let status = snapshot.status
+        let ratesDiffer = ratesDiffer(capture: status.captureFormat, render: status.renderFormat)
+
+        let rows = [
+            Row(label: "Effective Capture Format", value: format(status.captureFormat)),
+            Row(label: "Render/DSP Format", value: renderDSPFormat(render: status.renderFormat, dspSampleRate: status.dspSampleRate)),
+            Row(label: "Output Device Name", value: emptyAware(status.outputDevice?.name)),
+            Row(label: "Output Device UID", value: emptyAware(status.outputDevice?.uid)),
+            Row(label: "Output Device Nominal Sample Rate", value: formatSampleRate(status.outputDevice?.nominalSampleRate)),
+            Row(label: "Output Device Output Channels", value: formatCount(status.outputDevice?.outputChannelCount)),
+            Row(label: "Lifecycle State", value: formatLifecycle(status.lifecycleState, userEnabled: status.userEnabled, isRunning: status.isRunning)),
+            Row(label: "Rates Differ", value: ratesDiffer.map { $0 ? "Yes" : "No" } ?? unavailable),
+            Row(label: "Drift/Resampling Status", value: driftResamplingStatus(telemetry: snapshot.captureTelemetry, ratesDiffer: ratesDiffer)),
+            Row(label: "Last Failure", value: format(status.lastFailure))
+        ]
+
+        let report = (["iQualize Diagnostic Report"] + rows.map { "\($0.label): \($0.value)" }).joined(separator: "\n")
+        return RuntimeDiagnosticsPresentation(rows: rows, report: report)
+    }
+
+    private static func format(_ format: AudioRuntimeStatus.StreamFormat?) -> String {
+        guard let format else { return unavailable }
+        return "\(formatSampleRate(format.sampleRate)), \(format.channelCount) ch"
+    }
+
+    private static func renderDSPFormat(render: AudioRuntimeStatus.StreamFormat?, dspSampleRate: Double?) -> String {
+        let renderValue = format(render)
+        let dspValue = formatSampleRate(dspSampleRate)
+        return "Render: \(renderValue); DSP sample rate: \(dspValue)"
+    }
+
+    private static func ratesDiffer(
+        capture: AudioRuntimeStatus.StreamFormat?,
+        render: AudioRuntimeStatus.StreamFormat?
+    ) -> Bool? {
+        guard let capture, let render else { return nil }
+        return capture.sampleRate != render.sampleRate || capture.channelCount != render.channelCount
+    }
+
+    private static func driftResamplingStatus(telemetry: CaptureClient.Telemetry?, ratesDiffer: Bool?) -> String {
+        guard let telemetry else {
+            if ratesDiffer == true { return "Resampling expected; drift telemetry unavailable" }
+            return unavailable
+        }
+
+        let resampling = ratesDiffer == true ? "Resampling expected" : "Resampling not expected"
+        let drift = String(format: "%.2f ppm", telemetry.driftPpm)
+        return "\(resampling); drift \(drift); fill \(telemetry.fillFrames) frames; underruns \(telemetry.underruns); overrun resyncs \(telemetry.overrunResyncs)"
+    }
+
+    private static func formatLifecycle(
+        _ state: AudioLifecycleState,
+        userEnabled: Bool,
+        isRunning: Bool
+    ) -> String {
+        "\(state.rawValue) (user enabled: \(userEnabled ? "Yes" : "No"), running: \(isRunning ? "Yes" : "No"))"
+    }
+
+    private static func format(_ failure: AudioRuntimeFailure?) -> String {
+        guard let failure else { return unavailable }
+        switch failure {
+        case .permissionDenied(.processTap(let status)):
+            return "Permission denied: process tap" + statusSuffix(status)
+        case .helperMissing(let detail):
+            return "Capture helper missing at \(detail.path)"
+        case .helperExited(let detail):
+            return "Capture helper exited with status \(detail.status)" + (detail.signaled ? " (signaled)" : "")
+        case .deviceUnavailable(.defaultOutputNotReady):
+            return "Default output device not ready"
+        case .deviceUnavailable(.coreAudioStatus(let status)):
+            return "Core Audio device unavailable (status \(status))"
+        case .transient(.handshakeTimeout(let seconds)):
+            return String(format: "Handshake timed out after %.1f seconds", seconds)
+        case .transient(.handshakeRead(let errno)):
+            return "Handshake read failed (errno \(errno))"
+        case .transient(.sharedMemoryOpen(let errno)):
+            return "Shared memory open failed (errno \(errno))"
+        case .transient(.sharedMemoryStat(let errno)):
+            return "Shared memory stat failed (errno \(errno))"
+        case .transient(.sharedMemoryMap(let errno)):
+            return "Shared memory map failed (errno \(errno))"
+        case .transient(.sharedMemoryStartup(let exitCode)):
+            return "Shared memory startup failed (exit \(exitCode))"
+        case .terminal(.malformedHandshake):
+            return "Malformed helper handshake"
+        case .terminal(.helperStartup(let stage, let exitCode, let osStatus)):
+            return "Helper startup failed at \(stage.rawValue) (exit \(exitCode))" + statusSuffix(osStatus)
+        case .terminal(.invalidCaptureGeometry):
+            return "Invalid capture geometry"
+        case .terminal(.captureProtocolViolation):
+            return "Capture protocol violation"
+        case .terminal(.engineUnavailable):
+            return "Audio engine unavailable"
+        case .terminal(.renderConfiguration):
+            return "Render configuration failed"
+        case .terminal(.unknown):
+            return "Unknown terminal failure"
+        }
+    }
+
+    private static func statusSuffix(_ status: Int32?) -> String {
+        guard let status else { return "" }
+        return " (status \(status))"
+    }
+
+    private static func formatSampleRate(_ sampleRate: Double?) -> String {
+        guard let sampleRate else { return unavailable }
+        return String(format: "%.0f Hz", sampleRate)
+    }
+
+    private static func formatCount(_ count: UInt32?) -> String {
+        guard let count else { return unavailable }
+        return "\(count)"
+    }
+
+    private static func emptyAware(_ value: String?) -> String {
+        guard let value, !value.isEmpty else { return unavailable }
+        return value
+    }
+}

--- a/Sources/iQualize/RuntimeDiagnosticsPresentation.swift
+++ b/Sources/iQualize/RuntimeDiagnosticsPresentation.swift
@@ -1,14 +1,6 @@
 import Foundation
 
-struct RuntimeDiagnosticsSnapshot: Sendable {
-    let status: AudioRuntimeStatus
-    let captureTelemetry: CaptureClient.Telemetry?
-
-    init(status: AudioRuntimeStatus, captureTelemetry: CaptureClient.Telemetry? = nil) {
-        self.status = status
-        self.captureTelemetry = captureTelemetry
-    }
-}
+typealias RuntimeDiagnosticsSnapshot = AudioRuntimeDiagnosticsSnapshot
 
 struct RuntimeDiagnosticsPresentation: Equatable {
     struct Row: Equatable {
@@ -23,7 +15,12 @@ struct RuntimeDiagnosticsPresentation: Equatable {
 
     static func make(snapshot: RuntimeDiagnosticsSnapshot) -> RuntimeDiagnosticsPresentation {
         let status = snapshot.status
-        let ratesDiffer = ratesDiffer(capture: status.captureFormat, render: status.renderFormat)
+        let ratesDiffer = ratesDiffer(
+            capture: status.captureFormat,
+            render: status.renderFormat,
+            dspSampleRate: status.dspSampleRate,
+            outputSampleRate: status.outputDevice?.nominalSampleRate
+        )
 
         let rows = [
             Row(label: "Effective Capture Format", value: format(status.captureFormat)),
@@ -55,10 +52,17 @@ struct RuntimeDiagnosticsPresentation: Equatable {
 
     private static func ratesDiffer(
         capture: AudioRuntimeStatus.StreamFormat?,
-        render: AudioRuntimeStatus.StreamFormat?
+        render: AudioRuntimeStatus.StreamFormat?,
+        dspSampleRate: Double?,
+        outputSampleRate: Double?
     ) -> Bool? {
-        guard let capture, let render else { return nil }
-        return capture.sampleRate != render.sampleRate || capture.channelCount != render.channelCount
+        var rates: [Double] = []
+        if let capture { rates.append(capture.sampleRate) }
+        if let render { rates.append(render.sampleRate) }
+        if let dspSampleRate { rates.append(dspSampleRate) }
+        if let outputSampleRate { rates.append(outputSampleRate) }
+        guard let first = rates.first, rates.count >= 2 else { return nil }
+        return rates.dropFirst().contains { abs($0 - first) > 0.5 }
     }
 
     private static func driftResamplingStatus(telemetry: CaptureClient.Telemetry?, ratesDiffer: Bool?) -> String {

--- a/Sources/iqualize-cli/CLIOutput.swift
+++ b/Sources/iqualize-cli/CLIOutput.swift
@@ -40,6 +40,53 @@ func formatVersion(_ status: CLIStatusPayload) -> String {
     return status.gitCommit.map { "\(version) (\($0))" } ?? version
 }
 
+private func formatUnavailable<T>(_ value: T?, _ transform: (T) -> String) -> String {
+    value.map(transform) ?? "Unavailable"
+}
+
+private func formatRuntimeRate(_ value: Double?) -> String {
+    formatUnavailable(value) { String(format: "%.0f Hz", $0) }
+}
+
+private func formatRuntimeChannels(_ value: UInt32?) -> String {
+    formatUnavailable(value) { "\($0)" }
+}
+
+private func formatRuntimeBool(_ value: Bool?) -> String {
+    formatUnavailable(value) { $0 ? "yes" : "no" }
+}
+
+private func hasRuntimeDiagnostics(_ status: CLIStatusPayload) -> Bool {
+    status.runtimeLifecycleState != nil
+        || status.runtimeCaptureSampleRate != nil
+        || status.runtimeCaptureChannelCount != nil
+        || status.runtimeRenderSampleRate != nil
+        || status.runtimeRenderChannelCount != nil
+        || status.runtimeDSPSampleRate != nil
+        || status.runtimeOutputDeviceUID != nil
+        || status.runtimeOutputDeviceNominalSampleRate != nil
+        || status.runtimeOutputDeviceChannelCount != nil
+        || status.runtimeRatesDiffer != nil
+        || status.runtimeResamplingActive != nil
+        || status.runtimeUnavailableReason != nil
+}
+
+private func formatRuntimeDiagnostics(_ status: CLIStatusPayload) -> String {
+    """
+    Runtime diagnostics:
+      Lifecycle: \(status.runtimeLifecycleState ?? "Unavailable")
+      Capture stream: \(formatRuntimeRate(status.runtimeCaptureSampleRate)), \(formatRuntimeChannels(status.runtimeCaptureChannelCount)) channels
+      Render stream: \(formatRuntimeRate(status.runtimeRenderSampleRate)), \(formatRuntimeChannels(status.runtimeRenderChannelCount)) channels
+      DSP sample rate: \(formatRuntimeRate(status.runtimeDSPSampleRate))
+      Output device UID: \(status.runtimeOutputDeviceUID ?? "Unavailable")
+      Output device nominal rate: \(formatRuntimeRate(status.runtimeOutputDeviceNominalSampleRate))
+      Output device channels: \(formatRuntimeChannels(status.runtimeOutputDeviceChannelCount))
+      Rates differ: \(formatRuntimeBool(status.runtimeRatesDiffer))
+      Drift/resampling active: \(formatRuntimeBool(status.runtimeResamplingActive))
+      Unavailable: \(status.runtimeUnavailableReason ?? "Unavailable")
+    """
+}
+
 func formatStatus(_ status: CLIStatusPayload) -> String {
     let mode = status.gainIsGlobal ? "shared" : "per-preset"
     var lines = """
@@ -65,6 +112,9 @@ func formatStatus(_ status: CLIStatusPayload) -> String {
     }
     if let restarts = status.captureHelperRestarts, restarts > 0 {
         lines += "\nCapture helper restarts: \(restarts)"
+    }
+    if hasRuntimeDiagnostics(status) {
+        lines += "\n" + formatRuntimeDiagnostics(status)
     }
     return lines
 }

--- a/Sources/iqualize-cli/Iqualize.swift
+++ b/Sources/iqualize-cli/Iqualize.swift
@@ -66,7 +66,7 @@ struct Version: ParsableCommand {
 }
 
 struct Status: ParsableCommand {
-    static let configuration = CommandConfiguration(abstract: "Show app version, capture/bypass/limiter state, active preset, gain, balance, spectrum overlays, and output device.")
+    static let configuration = CommandConfiguration(abstract: "Show app version, capture/bypass/limiter state, active preset, gain, balance, spectrum overlays, output device, and runtime diagnostics.")
 
     @Flag(help: "Show quick usage examples for this command.")
     var tldr = false

--- a/Tests/iQualizeTests/AudioRuntimeStatusTests.swift
+++ b/Tests/iQualizeTests/AudioRuntimeStatusTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import iQualize
+
+final class AudioRuntimeStatusTests: XCTestCase {
+    func testInitialStatusHasSeparatedInactiveTelemetry() {
+        let status = AudioRuntimeStatus.initial
+
+        XCTAssertEqual(status.lifecycleState, .inactive)
+        XCTAssertFalse(status.userEnabled)
+        XCTAssertFalse(status.isRunning)
+        XCTAssertNil(status.captureFormat)
+        XCTAssertNil(status.renderFormat)
+        XCTAssertNil(status.dspSampleRate)
+        XCTAssertNil(status.outputDevice)
+        XCTAssertNil(status.lastFailure)
+        XCTAssertEqual(status.captureHelperRestartCount, 0)
+    }
+
+    func testLifecycleUpdatePreservesTelemetryAndDerivesRunningFlag() {
+        let output = CoreAudioOutputDevice(id: 42, name: "USB DAC", uid: "dac", nominalSampleRate: 96_000)
+        let format = AudioRuntimeStatus.StreamFormat(sampleRate: 48_000, channelCount: 2)
+        let status = AudioRuntimeStatus.initial
+            .updatingOutputDevice(output)
+            .updatingFormats(captureFormat: format, renderFormat: format, dspSampleRate: 48_000)
+            .updatingLifecycle(state: .running, userEnabled: true, captureHelperRestartCount: 3)
+
+        XCTAssertTrue(status.isRunning)
+        XCTAssertEqual(status.captureFormat?.sampleRate, 48_000)
+        XCTAssertEqual(status.renderFormat?.sampleRate, 48_000)
+        XCTAssertEqual(status.dspSampleRate, 48_000)
+        XCTAssertEqual(status.outputDevice?.nominalSampleRate, 96_000)
+        XCTAssertNil(status.outputDevice?.outputChannelCount)
+        XCTAssertNil(status.lastFailure)
+        XCTAssertEqual(status.captureHelperRestartCount, 3)
+    }
+
+    func testFailedLifecycleUpdateCarriesLastFailureWithoutClearingTelemetry() {
+        let output = CoreAudioOutputDevice(id: 42, name: "USB DAC", uid: "dac", nominalSampleRate: 96_000)
+        let format = AudioRuntimeStatus.StreamFormat(sampleRate: 48_000, channelCount: 2)
+        let running = AudioRuntimeStatus.initial
+            .updatingOutputDevice(output)
+            .updatingFormats(captureFormat: format, renderFormat: format, dspSampleRate: 48_000)
+            .updatingLifecycle(state: .running, userEnabled: true, captureHelperRestartCount: 2)
+
+        let failed = running.updatingLifecycle(
+            state: .failed,
+            userEnabled: true,
+            lastFailure: .deviceUnavailable(.defaultOutputNotReady)
+        )
+
+        XCTAssertEqual(failed.lifecycleState, .failed)
+        XCTAssertTrue(failed.userEnabled)
+        XCTAssertFalse(failed.isRunning)
+        XCTAssertEqual(failed.captureFormat, format)
+        XCTAssertEqual(failed.renderFormat, format)
+        XCTAssertEqual(failed.dspSampleRate, 48_000)
+        XCTAssertEqual(failed.outputDevice, output)
+        XCTAssertEqual(failed.lastFailure, .deviceUnavailable(.defaultOutputNotReady))
+        XCTAssertEqual(failed.captureHelperRestartCount, 2)
+    }
+
+    func testClearingActiveStreamFormatsPreservesOutputDeviceTelemetryAndLastFailure() {
+        let output = CoreAudioOutputDevice(id: 7, name: "Built-in", uid: "builtin", nominalSampleRate: 44_100)
+        let format = AudioRuntimeStatus.StreamFormat(sampleRate: 48_000, channelCount: 2)
+        let status = AudioRuntimeStatus.initial
+            .updatingOutputDevice(output)
+            .updatingFormats(captureFormat: format, renderFormat: format, dspSampleRate: 48_000)
+            .updatingLifecycle(
+                state: .failed,
+                userEnabled: true,
+                lastFailure: .permissionDenied(.processTap(status: -54)),
+                captureHelperRestartCount: 4
+            )
+            .clearingActiveStreamFormats()
+
+        XCTAssertNil(status.captureFormat)
+        XCTAssertNil(status.renderFormat)
+        XCTAssertNil(status.dspSampleRate)
+        XCTAssertEqual(status.outputDevice, output)
+        XCTAssertEqual(status.lastFailure, .permissionDenied(.processTap(status: -54)))
+        XCTAssertEqual(status.captureHelperRestartCount, 4)
+    }
+
+    func testOutputHardwareRateAndChannelsAreDistinctFromDSPRate() {
+        let output = CoreAudioOutputDevice(
+            id: 7,
+            name: "DAC",
+            uid: "dac",
+            nominalSampleRate: 192_000,
+            outputChannelCount: 8
+        )
+        let capture = AudioRuntimeStatus.StreamFormat(sampleRate: 48_000, channelCount: 2)
+        let render = AudioRuntimeStatus.StreamFormat(sampleRate: 48_000, channelCount: 2)
+        let status = AudioRuntimeStatus.initial
+            .updatingOutputDevice(output)
+            .updatingFormats(captureFormat: capture, renderFormat: render, dspSampleRate: 48_000)
+
+        XCTAssertEqual(status.outputDevice?.nominalSampleRate, 192_000)
+        XCTAssertEqual(status.outputDevice?.outputChannelCount, 8)
+        XCTAssertEqual(status.captureFormat?.channelCount, 2)
+        XCTAssertEqual(status.renderFormat?.channelCount, 2)
+        XCTAssertEqual(status.dspSampleRate, 48_000)
+    }
+}

--- a/Tests/iQualizeTests/CLIStatusRuntimeDiagnosticsTests.swift
+++ b/Tests/iQualizeTests/CLIStatusRuntimeDiagnosticsTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import IQControlProtocol
+import XCTest
+
+@testable import iqualize_cli
+
+final class CLIStatusRuntimeDiagnosticsTests: XCTestCase {
+    private let presetID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+    private func makeStatus(
+        runtimeLifecycleState: String? = nil,
+        runtimeCaptureSampleRate: Double? = nil,
+        runtimeCaptureChannelCount: UInt32? = nil,
+        runtimeRenderSampleRate: Double? = nil,
+        runtimeRenderChannelCount: UInt32? = nil,
+        runtimeDSPSampleRate: Double? = nil,
+        runtimeOutputDeviceUID: String? = nil,
+        runtimeOutputDeviceNominalSampleRate: Double? = nil,
+        runtimeOutputDeviceChannelCount: UInt32? = nil,
+        runtimeRatesDiffer: Bool? = nil,
+        runtimeResamplingActive: Bool? = nil,
+        runtimeUnavailableReason: String? = nil
+    ) -> CLIStatusPayload {
+        CLIStatusPayload(
+            bypassed: false,
+            activePresetID: presetID,
+            activePresetName: "Flat",
+            inputGainDB: 0,
+            outputGainDB: 0,
+            balance: 0,
+            gainIsGlobal: true,
+            outputDeviceName: "MacBook Speakers",
+            isRunning: true,
+            peakLimiter: true,
+            preEqSpectrumEnabled: false,
+            postEqSpectrumEnabled: true,
+            appVersion: "0.59.0",
+            gitCommit: "abcdef0",
+            runtimeLifecycleState: runtimeLifecycleState,
+            runtimeCaptureSampleRate: runtimeCaptureSampleRate,
+            runtimeCaptureChannelCount: runtimeCaptureChannelCount,
+            runtimeRenderSampleRate: runtimeRenderSampleRate,
+            runtimeRenderChannelCount: runtimeRenderChannelCount,
+            runtimeDSPSampleRate: runtimeDSPSampleRate,
+            runtimeOutputDeviceUID: runtimeOutputDeviceUID,
+            runtimeOutputDeviceNominalSampleRate: runtimeOutputDeviceNominalSampleRate,
+            runtimeOutputDeviceChannelCount: runtimeOutputDeviceChannelCount,
+            runtimeRatesDiffer: runtimeRatesDiffer,
+            runtimeResamplingActive: runtimeResamplingActive,
+            runtimeUnavailableReason: runtimeUnavailableReason
+        )
+    }
+
+    func testOldStatusFormattingIsUnchangedWhenRuntimeDiagnosticsAreAbsent() {
+        let output = formatStatus(makeStatus())
+
+        XCTAssertEqual(output, """
+        Version: 0.59.0 (abcdef0)
+        Capture: on
+        Bypass: off
+        Peak limiter: on
+        Preset: Flat
+        Gain: input +0.0 dB, output +0.0 dB (shared)
+        Balance: center
+        Pre-EQ spectrum: off
+        Post-EQ spectrum: on
+        Output device: MacBook Speakers
+        """)
+        XCTAssertFalse(output.contains("Runtime diagnostics:"))
+    }
+
+    func testRuntimeDiagnosticsFormattingIncludesUnavailableForNilValues() {
+        let output = formatStatus(makeStatus(
+            runtimeLifecycleState: "running",
+            runtimeCaptureSampleRate: 48_000,
+            runtimeCaptureChannelCount: 2,
+            runtimeRenderSampleRate: 48_000,
+            runtimeRenderChannelCount: 2,
+            runtimeDSPSampleRate: 48_000,
+            runtimeRatesDiffer: false,
+            runtimeResamplingActive: true
+        ))
+
+        XCTAssertTrue(output.contains("Runtime diagnostics:"))
+        XCTAssertTrue(output.contains("  Lifecycle: running"))
+        XCTAssertTrue(output.contains("  Capture stream: 48000 Hz, 2 channels"))
+        XCTAssertTrue(output.contains("  Render stream: 48000 Hz, 2 channels"))
+        XCTAssertTrue(output.contains("  DSP sample rate: 48000 Hz"))
+        XCTAssertTrue(output.contains("  Output device UID: Unavailable"))
+        XCTAssertTrue(output.contains("  Output device nominal rate: Unavailable"))
+        XCTAssertTrue(output.contains("  Output device channels: Unavailable"))
+        XCTAssertTrue(output.contains("  Rates differ: no"))
+        XCTAssertTrue(output.contains("  Drift/resampling active: yes"))
+        XCTAssertTrue(output.contains("  Unavailable: Unavailable"))
+    }
+
+    func testDecodingOldStatusPayloadLeavesRuntimeDiagnosticsNil() throws {
+        let json = """
+        {
+          "bypassed": false,
+          "activePresetID": "00000000-0000-0000-0000-000000000001",
+          "activePresetName": "Flat",
+          "inputGainDB": 0,
+          "outputGainDB": 0,
+          "balance": 0,
+          "gainIsGlobal": true,
+          "outputDeviceName": "MacBook Speakers",
+          "isRunning": true,
+          "peakLimiter": true,
+          "preEqSpectrumEnabled": false,
+          "postEqSpectrumEnabled": true,
+          "appVersion": "0.59.0",
+          "gitCommit": "abcdef0"
+        }
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(CLIStatusPayload.self, from: json)
+
+        XCTAssertEqual(status.activePresetName, "Flat")
+        XCTAssertNil(status.runtimeLifecycleState)
+        XCTAssertNil(status.runtimeCaptureSampleRate)
+        XCTAssertNil(status.runtimeCaptureChannelCount)
+        XCTAssertNil(status.runtimeRenderSampleRate)
+        XCTAssertNil(status.runtimeRenderChannelCount)
+        XCTAssertNil(status.runtimeDSPSampleRate)
+        XCTAssertNil(status.runtimeOutputDeviceUID)
+        XCTAssertNil(status.runtimeOutputDeviceNominalSampleRate)
+        XCTAssertNil(status.runtimeOutputDeviceChannelCount)
+        XCTAssertNil(status.runtimeRatesDiffer)
+        XCTAssertNil(status.runtimeResamplingActive)
+        XCTAssertNil(status.runtimeUnavailableReason)
+    }
+}

--- a/Tests/iQualizeTests/RuntimeDiagnosticsPresentationTests.swift
+++ b/Tests/iQualizeTests/RuntimeDiagnosticsPresentationTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import iQualize
+
+final class RuntimeDiagnosticsPresentationTests: XCTestCase {
+    func testUnavailableRowsDoNotInferDSPFromHardwareOutputRate() {
+        let snapshot = RuntimeDiagnosticsSnapshot(status: AudioRuntimeStatus(
+            lifecycleState: .inactive,
+            userEnabled: false,
+            isRunning: false,
+            captureFormat: nil,
+            renderFormat: nil,
+            dspSampleRate: nil,
+            outputDevice: CoreAudioOutputDevice(
+                id: 42,
+                name: "Studio Display Speakers",
+                uid: nil,
+                nominalSampleRate: 96_000,
+                outputChannelCount: nil
+            ),
+            lastFailure: nil,
+            captureHelperRestartCount: 0
+        ))
+
+        let presentation = RuntimeDiagnosticsPresentation.make(snapshot: snapshot)
+
+        XCTAssertEqual(value("Effective Capture Format", in: presentation), "Unavailable")
+        XCTAssertEqual(value("Render/DSP Format", in: presentation), "Render: Unavailable; DSP sample rate: Unavailable")
+        XCTAssertEqual(value("Output Device Nominal Sample Rate", in: presentation), "96000 Hz")
+        XCTAssertEqual(value("Output Device UID", in: presentation), "Unavailable")
+        XCTAssertEqual(value("Output Device Output Channels", in: presentation), "Unavailable")
+        XCTAssertEqual(value("Rates Differ", in: presentation), "Unavailable")
+        XCTAssertEqual(value("Last Failure", in: presentation), "Unavailable")
+        XCTAssertTrue(presentation.report.contains("DSP sample rate: Unavailable"))
+        XCTAssertFalse(presentation.report.contains("DSP sample rate: 96000 Hz"))
+    }
+
+    func testFormatsRatesDifferDriftAndFailureForReport() {
+        let status = AudioRuntimeStatus(
+            lifecycleState: .running,
+            userEnabled: true,
+            isRunning: true,
+            captureFormat: .init(sampleRate: 44_100, channelCount: 2),
+            renderFormat: .init(sampleRate: 48_000, channelCount: 2),
+            dspSampleRate: 48_000,
+            outputDevice: CoreAudioOutputDevice(
+                id: 7,
+                name: "External DAC",
+                uid: "dac-uid",
+                nominalSampleRate: 96_000,
+                outputChannelCount: 8
+            ),
+            lastFailure: .deviceUnavailable(.coreAudioStatus(-200)),
+            captureHelperRestartCount: 3
+        )
+        let telemetry = CaptureClient.Telemetry(
+            fillFrames: 512,
+            driftPpm: -12.345,
+            underruns: 2,
+            overrunResyncs: 1
+        )
+
+        let presentation = RuntimeDiagnosticsPresentation.make(snapshot: .init(status: status, captureTelemetry: telemetry))
+
+        XCTAssertEqual(value("Effective Capture Format", in: presentation), "44100 Hz, 2 ch")
+        XCTAssertEqual(value("Render/DSP Format", in: presentation), "Render: 48000 Hz, 2 ch; DSP sample rate: 48000 Hz")
+        XCTAssertEqual(value("Output Device Name", in: presentation), "External DAC")
+        XCTAssertEqual(value("Output Device UID", in: presentation), "dac-uid")
+        XCTAssertEqual(value("Output Device Output Channels", in: presentation), "8")
+        XCTAssertEqual(value("Lifecycle State", in: presentation), "running (user enabled: Yes, running: Yes)")
+        XCTAssertEqual(value("Rates Differ", in: presentation), "Yes")
+        XCTAssertEqual(
+            value("Drift/Resampling Status", in: presentation),
+            "Resampling expected; drift -12.35 ppm; fill 512 frames; underruns 2; overrun resyncs 1"
+        )
+        XCTAssertEqual(value("Last Failure", in: presentation), "Core Audio device unavailable (status -200)")
+        XCTAssertTrue(presentation.report.hasPrefix("iQualize Diagnostic Report\n"))
+        XCTAssertTrue(presentation.report.contains("Output Device UID: dac-uid"))
+    }
+
+    private func value(_ label: String, in presentation: RuntimeDiagnosticsPresentation) -> String? {
+        presentation.rows.first { $0.label == label }?.value
+    }
+}

--- a/Tests/iQualizeTests/RuntimeDiagnosticsPresentationTests.swift
+++ b/Tests/iQualizeTests/RuntimeDiagnosticsPresentationTests.swift
@@ -77,6 +77,31 @@ final class RuntimeDiagnosticsPresentationTests: XCTestCase {
         XCTAssertTrue(presentation.report.contains("Output Device UID: dac-uid"))
     }
 
+    func testMatchingEffectiveAndHardwareRatesReportNoDifference() {
+        let status = AudioRuntimeStatus(
+            lifecycleState: .running,
+            userEnabled: true,
+            isRunning: true,
+            captureFormat: .init(sampleRate: 48_000, channelCount: 2),
+            renderFormat: .init(sampleRate: 48_000, channelCount: 2),
+            dspSampleRate: 48_000,
+            outputDevice: .init(
+                id: 1,
+                name: "Built-in Output",
+                uid: "builtin",
+                nominalSampleRate: 48_000,
+                outputChannelCount: 2
+            ),
+            lastFailure: nil,
+            captureHelperRestartCount: 0
+        )
+
+        let presentation = RuntimeDiagnosticsPresentation.make(snapshot: .init(status: status))
+
+        XCTAssertEqual(value("Rates Differ", in: presentation), "No")
+        XCTAssertEqual(value("Drift/Resampling Status", in: presentation), "Unavailable")
+    }
+
     private func value(_ label: String, in presentation: RuntimeDiagnosticsPresentation) -> String? {
         presentation.rows.first { $0.label == label }?.value
     }


### PR DESCRIPTION
## Summary

Adds M5 runtime diagnostics for effective audio formats, output-device identity, and runtime health state.

- Adds an immutable `AudioRuntimeStatus` snapshot with distinct capture, render/DSP, and physical output-device telemetry.
- Queries Core Audio output-device nominal sample rate and channel count without using hardware values for DSP coefficients.
- Publishes status at lifecycle, device-change, sleep/wake, teardown, recovery, and helper-failure boundaries.
- Exposes the same snapshot through CLI status output, structured logs, and a read-only diagnostics window with copyable reports.
- Preserves unavailable values as `Unavailable` and keeps diagnostics reads non-mutating.
- Bumps the app to `0.60.0` and documents the feature in `CHANGELOG.md`.

This intentionally provides the measurements needed for the separate USB DAC sample-rate switching investigation without changing switching behavior.

Fixes #157

## Validation

- [x] `swift test` — 228 tests, 0 failures.
- [x] `git diff --check`.
- [x] Installed app launch verification passed.
- [x] Installed CLI status verified with capture/render/DSP/output-device telemetry.