### PR TITLE
docs(release): add v0.60.0 highlights

### DIFF
--- a/.github/release-notes/highlights/v0.60.0.md
+++ b/.github/release-notes/highlights/v0.60.0.md
@@ -1,4 +1,5 @@
 <!-- title: v0.60.0 — Runtime diagnostics you can trust -->
+<!-- song: Melvin Spix — Strike of Determination — https://music.apple.com/de/album/strike-of-determination/1566848460?i=1566848462 -->
 ## Highlights
 
 - **See the whole audio path.** Runtime diagnostics now distinguish the captured stream, render/DSP graph, and physical output device, including effective sample rates, channel counts, device identity, lifecycle state, and recovery counters (#157).

--- a/.github/release-notes/highlights/v0.60.0.md
+++ b/.github/release-notes/highlights/v0.60.0.md
@@ -1,0 +1,6 @@
+<!-- title: v0.60.0 — Runtime diagnostics you can trust -->
+## Highlights
+
+- **See the whole audio path.** Runtime diagnostics now distinguish the captured stream, render/DSP graph, and physical output device, including effective sample rates, channel counts, device identity, lifecycle state, and recovery counters (#157).
+- **Unavailable stays honest.** The CLI and diagnostics window consume the same immutable status snapshot, preserve missing telemetry as `Unavailable`, and provide a copyable report without guessing or interrupting playback.
+- **Measure before changing behavior.** Structured status logs publish at lifecycle, device-change, sleep/wake, teardown, recovery, and helper-failure boundaries, providing the evidence needed to investigate automatic USB DAC sample-rate switching separately (#158).


### PR DESCRIPTION
## Summary

Adds the curated title and highlights file required for the `v0.60.0` release workflow.

- Describes the new capture, render/DSP, and physical output-device telemetry.
- Documents explicit `Unavailable` handling and the read-only CLI/UI diagnostics surfaces.
- Frames USB DAC sample-rate switching as the follow-up investigation for #158.

## Validation

- [x] `bash .github/scripts/release-highlights.sh title v0.60.0`
- [x] `bash .github/scripts/release-highlights.sh body v0.60.0`
- [x] `git diff --check`